### PR TITLE
Add test for downloadPackage

### DIFF
--- a/packages/just-scripts-utils/src/__tests__/downloadPackage.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/downloadPackage.spec.ts
@@ -1,0 +1,126 @@
+import mockfs from 'mock-fs';
+import fs from 'fs';
+import path from 'path';
+import child_process from 'child_process';
+import tar from 'tar';
+import { paths } from '../paths';
+import { logger } from '../logger';
+import { _isDevMode, downloadPackage, _setMockDirname } from '../downloadPackage';
+
+// TODO: make sure this works on windows (different slash format)
+
+describe('downloadPackage', () => {
+  /**
+   * Final part of the directory containing the built version of downloadPackage.ts.
+   * We use this various places to set a fake __dirname for the built downloadPackage.js.
+   * This should ideally be kept in sync with the actual package name and output location.
+   */
+  const libDir = 'just-scripts-utils/lib';
+
+  const fakeTemp = 'temp';
+  const fakeLoggerError = jest.fn();
+
+  beforeAll(() => {
+    jest.spyOn(paths, 'tempPath').mockImplementation(pkg => {
+      return path.join(fakeTemp, pkg);
+    });
+    // prevent logged errors from failing tests
+    jest.spyOn(logger, 'error').mockImplementation(fakeLoggerError);
+  });
+
+  afterEach(() => {
+    _setMockDirname('');
+    mockfs.restore();
+    fakeLoggerError.mockReset();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('correctly detects dev mode in real repo', () => {
+    // real package in real directory structure
+    expect(_isDevMode('just-stack-monorepo')).toBe(true);
+    // this package doesn't exist
+    expect(_isDevMode('foo')).toBe(false);
+  });
+
+  it('correctly detects not dev mode', () => {
+    const libInNodeModules = path.join('foo/node_modules', libDir);
+    mockfs({
+      // almost a realistic "dev mode" case but has the wrong package name
+      'just-task': {
+        'package.json': JSON.stringify({ name: 'not-just-task' }),
+        packages: {
+          [libDir]: {},
+          'foo/template': {}
+        }
+      },
+      // another case simulating being installed in node_modules
+      [libInNodeModules]: {}
+    });
+
+    _setMockDirname('not-just-task/packages/just-scripts-utils/lib');
+    expect(_isDevMode('foo')).toBe(false);
+
+    _setMockDirname(libInNodeModules);
+    expect(_isDevMode('foo')).toBe(false);
+  });
+
+  it('returns local template path in dev mode', async () => {
+    const pkg = 'just-stack-monorepo';
+    const result = await downloadPackage(pkg);
+    expect(result).toBe(path.join(__dirname, '../../..', pkg, 'template'));
+  });
+
+  it('removes previous download and handles npm pack errors', async () => {
+    const pkg = 'foo';
+    const tempPath = `${fakeTemp}/${pkg}`;
+    mockfs({
+      [tempPath]: {
+        'file.txt': 'stuff'
+      }
+    });
+    // cause npm pack to "error"
+    jest.spyOn(child_process, 'spawnSync').mockImplementationOnce((cmd: string, args: string[]) => {
+      expect(args).toContain(`${pkg}@latest`);
+      return { error: new Error('fail') };
+    });
+
+    const result = await downloadPackage(pkg);
+
+    // old directory contents got deleted
+    expect(fs.existsSync(path.join(tempPath, 'file.txt'))).toBe(false);
+    // directory got re-created
+    expect(fs.existsSync(tempPath)).toBe(true);
+
+    // npm pack "errored"
+    expect(result).toBeNull();
+    expect(fakeLoggerError).toBeCalled();
+  });
+
+  it('downloads package', async () => {
+    const pkg = 'foo';
+    const version = '1.2.3';
+    mockfs({
+      [fakeTemp]: {},
+      // this will be tar'd up by fake npm pack below
+      [`${pkg}/package/template`]: {
+        'file.txt': 'stuff'
+      }
+    });
+
+    // fake the result of npm pack
+    jest
+      .spyOn(child_process, 'spawnSync')
+      .mockImplementationOnce((cmd: string, args?: string[]) => {
+        expect(args).toContain(`${pkg}@${version}`);
+        // instead of downloading a tarball, create one in the expected spot
+        tar.create({ sync: true, gzip: true, file: path.join(fakeTemp, pkg, 'result.tgz') }, [pkg]);
+        return {};
+      });
+
+    const result = await downloadPackage(pkg, version);
+    expect(result).toBe(path.join(fakeTemp, pkg, 'package/template'));
+  });
+});

--- a/packages/just-scripts-utils/src/index.ts
+++ b/packages/just-scripts-utils/src/index.ts
@@ -1,4 +1,4 @@
-export * from './downloadPackage';
+export { downloadPackage } from './downloadPackage';
 export * from './findMonoRepoRootPath';
 export * from './IPackageJson';
 export { logger } from './logger';


### PR DESCRIPTION
Add a test and more error checking for downloadPackage. This is where things really get start getting interesting with fs and function mocks! I also had to make the isDevMode function exported for separate testing (but still excluded from index.ts) and add a test-only helper to override __dirname, since I couldn't find any way to override that using a jest mock.