### PR TITLE
Start adding tests, naming update, more config updates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug test",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/packages/just-scripts-utils/node_modules/jest/bin/jest.js",
+      "cwd": "${fileDirname}",
+      "args": ["-i", "--runInBand"],
+      "runtimeArgs": ["--nolazy", "--debug"],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": []
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,8 @@
   "editor.tabSize": 2,
   "files.trimTrailingWhitespace": true,
   "json.format.enable": false,
+  "javascript.preferences.quoteStyle": "single",
+  "typescript.preferences.quoteStyle": "single",
   "[handlebars]": {
     "editor.formatOnSave": false
   },

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -25,6 +25,7 @@ dependencies:
   '@types/jju': 1.4.0
   '@types/marked': 0.6.0
   '@types/marked-terminal': 3.1.1
+  '@types/mock-fs': 3.6.30
   '@types/node': 10.12.21
   '@types/prompts': 1.2.0
   '@types/resolve': 0.0.8
@@ -48,6 +49,7 @@ dependencies:
   json5: 2.1.0
   marked: 0.6.0
   marked-terminal: 3.2.0
+  mock-fs: 4.8.0
   npm-registry-fetch: 3.9.0
   office-ui-fabric-react: 6.133.0
   prompts: 2.0.1
@@ -329,7 +331,6 @@ packages:
       integrity: sha512-wNHxLkEKTQ2ay0tnsam2z7fGZUi+05ziDJflEt3AZTP3oXLKHJp9HqhfroB/vdMvt3sda9fAbq7FsG8QPDrZBg==
   /@babel/plugin-proposal-class-properties/7.3.0/@babel!core@7.2.2:
     dependencies:
-      '@babel/core': 7.2.2
       '@babel/helper-create-class-features-plugin': /@babel/helper-create-class-features-plugin/7.3.2/@babel!core@7.2.2
       '@babel/helper-plugin-utils': 7.0.0
     dev: false
@@ -369,7 +370,6 @@ packages:
       integrity: sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==
   /@babel/plugin-proposal-object-rest-spread/7.3.2/@babel!core@7.2.2:
     dependencies:
-      '@babel/core': 7.2.2
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.2.2
     dev: false
@@ -1213,7 +1213,6 @@ packages:
       integrity: sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==
   /@babel/preset-env/7.3.1/@babel!core@7.2.2:
     dependencies:
-      '@babel/core': 7.2.2
       '@babel/helper-module-imports': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-proposal-async-generator-functions': /@babel/plugin-proposal-async-generator-functions/7.2.0/@babel!core@7.2.2
@@ -1277,7 +1276,6 @@ packages:
       integrity: sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==
   /@babel/preset-react/7.0.0/@babel!core@7.2.2:
     dependencies:
-      '@babel/core': 7.2.2
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-transform-react-display-name': /@babel/plugin-transform-react-display-name/7.2.0/@babel!core@7.2.2
       '@babel/plugin-transform-react-jsx': /@babel/plugin-transform-react-jsx/7.3.0/@babel!core@7.2.2
@@ -1305,7 +1303,6 @@ packages:
       integrity: sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==
   /@babel/register/7.0.0/@babel!core@7.2.2:
     dependencies:
-      '@babel/core': 7.2.2
       core-js: 2.6.3
       find-cache-dir: 1.0.0
       home-or-tmp: 3.0.0
@@ -1469,6 +1466,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+  /@types/mock-fs/3.6.30:
+    dependencies:
+      '@types/node': 10.12.21
+    dev: false
+    resolution:
+      integrity: sha1-TYElQeh7I1dyYaWqlfcE3T0B5BA=
   /@types/node/10.12.21:
     dev: false
     resolution:
@@ -1577,28 +1580,10 @@ packages:
       react-dom: ^0.14.9 || ^15.0.1-0 || ^16.0.0-0
     resolution:
       integrity: sha512-iFwuoFUQoS6H6paxrRsVCxQnw2SqnxhS+EBh54Gb3A6HxS2IKzGAE5c4tnZcqjXNPxXTvXgt5iQg3xycIa95cg==
-  /@uifabric/charting/0.28.5/react-dom@16.7.0+react@16.7.0:
+  /@uifabric/charting/0.28.5/react-dom@16.7.0:
     dependencies:
-      '@microsoft/load-themed-styles': 1.8.56
-      '@types/d3-array': 1.2.1
-      '@types/d3-axis': 1.0.10
-      '@types/d3-scale': 2.0.0
-      '@types/d3-selection': 1.3.0
-      '@types/d3-shape': 1.3.0
-      '@types/d3-time-format': 2.1.0
-      '@uifabric/icons': 6.3.0
-      '@uifabric/set-version': 1.1.3
-      d3-array: 1.2.1
-      d3-axis: 1.0.8
-      d3-scale: 2.0.0
-      d3-selection: 1.3.0
-      d3-shape: 1.3.4
-      d3-time-format: 2.1.3
-      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0
-      prop-types: 15.6.2
-      react: 16.7.0
-      react-dom: /react-dom/16.7.0/react@16.7.0
-      tslib: 1.9.3
+      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0
+      react-dom: 16.7.0
     dev: false
     id: registry.npmjs.org/@uifabric/charting/0.28.5
     peerDependencies:
@@ -1631,27 +1616,14 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-+1z5RUSP5gWfB5VIcD1A7O1ITbzwBEvCOOn0Md5vOhozrcDPxEAcoIve29Ckckd/05xmMAYTjgQVMjgE4y8Rng==
-  /@uifabric/experiments/6.54.2/react-dom@16.7.0+react@16.7.0:
+  /@uifabric/experiments/6.54.2/react-dom@16.7.0:
     dependencies:
-      '@microsoft/load-themed-styles': 1.8.56
-      '@uifabric/azure-themes': 0.1.5
-      '@uifabric/charting': /@uifabric/charting/0.28.5/react-dom@16.7.0+react@16.7.0
-      '@uifabric/file-type-icons': /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0+react@16.7.0
-      '@uifabric/fluent-theme': 0.13.4
-      '@uifabric/foundation': /@uifabric/foundation/0.7.1/react-dom@16.7.0+react@16.7.0
-      '@uifabric/icons': 6.3.0
-      '@uifabric/merge-styles': 6.15.2
-      '@uifabric/set-version': 1.1.3
-      '@uifabric/styling': 6.41.0
-      '@uifabric/theme-samples': 0.1.4
-      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0
-      '@uifabric/variants': 6.14.0
-      deep-assign: 2.0.0
-      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0
-      prop-types: 15.6.2
-      react: 16.7.0
-      react-dom: /react-dom/16.7.0/react@16.7.0
-      tslib: 1.9.3
+      '@uifabric/charting': /@uifabric/charting/0.28.5/react-dom@16.7.0
+      '@uifabric/file-type-icons': /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0
+      '@uifabric/foundation': /@uifabric/foundation/0.7.1/react-dom@16.7.0
+      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0
+      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0
+      react-dom: 16.7.0
     dev: false
     id: registry.npmjs.org/@uifabric/experiments/6.54.2
     peerDependencies:
@@ -1670,13 +1642,9 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-T6wGiA/RjLqRE+P5RRObpcRJ+ejh4ZwZX584GgEymOCcU7kjzWSZR7imTA65FbUMUhXxR68b3oiWgPSaCAXE8w==
-  /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0+react@16.7.0:
+  /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0:
     dependencies:
-      '@uifabric/set-version': 1.1.3
-      '@uifabric/styling': 6.41.0
-      react: 16.7.0
-      react-dom: /react-dom/16.7.0/react@16.7.0
-      tslib: 1.9.3
+      react-dom: 16.7.0
     dev: false
     id: registry.npmjs.org/@uifabric/file-type-icons/6.4.1
     peerDependencies:
@@ -1707,14 +1675,10 @@ packages:
       react-dom: ^0.14.9 || ^15.0.1-0 || ^16.0.0-0
     resolution:
       integrity: sha512-YrdaJXAe4x7whaj7/x1fhFsBGao0vAec6mVIAYCvC09AK+puEYDahIloVWA6vLTRlWzzOZWsvN3S3Z1tzfhIRw==
-  /@uifabric/foundation/0.7.1/react-dom@16.7.0+react@16.7.0:
+  /@uifabric/foundation/0.7.1/react-dom@16.7.0:
     dependencies:
-      '@uifabric/set-version': 1.1.3
-      '@uifabric/styling': 6.41.0
-      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0
-      react: 16.7.0
-      react-dom: /react-dom/16.7.0/react@16.7.0
-      tslib: 1.9.3
+      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0
+      react-dom: 16.7.0
     dev: false
     id: registry.npmjs.org/@uifabric/foundation/0.7.1
     peerDependencies:
@@ -1774,14 +1738,9 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-2VKRadp+pGV5PFubSYCUTU4Sg3NdztECFiEvgyVDIrGYZhSwOVHMwAKb+I9hr990OLCb+gSK3rekJp/To9NZFQ==
-  /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0:
+  /@uifabric/utilities/6.29.0/react-dom@16.7.0:
     dependencies:
-      '@uifabric/merge-styles': 6.15.2
-      '@uifabric/set-version': 1.1.3
-      prop-types: 15.6.2
-      react: 16.7.0
-      react-dom: /react-dom/16.7.0/react@16.7.0
-      tslib: 1.9.3
+      react-dom: 16.7.0
     dev: false
     id: registry.npmjs.org/@uifabric/utilities/6.29.0
     peerDependencies:
@@ -7443,6 +7402,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  /mock-fs/4.8.0:
+    dev: false
+    resolution:
+      integrity: sha512-Gwj4KnJOW15YeTJKO5frFd/WDO5Mc0zxXqL9oHx3+e9rBqW8EVARqQHSaIXznUdljrD6pvbNGW2ZGXKPEfYJfw==
   /move-concurrently/1.0.1:
     dependencies:
       aproba: 1.2.0
@@ -7797,18 +7760,10 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-FbDUIfiy+X9+rYg4r2FWWem2Y9bdiqYDHv+qRY9kW5FYA30mb4VjlByLnJZnm4erKm0i/RCLUWJ5+TP88PgdeA==
-  /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0:
+  /office-ui-fabric-react/6.133.0/react-dom@16.7.0:
     dependencies:
-      '@microsoft/load-themed-styles': 1.8.56
-      '@uifabric/icons': 6.3.0
-      '@uifabric/merge-styles': 6.15.2
-      '@uifabric/set-version': 1.1.3
-      '@uifabric/styling': 6.41.0
-      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0
-      prop-types: 15.6.2
-      react: 16.7.0
-      react-dom: /react-dom/16.7.0/react@16.7.0
-      tslib: 1.9.3
+      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0
+      react-dom: 16.7.0
     dev: false
     id: registry.npmjs.org/office-ui-fabric-react/6.133.0
     peerDependencies:
@@ -8827,7 +8782,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.6.2
-      react: 16.7.0
       scheduler: 0.12.0
     dev: false
     id: registry.npmjs.org/react-dom/16.7.0
@@ -10271,27 +10225,6 @@ packages:
       jest: '>=22 <24'
     resolution:
       integrity: sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==
-  /ts-jest/23.10.5/jest@23.6.0:
-    dependencies:
-      bs-logger: 0.2.6
-      buffer-from: 1.1.1
-      fast-json-stable-stringify: 2.0.0
-      jest: 23.6.0
-      json5: 2.1.0
-      make-error: 1.3.5
-      mkdirp: 0.5.1
-      resolve: 1.10.0
-      semver: 5.6.0
-      yargs-parser: 10.1.0
-    dev: false
-    engines:
-      node: '>= 6'
-    hasBin: true
-    id: registry.npmjs.org/ts-jest/23.10.5
-    peerDependencies:
-      jest: '>=22 <24'
-    resolution:
-      integrity: sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==
   /ts-loader/5.3.3:
     dependencies:
       chalk: 2.4.2
@@ -10302,22 +10235,6 @@ packages:
     dev: false
     engines:
       node: '>=6.11.5'
-    peerDependencies:
-      typescript: '*'
-    resolution:
-      integrity: sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==
-  /ts-loader/5.3.3/typescript@3.3.1:
-    dependencies:
-      chalk: 2.4.2
-      enhanced-resolve: 4.1.0
-      loader-utils: 1.2.3
-      micromatch: 3.1.10
-      semver: 5.6.0
-      typescript: 3.3.1
-    dev: false
-    engines:
-      node: '>=6.11.5'
-    id: registry.npmjs.org/ts-loader/5.3.3
     peerDependencies:
       typescript: '*'
     resolution:
@@ -10700,32 +10617,6 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-jeJveHwz/vwpJ3B8bxEL5a/rVKIpRNJDsKggfKnxuYeohNDW4Y/wB9N/XHJA093qZyS0r6mYL+/crLsIol4WKA==
-  /webpack-cli/3.2.1/webpack@4.29.1:
-    dependencies:
-      chalk: 2.4.2
-      cross-spawn: 6.0.5
-      enhanced-resolve: 4.1.0
-      findup-sync: 2.0.0
-      global-modules: 1.0.0
-      global-modules-path: 2.3.1
-      import-local: 2.0.0
-      interpret: 1.2.0
-      lightercollective: 0.1.0
-      loader-utils: 1.2.3
-      supports-color: 5.5.0
-      v8-compile-cache: 2.0.2
-      webpack: 4.29.1
-      yargs: 12.0.5
-    dev: false
-    engines:
-      node: '>=6.11.5'
-    hasBin: true
-    id: registry.npmjs.org/webpack-cli/3.2.1
-    peerDependencies:
-      webpack: 4.x.x
-    requiresBuild: true
-    resolution:
-      integrity: sha512-jeJveHwz/vwpJ3B8bxEL5a/rVKIpRNJDsKggfKnxuYeohNDW4Y/wB9N/XHJA093qZyS0r6mYL+/crLsIol4WKA==
   /webpack-merge/4.2.1:
     dependencies:
       lodash: 4.17.11
@@ -10990,10 +10881,10 @@ packages:
       '@types/yargs': 12.0.1
       fs-extra: 7.0.1
       prompts: 2.0.1
-      ts-loader: /ts-loader/5.3.3/typescript@3.3.1
+      ts-loader: 5.3.3
       typescript: 3.3.1
       webpack: 4.29.1
-      webpack-cli: /webpack-cli/3.2.1/webpack@4.29.1
+      webpack-cli: 3.2.1
       yargs: 12.0.5
     dev: false
     name: '@rush-temp/create-just'
@@ -11018,6 +10909,7 @@ packages:
       '@types/jju': 1.4.0
       '@types/marked': 0.6.0
       '@types/marked-terminal': 3.1.1
+      '@types/mock-fs': 3.6.30
       '@types/node': 10.12.21
       '@types/semver': 5.5.0
       '@types/tar': 4.0.0
@@ -11028,12 +10920,13 @@ packages:
       jju: 1.4.0
       marked: 0.6.0
       marked-terminal: /marked-terminal/3.2.0/marked@0.6.0
+      mock-fs: 4.8.0
       semver: 5.6.0
       tar: 4.4.8
     dev: false
     name: '@rush-temp/just-scripts-utils'
     resolution:
-      integrity: sha512-8AU5ZnwJ1G++U2XYcK1oM3IFdWUa1GAC5FZimHR+MfUNYKiGIIoK8xpYb+L3yLa/hUxSgLYL/QxZkpHfFIdwMA==
+      integrity: sha512-ozXFDpHhjUFn4XvVn154k+25DK9uGuJGI99vdulBVw/qFnqCqvHn/kxejaZPLzYODHxFO1PC/NAhRbiwRyRI3g==
       tarball: 'file:projects/just-scripts-utils.tgz'
     version: 0.0.0
   'file:projects/just-scripts.tgz':
@@ -11051,10 +10944,10 @@ packages:
       npm-registry-fetch: 3.9.0
       prompts: 2.0.1
       run-parallel-limit: 1.0.5
-      ts-loader: /ts-loader/5.3.3/typescript@3.3.1
+      ts-loader: 5.3.3
       typescript: 3.3.1
       webpack: 4.29.1
-      webpack-cli: /webpack-cli/3.2.1/webpack@4.29.1
+      webpack-cli: 3.2.1
       webpack-merge: 4.2.1
     dev: false
     name: '@rush-temp/just-scripts'
@@ -11104,20 +10997,20 @@ packages:
   'file:projects/just-task-docs.tgz':
     dependencies:
       '@babel/core': 7.2.2
-      '@babel/plugin-proposal-class-properties': /@babel/plugin-proposal-class-properties/7.3.0/@babel!core@7.2.2
-      '@babel/plugin-proposal-object-rest-spread': /@babel/plugin-proposal-object-rest-spread/7.3.2/@babel!core@7.2.2
+      '@babel/plugin-proposal-class-properties': 7.3.0
+      '@babel/plugin-proposal-object-rest-spread': 7.3.2
       '@babel/polyfill': 7.2.5
-      '@babel/preset-env': /@babel/preset-env/7.3.1/@babel!core@7.2.2
-      '@babel/preset-react': /@babel/preset-react/7.0.0/@babel!core@7.2.2
-      '@babel/register': /@babel/register/7.0.0/@babel!core@7.2.2
+      '@babel/preset-env': 7.3.1
+      '@babel/preset-react': 7.0.0
+      '@babel/register': 7.0.0
       '@babel/traverse': 7.2.3
       '@babel/types': 7.3.2
-      '@uifabric/experiments': /@uifabric/experiments/6.54.2/react-dom@16.7.0+react@16.7.0
+      '@uifabric/experiments': /@uifabric/experiments/6.54.2/react-dom@16.7.0
       cpx: 1.5.0
       docusaurus: 1.7.2
-      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0
+      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0
       react: 16.7.0
-      react-dom: /react-dom/16.7.0/react@16.7.0
+      react-dom: 16.7.0
     dev: false
     name: '@rush-temp/just-task-docs'
     resolution:
@@ -11144,7 +11037,7 @@ packages:
       chalk: 2.4.2
       jest: 23.6.0
       resolve: 1.10.0
-      ts-jest: /ts-jest/23.10.5/jest@23.6.0
+      ts-jest: 23.10.5
       typescript: 3.3.1
       undertaker: 1.2.0
       undertaker-registry: 1.0.1
@@ -11185,6 +11078,7 @@ specifiers:
   '@types/jju': ^1.4.0
   '@types/marked': ^0.6.0
   '@types/marked-terminal': ^3.1.1
+  '@types/mock-fs': ^3.6.30
   '@types/node': ^10.12.18
   '@types/prompts': ^1.2.0
   '@types/resolve': ^0.0.8
@@ -11208,6 +11102,7 @@ specifiers:
   json5: ^2.1.0
   marked: ^0.6.0
   marked-terminal: ^3.2.0
+  mock-fs: ^4.8.0
   npm-registry-fetch: ^3.9.0
   office-ui-fabric-react: ^6.109.0
   prompts: ^2.0.1

--- a/packages/create-just/src/commands/initCommand.ts
+++ b/packages/create-just/src/commands/initCommand.ts
@@ -1,4 +1,11 @@
-import { paths, logger, transform, prettyPrintMarkdown, rushUpdate, downloadPackage } from 'just-scripts-utils';
+import {
+  paths,
+  logger,
+  transform,
+  prettyPrintMarkdown,
+  rushUpdate,
+  downloadPackage
+} from 'just-scripts-utils';
 import path from 'path';
 import { readdirSync } from 'fs';
 import fse from 'fs-extra';
@@ -6,8 +13,8 @@ import prompts from 'prompts';
 import { execSync } from 'child_process';
 import yargs from 'yargs';
 
-function checkEmptyRepo(installPath: string) {
-  return readdirSync(installPath).length === 0;
+function checkEmptyRepo(projectPath: string) {
+  return readdirSync(projectPath).length === 0;
 }
 
 export async function initCommand(argv: yargs.Arguments) {
@@ -27,45 +34,45 @@ export async function initCommand(argv: yargs.Arguments) {
   }
 
   let name: string = '';
-  if (!argv.name && !checkEmptyRepo(paths.installPath)) {
+  if (!argv.name && !checkEmptyRepo(paths.projectPath)) {
     let response = await prompts({
       type: 'text',
       name: 'name',
       message: 'What is the name of the repo to create?'
     });
     name = response.name;
-    paths.installPath = path.join(paths.installPath, name);
+    paths.projectPath = path.join(paths.projectPath, name);
   } else if (!argv.name) {
-    name = path.basename(paths.installPath);
+    name = path.basename(paths.projectPath);
   } else {
     name = argv.name;
-    paths.installPath = path.join(paths.installPath, name);
+    paths.projectPath = path.join(paths.projectPath, name);
   }
 
-  if (!fse.pathExistsSync(paths.installPath)) {
-    fse.mkdirpSync(paths.installPath);
+  if (!fse.pathExistsSync(paths.projectPath)) {
+    fse.mkdirpSync(paths.projectPath);
   }
 
-  process.chdir(paths.installPath);
+  process.chdir(paths.projectPath);
 
   logger.info('Initializing the repo in the current directory');
 
   const templatePath = await downloadPackage(argv.type);
 
   if (templatePath) {
-    transform(templatePath, paths.installPath, { name });
+    transform(templatePath, paths.projectPath, { name });
 
     execSync('git init');
     execSync('git add .');
     execSync('git commit -m "initial commit"');
 
     if (argv.type.includes('monorepo')) {
-      rushUpdate(paths.installPath);
+      rushUpdate(paths.projectPath);
     }
 
     logger.info('All Set!');
 
-    const readmeFile = path.join(paths.installPath, 'README.md');
+    const readmeFile = path.join(paths.projectPath, 'README.md');
     if (fse.existsSync(readmeFile)) {
       logger.info('\n' + prettyPrintMarkdown(fse.readFileSync(readmeFile).toString()));
     }

--- a/packages/just-scripts-utils/.npmignore
+++ b/packages/just-scripts-utils/.npmignore
@@ -1,0 +1,3 @@
+src
+CHANGELOG.*
+__tests__

--- a/packages/just-scripts-utils/jest.config.js
+++ b/packages/just-scripts-utils/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  roots: ['<rootDir>/src'],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).ts']
+};

--- a/packages/just-scripts-utils/package.json
+++ b/packages/just-scripts-utils/package.json
@@ -1,25 +1,18 @@
 {
   "name": "just-scripts-utils",
   "version": "0.3.3",
-  "description": "",
+  "description": "Utilities for Just stack scripts",
   "main": "./lib/index.js",
   "scripts": {
     "build": "tsc",
-    "start": "tsc -w --preserveWatchOutput"
+    "start": "tsc -w --preserveWatchOutput",
+    "test": "jest",
+    "start-test": "jest --watch"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
-  "devDependencies": {
-    "@types/fs-extra": "^5.0.4",
-    "@types/glob": "^7.1.1",
-    "@types/handlebars": "^4.0.39",
-    "@types/jju": "^1.4.0",
-    "@types/marked-terminal": "^3.1.1",
-    "@types/marked": "^0.6.0",
-    "@types/node": "^10.12.18",
-    "@types/semver": "^5.5.0",
-    "@types/tar": "^4.0.0",
+  "dependencies": {
     "chalk": "^2.4.1",
     "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
@@ -29,5 +22,21 @@
     "marked-terminal": "^3.2.0",
     "semver": "^5.6.0",
     "tar": "^4.4.8"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^5.0.4",
+    "@types/glob": "^7.1.1",
+    "@types/handlebars": "^4.0.39",
+    "@types/jest": "^23.3.13",
+    "@types/jju": "^1.4.0",
+    "@types/marked": "^0.6.0",
+    "@types/marked-terminal": "^3.1.1",
+    "@types/mock-fs": "^3.6.30",
+    "@types/node": "^10.12.18",
+    "@types/semver": "^5.5.0",
+    "@types/tar": "^4.0.0",
+    "jest": "^23.6.0",
+    "mock-fs": "^4.8.0",
+    "ts-jest": "^23.10.5"
   }
 }

--- a/packages/just-scripts-utils/src/__tests__/paths.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/paths.spec.ts
@@ -1,0 +1,32 @@
+import path from 'path';
+import os from 'os';
+import { paths } from '../paths';
+
+describe('paths', () => {
+  describe('projectPath', () => {
+    afterEach(() => {
+      paths.projectPath = '';
+    });
+
+    it('defaults to cwd', () => {
+      expect(paths.projectPath).toEqual(process.cwd());
+    });
+
+    it('respects updated setting', () => {
+      paths.projectPath = 'foo';
+      expect(paths.projectPath).toEqual('foo');
+    });
+  });
+
+  describe('tempPath', () => {
+    it('returns default value', () => {
+      const defaultPath = path.resolve(os.tmpdir(), 'just-stack');
+      expect(paths.tempPath()).toEqual(defaultPath);
+    });
+
+    it('uses extra path segments', () => {
+      const extraPath = path.resolve(os.tmpdir(), 'just-stack', 'foo', 'bar');
+      expect(paths.tempPath('foo', 'bar')).toEqual(extraPath);
+    });
+  });
+});

--- a/packages/just-scripts-utils/src/findMonoRepoRootPath.ts
+++ b/packages/just-scripts-utils/src/findMonoRepoRootPath.ts
@@ -3,11 +3,11 @@ import path from 'path';
 import fse from 'fs-extra';
 
 export function findMonoRepoRootPath() {
-  const { installPath } = paths;
+  const { projectPath } = paths;
   let found = false;
-  let currentPath = installPath;
+  let currentPath = projectPath;
 
-  const { root } = path.parse(installPath);
+  const { root } = path.parse(projectPath);
 
   while (!found && currentPath !== root) {
     const packageJsonFile = path.join(currentPath, 'package.json');

--- a/packages/just-scripts-utils/src/paths.ts
+++ b/packages/just-scripts-utils/src/paths.ts
@@ -1,21 +1,18 @@
 import path from 'path';
 import os from 'os';
 
-let installPath: string = '';
+let projectPath: string = '';
 
 export const paths = {
   /**
-   * Gets the location where the generated project will go. Defaults to `process.cwd()`.
+   * Location where the generated project will go. Defaults to `process.cwd()`.
    */
-  get installPath(): string {
-    return installPath || process.cwd();
+  get projectPath(): string {
+    return projectPath || process.cwd();
   },
 
-  /**
-   * Sets the location where the generated project will go.
-   */
-  set installPath(value: string) {
-    installPath = value;
+  set projectPath(value: string) {
+    projectPath = value;
   },
 
   /**

--- a/packages/just-scripts/package.json
+++ b/packages/just-scripts/package.json
@@ -6,19 +6,6 @@
   "author": "",
   "license": "MIT",
   "main": "./lib/index.js",
-  "dependencies": {
-    "chalk": "^2.4.1",
-    "just-task": ">=0.7.6 <1.0.0",
-    "just-scripts-utils": ">=0.3.3 <1.0.0",
-    "fs-extra": "^7.0.1",
-    "glob": "^7.1.3",
-    "npm-registry-fetch": "^3.9.0",
-    "prompts": "^2.0.1",
-    "run-parallel-limit": "^1.0.5",
-    "typescript": "^3.2.4",
-    "webpack-merge": "^4.2.1",
-    "webpack": "^4.28.4"
-  },
   "devDependencies": {
     "@types/fs-extra": "^5.0.4",
     "@types/glob": "^7.1.1",
@@ -27,8 +14,19 @@
     "@types/prompts": "^1.2.0",
     "@types/run-parallel-limit": "^1.0.0",
     "@types/webpack-merge": "^4.1.3",
+    "chalk": "^2.4.1",
+    "fs-extra": "^7.0.1",
+    "glob": "^7.1.3",
     "jest": "^23.6.0",
-    "ts-loader": "^5.3.3"
+    "just-scripts-utils": ">=0.3.3 <1.0.0",
+    "just-task": ">=0.7.6 <1.0.0",
+    "npm-registry-fetch": "^3.9.0",
+    "prompts": "^2.0.1",
+    "run-parallel-limit": "^1.0.5",
+    "ts-loader": "^5.3.3",
+    "typescript": "^3.2.4",
+    "webpack": "^4.28.4",
+    "webpack-merge": "^4.2.1"
   },
   "scripts": {
     "build": "webpack --mode production",

--- a/packages/just-scripts/package.json
+++ b/packages/just-scripts/package.json
@@ -6,10 +6,20 @@
   "author": "",
   "license": "MIT",
   "main": "./lib/index.js",
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
+    "chalk": "^2.4.1",
     "just-task": ">=0.7.6 <1.0.0",
     "just-scripts-utils": ">=0.3.3 <1.0.0",
+    "fs-extra": "^7.0.1",
+    "glob": "^7.1.3",
+    "npm-registry-fetch": "^3.9.0",
+    "prompts": "^2.0.1",
+    "run-parallel-limit": "^1.0.5",
+    "typescript": "^3.2.4",
+    "webpack-merge": "^4.2.1",
+    "webpack": "^4.28.4"
+  },
+  "devDependencies": {
     "@types/fs-extra": "^5.0.4",
     "@types/glob": "^7.1.1",
     "@types/jest": "^23.3.13",
@@ -17,20 +27,12 @@
     "@types/prompts": "^1.2.0",
     "@types/run-parallel-limit": "^1.0.0",
     "@types/webpack-merge": "^4.1.3",
-    "chalk": "^2.4.1",
-    "fs-extra": "^7.0.1",
-    "glob": "^7.1.3",
-    "npm-registry-fetch": "^3.9.0",
-    "prompts": "^2.0.1",
-    "run-parallel-limit": "^1.0.5",
-    "ts-loader": "^5.3.3",
-    "typescript": "^3.2.4",
-    "webpack-cli": "^3.2.1",
-    "webpack-merge": "^4.2.1",
-    "webpack": "^4.28.4"
+    "jest": "^23.6.0",
+    "ts-loader": "^5.3.3"
   },
   "scripts": {
     "build": "webpack --mode production",
-    "start": "webpack --watch --progress --mode development"
+    "start": "webpack --watch --progress --mode development",
+    "test": "jest"
   }
 }

--- a/packages/just-scripts/src/tasks/upgradeStackTask.ts
+++ b/packages/just-scripts/src/tasks/upgradeStackTask.ts
@@ -5,8 +5,8 @@ import { logger } from 'just-task';
 import { paths, downloadPackage, transform, mergePackageJson } from 'just-scripts-utils';
 
 export async function upgradeStackTask() {
-  const { installPath } = paths;
-  return upgradeStackPackageJsonFile(installPath);
+  const { projectPath } = paths;
+  return upgradeStackPackageJsonFile(projectPath);
 }
 
 /**

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  printWidth: 100,
+  tabWidth: 2,
+  singleQuote: true
+};


### PR DESCRIPTION
Get tests running in `just-scripts-utils` and add a first basic test.

Rename `paths.installPath` to `paths.projectPath`.

Config updates:
- Add `npmignore` for `just-scripts-utils`
- Add prettier config. At this point it's totally opt-in (only does anything when you have the prettier extension installed+enabled in VS Code). I set the `printWidth` to 100 since that's what I prefer for working on a small-ish screen with split windows, but I might also be okay with 120.