### PR TITLE
findMonoRepoRootPath tests + readPackageJson handles invalid JSON

### DIFF
--- a/packages/just-scripts-utils/src/__tests__/findMonoRepoRootPath.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/findMonoRepoRootPath.spec.ts
@@ -1,0 +1,94 @@
+import mockfs from 'mock-fs';
+import { paths } from '../paths';
+import { findMonoRepoRootPath } from '../findMonoRepoRootPath';
+
+// TODO: make sure tests pass on windows
+
+describe('findMonoRepoRootPath', () => {
+  const packageJsonWithJustStack = JSON.stringify({ just: { stack: 'just-stack-monorepo' } });
+  const packageJsonWithWrongStack = JSON.stringify({ just: { stack: 'no' } });
+
+  afterEach(() => {
+    paths.projectPath = '';
+    mockfs.restore();
+  });
+
+  it('returns null when there is no monorepo root', () => {
+    mockfs({
+      '/a': {},
+      '/b/c/d': {},
+      '/e': {
+        'package.json': '{}', // no just.stack
+        f: {
+          'package.json': packageJsonWithWrongStack,
+          g: {}
+        }
+      },
+      '/h': {
+        i: {}, // this will be the projectPath
+        j: { 'rush.json': '{}' } // rush.json is in the wrong place
+      }
+    });
+
+    paths.projectPath = '/a';
+    expect(findMonoRepoRootPath()).toBeNull();
+
+    paths.projectPath = '/b/c/d';
+    expect(findMonoRepoRootPath()).toBeNull();
+
+    paths.projectPath = '/e/f/g';
+    expect(findMonoRepoRootPath()).toBeNull();
+
+    paths.projectPath = '/h/i';
+    expect(findMonoRepoRootPath()).toBeNull();
+  });
+
+  it('works when projectPath is the monorepo root', () => {
+    mockfs({
+      '/a': { 'rush.json': '{}' },
+      '/b': { 'package.json': packageJsonWithJustStack }
+    });
+
+    paths.projectPath = '/a';
+    expect(findMonoRepoRootPath()).toBe('/a');
+
+    paths.projectPath = '/b';
+    expect(findMonoRepoRootPath()).toBe('/b');
+  });
+
+  it('works in a general case with rush.json at root', () => {
+    mockfs({
+      '/a/b': {
+        'rush.json': '{}', // real root
+        c: {
+          'package.json': '{', // invalid json
+          d: {
+            'package.json': packageJsonWithWrongStack,
+            e: {}
+          }
+        }
+      }
+    });
+
+    paths.projectPath = '/a/b/c/d/e';
+    expect(findMonoRepoRootPath()).toBe('/a/b');
+  });
+
+  it('works in a general case with package.json with just.stack at root', () => {
+    mockfs({
+      '/a/b': {
+        'rush.json': packageJsonWithJustStack, // real root
+        c: {
+          'package.json': '{', // invalid json
+          d: {
+            'package.json': packageJsonWithWrongStack,
+            e: {}
+          }
+        }
+      }
+    });
+
+    paths.projectPath = '/a/b/c/d/e';
+    expect(findMonoRepoRootPath()).toBe('/a/b');
+  });
+});

--- a/packages/just-scripts-utils/src/__tests__/readPackageJson.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/readPackageJson.spec.ts
@@ -3,12 +3,16 @@ import { readPackageJson } from '../readPackageJson';
 
 describe('readPackageJson', () => {
   const testDir = 'testDir';
+  const badDir = 'badDir';
   const testName = 'my-fake-package';
 
   beforeAll(() => {
     mockfs({
       [testDir]: {
         'package.json': JSON.stringify({ name: testName })
+      },
+      [badDir]: {
+        'package.json': '{' // invalid JSON
       }
     });
   });
@@ -25,5 +29,10 @@ describe('readPackageJson', () => {
     const packageJson = readPackageJson(testDir);
     expect(packageJson).toBeDefined();
     expect(packageJson!.name).toEqual(testName);
+  });
+
+  it('returns undefined for invalid json', () => {
+    const packageJson = readPackageJson(badDir);
+    expect(packageJson).toBeUndefined();
   });
 });

--- a/packages/just-scripts-utils/src/findMonoRepoRootPath.ts
+++ b/packages/just-scripts-utils/src/findMonoRepoRootPath.ts
@@ -3,7 +3,14 @@ import path from 'path';
 import fse from 'fs-extra';
 import { readPackageJson } from './readPackageJson';
 
-export function findMonoRepoRootPath() {
+/**
+ * Find the path of a monorepo root relative to the project being generated/updated (as defined
+ * by `paths.projectPath`, or defaulting to `process.cwd()`).
+ *
+ * This will be either the directory containing rush.json or the root of a package which uses
+ * the `just-stack-monorepo` stack according to the `just.stack` property of its package.json.
+ */
+export function findMonoRepoRootPath(): string | null {
   const { projectPath } = paths;
   let found = false;
   let currentPath = projectPath;

--- a/packages/just-scripts-utils/src/readPackageJson.ts
+++ b/packages/just-scripts-utils/src/readPackageJson.ts
@@ -10,6 +10,6 @@ import { IPackageJson } from './IPackageJson';
 export function readPackageJson(folderPath: string): IPackageJson | undefined {
   const packageJsonPath = path.join(folderPath, 'package.json');
   if (fse.existsSync(packageJsonPath)) {
-    return fse.readJsonSync(packageJsonPath);
+    return fse.readJsonSync(packageJsonPath, { throws: false }) || undefined;
   }
 }


### PR DESCRIPTION
Add tests for `findMonoRepoRootPath`. Also realized I should make `readPackageJson` handle if a package.json file exists but is invalid.