### PR TITLE
Logger tests + add verbose mode

### DIFF
--- a/packages/just-scripts-utils/package.json
+++ b/packages/just-scripts-utils/package.json
@@ -21,7 +21,8 @@
     "marked": "^0.6.0",
     "marked-terminal": "^3.2.0",
     "semver": "^5.6.0",
-    "tar": "^4.4.8"
+    "tar": "^4.4.8",
+    "yargs": "^12.0.5"
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.4",
@@ -35,6 +36,7 @@
     "@types/node": "^10.12.18",
     "@types/semver": "^5.5.0",
     "@types/tar": "^4.0.0",
+    "@types/yargs": "12.0.1",
     "jest": "^23.6.0",
     "mock-fs": "^4.8.0",
     "ts-jest": "^23.10.5"

--- a/packages/just-scripts-utils/src/__tests__/logger.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/logger.spec.ts
@@ -55,11 +55,13 @@ describe('logger', () => {
     expect(consoleInfo).toHaveBeenCalledWith(timeStr, square, obj, 3, null, undefined);
   });
 
-  it('handles verbose logging', () => {
+  it('ignores verbose logs when enableVerbose is false', () => {
     logger.enableVerbose = false;
     logger.verbose('hi');
     expect(consoleInfo).toHaveBeenCalledTimes(0);
+  });
 
+  it('prints verbose logs when enableVerbose is true', () => {
     logger.enableVerbose = true;
     logger.verbose('hi');
     expect(consoleInfo).toHaveBeenCalledTimes(1);

--- a/packages/just-scripts-utils/src/__tests__/logger.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/logger.spec.ts
@@ -1,0 +1,80 @@
+import { logger } from '../logger';
+import chalk from 'chalk';
+
+describe('logger', () => {
+  const fakeTime = new Date().toLocaleTimeString();
+  const timeStr = `[${fakeTime}]`;
+  const emptySquare = '\u25a1';
+  const square = '\u25a0';
+  const triangle = '\u25b2';
+  const consoleInfo = jest.fn();
+  const consoleWarn = jest.fn();
+  const consoleError = jest.fn();
+
+  beforeAll(() => {
+    // Log entries include time, so use a constant value for testing
+    jest.spyOn(Date.prototype, 'toLocaleTimeString').mockReturnValue(fakeTime);
+    // Override console methods
+    jest.spyOn(console, 'info').mockImplementation(consoleInfo);
+    jest.spyOn(console, 'warn').mockImplementation(consoleWarn);
+    jest.spyOn(console, 'error').mockImplementation(consoleError);
+    // Disable chalk colors so it's easier to compare results
+    chalk.enabled = false;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks(); // reset call counts
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+    chalk.enabled = true;
+    logger.enableVerbose = false;
+  });
+
+  // All logger methods use the same helper internally, so we use logger.info for most tests.
+
+  it('handles logging with varying arg counts', () => {
+    logger.info();
+    expect(consoleInfo).toHaveBeenCalledTimes(1);
+    expect(consoleInfo).toHaveBeenCalledWith(timeStr, square);
+
+    logger.info('hello');
+    expect(consoleInfo).toHaveBeenCalledTimes(2);
+    expect(consoleInfo).toHaveBeenCalledWith(timeStr, square, 'hello');
+
+    logger.info('hello', 'world');
+    expect(consoleInfo).toHaveBeenCalledTimes(3);
+    expect(consoleInfo).toHaveBeenCalledWith(timeStr, square, 'hello', 'world');
+  });
+
+  it('handles logging non-strings', () => {
+    const obj = {};
+    logger.info(obj, 3, null, undefined);
+    expect(consoleInfo).toHaveBeenCalledTimes(1);
+    expect(consoleInfo).toHaveBeenCalledWith(timeStr, square, obj, 3, null, undefined);
+  });
+
+  it('handles verbose logging', () => {
+    logger.enableVerbose = false;
+    logger.verbose('hi');
+    expect(consoleInfo).toHaveBeenCalledTimes(0);
+
+    logger.enableVerbose = true;
+    logger.verbose('hi');
+    expect(consoleInfo).toHaveBeenCalledTimes(1);
+    expect(consoleInfo).toHaveBeenCalledWith(timeStr, emptySquare, 'hi');
+  });
+
+  it('handles warn logging', () => {
+    logger.warn('warning');
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+    expect(consoleWarn).toHaveBeenCalledWith(timeStr, triangle, 'warning');
+  });
+
+  it('handles error logging', () => {
+    logger.error('oh no!');
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(timeStr, 'x', 'oh no!');
+  });
+});

--- a/packages/just-scripts-utils/src/logger.ts
+++ b/packages/just-scripts-utils/src/logger.ts
@@ -1,26 +1,48 @@
 import chalk from 'chalk';
+import yargs from 'yargs';
 
-function getTimestamp() {
+function logInternal(method: 'info' | 'warn' | 'error', symbol: string, ...args: any[]) {
   const now = new Date();
-  return `[${now.toLocaleTimeString()}]`;
+  const timestamp = chalk.gray(`[${now.toLocaleTimeString()}]`);
+
+  console[method](timestamp, symbol, ...args);
 }
 
 export interface ILogger {
-  info(msg?: any, ...optionalParams: any[]): void;
-  warn(msg?: any, ...optionalParams: any[]): void;
-  error(msg?: any, ...optionalParams: any[]): void;
+  /** Whether verbose logging is enabled. Default false unless --verbose arg is given. */
+  enableVerbose: boolean;
+  /** Log to `console.info` with a timestamp, but only if verbose logging is enabled. */
+  verbose(...args: any[]): void;
+  /** Log to `console.info` with a timestamp. */
+  info(...args: any[]): void;
+  /** Log to `console.warn` with a timestamp. */
+  warn(...args: any[]): void;
+  /** Log to `console.error` with a timestamp. */
+  error(...args: any[]): void;
 }
 
+const emptySquare = '\u25a1';
+const square = '\u25a0';
+const triangle = '\u25b2';
+
 export const logger: ILogger = {
-  info(msg?: any, ...optionalParams: any[]) {
-    console.info.apply(null, [`${chalk.gray(getTimestamp())} ${chalk.green('\u25a0')} ${msg}`, ...optionalParams]);
+  enableVerbose: !!yargs.argv.verbose,
+
+  verbose(...args: any[]) {
+    if (logger.enableVerbose) {
+      logInternal('info', chalk.gray(emptySquare), ...args);
+    }
   },
 
-  warn(msg?: any, ...optionalParams: any[]) {
-    console.warn.apply(null, [`${chalk.gray(getTimestamp())} ${chalk.yellow('\u25b2')} ${msg}`, ...optionalParams]);
+  info(...args: any[]) {
+    logInternal('info', chalk.green(square), ...args);
   },
 
-  error(msg?: any, ...optionalParams: any[]) {
-    console.error.apply(null, [`${chalk.gray(getTimestamp())} ${chalk.redBright('x')} ${msg}`, ...optionalParams]);
+  warn(...args: any[]) {
+    logInternal('warn', chalk.yellow(triangle), ...args);
+  },
+
+  error(...args: any[]) {
+    logInternal('error', chalk.redBright('x'), ...args);
   }
 };


### PR DESCRIPTION
Add tests for the logger. Also add a verbose logging mode since that seemed like it could be useful (I wanted it a couple times when working on scripts in fabric). Verbose mode can be enabled either by setting `logger.enableVerbose` or by providing the `--verbose` command line arg.