### PR TITLE
Rush utility testing and error handling

### DIFF
--- a/packages/just-scripts-utils/src/IRushJson.ts
+++ b/packages/just-scripts-utils/src/IRushJson.ts
@@ -1,0 +1,12 @@
+export interface IRushProject {
+  packageName: string;
+  projectFolder: string;
+  shouldPublish?: boolean;
+  versionPolicyName?: string;
+}
+
+export interface IRushJson {
+  projects: IRushProject[];
+  rushVersion: string;
+  // more properties can be added as needed
+}

--- a/packages/just-scripts-utils/src/__tests__/rush.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/rush.spec.ts
@@ -1,0 +1,136 @@
+import fs from 'fs';
+import mockfs from 'mock-fs';
+import jju from 'jju';
+import { _justReadRushJson, _parseRushJson, rushAddPackage } from '../rush';
+
+// TODO: test on Windows
+
+const rushJsonStrNoProjects = `{
+  // this is a comment
+  "rushVersion": "5.5.4"
+}`;
+const rushJsonStr = `{
+  // this is a comment
+  "rushVersion": "5.5.4",
+  "projects": [
+    {
+      "packageName": "a",
+      "projectFolder": "packages/a"
+    }
+  ]
+}`;
+const rushJsonUpdatedStr = `{
+  // this is a comment
+  "rushVersion": "5.5.4",
+  "projects": [
+    {
+      "packageName": "a",
+      "projectFolder": "packages/a"
+    },
+    {
+      "packageName": "b",
+      "projectFolder": "packages/b"
+    }
+  ]
+}`;
+
+describe('rushUpdate', () => {
+  // TOOD: not sure what to test here
+});
+
+describe('_justReadRushJson', () => {
+  beforeAll(() => {
+    mockfs({
+      root: { 'rush.json': rushJsonStr },
+      badRoot: {}
+    });
+  });
+
+  afterAll(() => {
+    mockfs.restore();
+  });
+
+  it('reads existing file', () => {
+    expect(_justReadRushJson('root/rush.json')).toBe(rushJsonStr);
+  });
+
+  it('returns undefined for nonexistent file', () => {
+    expect(_justReadRushJson('badRoot/rush.json')).toBeUndefined();
+  });
+});
+
+describe('_parseRushJson', () => {
+  it('handles invalid input', () => {
+    expect(_justReadRushJson(undefined as any)).toBeUndefined();
+    expect(_justReadRushJson('{')).toBeUndefined();
+  });
+
+  it('parses file', () => {
+    const rushJsonParsed = jju.parse(rushJsonStr, { mode: 'cjson' });
+    expect(_parseRushJson(rushJsonStr)).toEqual(rushJsonParsed);
+  });
+});
+
+describe('readRushJson', () => {
+  afterEach(() => {
+    mockfs.restore();
+    jest.restoreAllMocks();
+  });
+
+  it('handles invalid file', () => {
+    const consoleError = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(consoleError);
+    mockfs({
+      root: { 'rush.json': '{' }
+    });
+
+    rushAddPackage('b', 'root');
+    // console.error called
+    expect(consoleError).toHaveBeenCalled();
+    // rush.json not updated
+    expect(fs.readFileSync('root/rush.json').toString()).toBe('{');
+  });
+
+  it('handles valid case', () => {
+    // call this before mocking fs since it internally uses a dynamic require,
+    // which doesn't work while fs is mocked (but if it's called before mocking,
+    // the required file will be cached)
+    jju.update('{}', {});
+
+    mockfs({
+      root1: { 'rush.json': rushJsonStrNoProjects }, // no projects yet
+      root2: { 'rush.json': rushJsonStr } // already has a project
+    });
+
+    rushAddPackage('a', 'root1');
+    expect(fs.readFileSync('root1/rush.json').toString()).toBe(rushJsonStr);
+
+    rushAddPackage('b', 'root2');
+    expect(fs.readFileSync('root2/rush.json').toString()).toBe(rushJsonUpdatedStr);
+  });
+
+  it('handles update or write errors', () => {
+    jju.update('{}', {});
+    const consoleError = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(consoleError);
+    const throwError = () => {
+      throw new Error('error');
+    };
+
+    mockfs({
+      root: { 'rush.json': rushJsonStr }
+    });
+
+    // cause a fake update error
+    jest.spyOn(jju, 'update', 'get').mockImplementationOnce(throwError);
+    rushAddPackage('b', 'root');
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync('root/rush.json').toString()).toEqual(rushJsonStr);
+
+    // cause a fake write error
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(throwError);
+    rushAddPackage('b', 'root');
+    expect(consoleError).toHaveBeenCalledTimes(2);
+    expect(fs.readFileSync('root/rush.json').toString()).toEqual(rushJsonStr);
+  });
+});

--- a/packages/just-scripts-utils/src/index.ts
+++ b/packages/just-scripts-utils/src/index.ts
@@ -1,10 +1,11 @@
 export { downloadPackage } from './downloadPackage';
 export * from './findMonoRepoRootPath';
 export * from './IPackageJson';
+export * from './IRushJson';
 export { logger } from './logger';
 export * from './mergePackageJson';
 export * from './paths';
 export * from './prettyPrintMarkdown';
 export * from './readPackageJson';
-export * from './rush';
+export { readRushJson, rushAddPackage, rushUpdate } from './rush';
 export * from './transform';

--- a/packages/just-scripts-utils/src/rush.ts
+++ b/packages/just-scripts-utils/src/rush.ts
@@ -2,27 +2,30 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import jju from 'jju';
+import { logger } from './logger';
+import { IRushJson } from './IRushJson';
 
 /**
  * Runs rush update.
  * @param cwd Working directory in which to run the command.
  */
 export function rushUpdate(cwd: string): void {
-  execSync(`${process.execPath} common/scripts/install-run-rush.js update`, { cwd, stdio: 'inherit' });
+  // TODO: does this work on Windows?
+  execSync(`${process.execPath} common/scripts/install-run-rush.js update`, {
+    cwd,
+    stdio: 'inherit'
+  });
 }
 
 /**
  * Reads the contents of rush.json (using a parser which handles comments).
  * @param rootPath Path to the folder containing rush.json.
- * @returns The parsed contents of rush.json.
+ * @returns The parsed contents of rush.json or undefined if it's not found.
  */
-export function readRushJson(rootPath: string): any {
-  const rushJsonFile = path.join(rootPath, 'rush.json');
-  // TODO: handle if file doesn't exist
-
-  const contents = fs.readFileSync(rushJsonFile, 'utf8').toString();
-  return jju.parse(contents);
-
+export function readRushJson(rootPath: string): IRushJson | undefined {
+  const rushJsonPath = path.join(rootPath, 'rush.json');
+  const contents = _justReadRushJson(rushJsonPath);
+  return _parseRushJson(contents!);
 }
 
 /**
@@ -31,21 +34,46 @@ export function readRushJson(rootPath: string): any {
  * @param rootPath Path to the folder containing rush.json.
  */
 export function rushAddPackage(packageName: string, rootPath: string): void {
-  const rushJsonFile = path.join(rootPath, 'rush.json');
-  // TODO: handle if file doesn't exist
+  const rushJsonPath = path.join(rootPath, 'rush.json');
+  const oldContents = _justReadRushJson(rushJsonPath)!;
+  const rushJson = _parseRushJson(oldContents);
+  if (!rushJson) {
+    logger.error(`Couldn't read rush.json under ${rootPath}. Not adding package.`);
+    return;
+  }
 
-  const oldContents = fs.readFileSync(rushJsonFile, 'utf8').toString();
-  // rush.json can contain comments, so we have to use a json library which supports comments
-  // (instead of JSON.parse/JSON.stringify)
-  const rushJson = jju.parse(oldContents);
+  if (!rushJson.projects) {
+    rushJson.projects = [];
+  }
   rushJson.projects.push({
     packageName,
     projectFolder: `packages/${packageName}`
   });
 
-  const newContents = jju.update(oldContents, rushJson, {
-    mode: 'cjson',
-    indent: 2
-  });
-  fs.writeFileSync(rushJsonFile, newContents);
+  try {
+    const newContents = jju.update(oldContents, rushJson, { mode: 'cjson', indent: 2 });
+    fs.writeFileSync(rushJsonPath, newContents);
+  } catch {
+    logger.error(`Couldn't update rush.json under ${rootPath}. Not adding package.`);
+  }
+}
+
+/** Read (but don't parse) rush.json. Exported for testing only. */
+export function _justReadRushJson(rushJsonPath: string): string | undefined {
+  try {
+    return fs.readFileSync(rushJsonPath, 'utf8').toString();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Parse an already-read rush.json. Exported for testing only. */
+export function _parseRushJson(rushJsonContents: string): IRushJson | undefined {
+  try {
+    // rush.json can contain comments, so we have to use a json library which supports comments
+    // (instead of JSON.parse/JSON.stringify)
+    return jju.parse(rushJsonContents, { mode: 'cjson' });
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
Add tests for the rush-related utilities, and improve their error handling. Some error handling improvements for the upgrade repo task too, but it still needs more work.