### PR TITLE
Lock dep versions, update gitignores

### DIFF
--- a/common/changes/create-just/ecraig-config_2019-02-20-21-50.json
+++ b/common/changes/create-just/ecraig-config_2019-02-20-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "create-just",
+      "comment": "Lock some dep versions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "create-just",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-scripts/ecraig-config_2019-02-20-21-50.json
+++ b/common/changes/just-scripts/ecraig-config_2019-02-20-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "Lock some dep versions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-monorepo/ecraig-config_2019-02-20-21-50.json
+++ b/common/changes/just-stack-monorepo/ecraig-config_2019-02-20-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-monorepo",
+      "comment": "Add scss.ts to gitignore",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-stack-monorepo",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-single-lib/ecraig-config_2019-02-20-21-50.json
+++ b/common/changes/just-stack-single-lib/ecraig-config_2019-02-20-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-single-lib",
+      "comment": "Add scss.ts to gitignore",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-stack-single-lib",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-uifabric/ecraig-config_2019-02-20-21-50.json
+++ b/common/changes/just-stack-uifabric/ecraig-config_2019-02-20-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-uifabric",
+      "comment": "Add scss.ts to gitignore",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-stack-uifabric",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-task/ecraig-config_2019-02-20-21-50.json
+++ b/common/changes/just-task/ecraig-config_2019-02-20-21-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-task",
+      "comment": "Lock some dep versions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-task",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -44,6 +44,7 @@ dependencies:
   glob: 7.1.3
   handlebars: 4.0.12
   jest: 23.6.0
+  jest-cli: 23.6.0
   jest-expect-message: 1.0.2
   jju: 1.4.0
   json5: 2.1.0
@@ -61,10 +62,10 @@ dependencies:
   tar: 4.4.8
   ts-jest: 23.10.5
   ts-loader: 5.3.3
-  typescript: 3.3.1
+  typescript: 3.3.3
   undertaker: 1.2.0
   undertaker-registry: 1.0.1
-  webpack: 4.29.1
+  webpack: 4.29.5
   webpack-cli: 3.2.1
   webpack-merge: 4.2.1
   yargs: 12.0.5
@@ -331,6 +332,7 @@ packages:
       integrity: sha512-wNHxLkEKTQ2ay0tnsam2z7fGZUi+05ziDJflEt3AZTP3oXLKHJp9HqhfroB/vdMvt3sda9fAbq7FsG8QPDrZBg==
   /@babel/plugin-proposal-class-properties/7.3.0/@babel!core@7.2.2:
     dependencies:
+      '@babel/core': 7.2.2
       '@babel/helper-create-class-features-plugin': /@babel/helper-create-class-features-plugin/7.3.2/@babel!core@7.2.2
       '@babel/helper-plugin-utils': 7.0.0
     dev: false
@@ -370,6 +372,7 @@ packages:
       integrity: sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==
   /@babel/plugin-proposal-object-rest-spread/7.3.2/@babel!core@7.2.2:
     dependencies:
+      '@babel/core': 7.2.2
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.2.2
     dev: false
@@ -1213,6 +1216,7 @@ packages:
       integrity: sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==
   /@babel/preset-env/7.3.1/@babel!core@7.2.2:
     dependencies:
+      '@babel/core': 7.2.2
       '@babel/helper-module-imports': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-proposal-async-generator-functions': /@babel/plugin-proposal-async-generator-functions/7.2.0/@babel!core@7.2.2
@@ -1276,6 +1280,7 @@ packages:
       integrity: sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==
   /@babel/preset-react/7.0.0/@babel!core@7.2.2:
     dependencies:
+      '@babel/core': 7.2.2
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-transform-react-display-name': /@babel/plugin-transform-react-display-name/7.2.0/@babel!core@7.2.2
       '@babel/plugin-transform-react-jsx': /@babel/plugin-transform-react-jsx/7.3.0/@babel!core@7.2.2
@@ -1303,6 +1308,7 @@ packages:
       integrity: sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==
   /@babel/register/7.0.0/@babel!core@7.2.2:
     dependencies:
+      '@babel/core': 7.2.2
       core-js: 2.6.3
       find-cache-dir: 1.0.0
       home-or-tmp: 3.0.0
@@ -1580,10 +1586,28 @@ packages:
       react-dom: ^0.14.9 || ^15.0.1-0 || ^16.0.0-0
     resolution:
       integrity: sha512-iFwuoFUQoS6H6paxrRsVCxQnw2SqnxhS+EBh54Gb3A6HxS2IKzGAE5c4tnZcqjXNPxXTvXgt5iQg3xycIa95cg==
-  /@uifabric/charting/0.28.5/react-dom@16.7.0:
+  /@uifabric/charting/0.28.5/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0
-      react-dom: 16.7.0
+      '@microsoft/load-themed-styles': 1.8.56
+      '@types/d3-array': 1.2.1
+      '@types/d3-axis': 1.0.10
+      '@types/d3-scale': 2.0.0
+      '@types/d3-selection': 1.3.0
+      '@types/d3-shape': 1.3.0
+      '@types/d3-time-format': 2.1.0
+      '@uifabric/icons': 6.3.0
+      '@uifabric/set-version': 1.1.3
+      d3-array: 1.2.1
+      d3-axis: 1.0.8
+      d3-scale: 2.0.0
+      d3-selection: 1.3.0
+      d3-shape: 1.3.4
+      d3-time-format: 2.1.3
+      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0
+      prop-types: 15.6.2
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/@uifabric/charting/0.28.5
     peerDependencies:
@@ -1616,14 +1640,27 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-+1z5RUSP5gWfB5VIcD1A7O1ITbzwBEvCOOn0Md5vOhozrcDPxEAcoIve29Ckckd/05xmMAYTjgQVMjgE4y8Rng==
-  /@uifabric/experiments/6.54.2/react-dom@16.7.0:
+  /@uifabric/experiments/6.54.2/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      '@uifabric/charting': /@uifabric/charting/0.28.5/react-dom@16.7.0
-      '@uifabric/file-type-icons': /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0
-      '@uifabric/foundation': /@uifabric/foundation/0.7.1/react-dom@16.7.0
-      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0
-      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0
-      react-dom: 16.7.0
+      '@microsoft/load-themed-styles': 1.8.56
+      '@uifabric/azure-themes': 0.1.5
+      '@uifabric/charting': /@uifabric/charting/0.28.5/react-dom@16.7.0+react@16.7.0
+      '@uifabric/file-type-icons': /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0+react@16.7.0
+      '@uifabric/fluent-theme': 0.13.4
+      '@uifabric/foundation': /@uifabric/foundation/0.7.1/react-dom@16.7.0+react@16.7.0
+      '@uifabric/icons': 6.3.0
+      '@uifabric/merge-styles': 6.15.2
+      '@uifabric/set-version': 1.1.3
+      '@uifabric/styling': 6.41.0
+      '@uifabric/theme-samples': 0.1.4
+      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0
+      '@uifabric/variants': 6.14.0
+      deep-assign: 2.0.0
+      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0
+      prop-types: 15.6.2
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/@uifabric/experiments/6.54.2
     peerDependencies:
@@ -1642,9 +1679,13 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-T6wGiA/RjLqRE+P5RRObpcRJ+ejh4ZwZX584GgEymOCcU7kjzWSZR7imTA65FbUMUhXxR68b3oiWgPSaCAXE8w==
-  /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0:
+  /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      react-dom: 16.7.0
+      '@uifabric/set-version': 1.1.3
+      '@uifabric/styling': 6.41.0
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/@uifabric/file-type-icons/6.4.1
     peerDependencies:
@@ -1675,10 +1716,14 @@ packages:
       react-dom: ^0.14.9 || ^15.0.1-0 || ^16.0.0-0
     resolution:
       integrity: sha512-YrdaJXAe4x7whaj7/x1fhFsBGao0vAec6mVIAYCvC09AK+puEYDahIloVWA6vLTRlWzzOZWsvN3S3Z1tzfhIRw==
-  /@uifabric/foundation/0.7.1/react-dom@16.7.0:
+  /@uifabric/foundation/0.7.1/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0
-      react-dom: 16.7.0
+      '@uifabric/set-version': 1.1.3
+      '@uifabric/styling': 6.41.0
+      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/@uifabric/foundation/0.7.1
     peerDependencies:
@@ -1738,9 +1783,14 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-2VKRadp+pGV5PFubSYCUTU4Sg3NdztECFiEvgyVDIrGYZhSwOVHMwAKb+I9hr990OLCb+gSK3rekJp/To9NZFQ==
-  /@uifabric/utilities/6.29.0/react-dom@16.7.0:
+  /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      react-dom: 16.7.0
+      '@uifabric/merge-styles': 6.15.2
+      '@uifabric/set-version': 1.1.3
+      prop-types: 15.6.2
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/@uifabric/utilities/6.29.0
     peerDependencies:
@@ -1756,139 +1806,142 @@ packages:
     dev: false
     resolution:
       integrity: sha512-RZyGrkl9gWvp9n0/+4j6yif9GdqP0WI5izjhMtWG7b+pNyJIVasP8fjtFZrjQj6WHaYlOMfSgnjbi1mjkZA8hg==
-  /@webassemblyjs/ast/1.7.11:
+  /@webassemblyjs/ast/1.8.3:
     dependencies:
-      '@webassemblyjs/helper-module-context': 1.7.11
-      '@webassemblyjs/helper-wasm-bytecode': 1.7.11
-      '@webassemblyjs/wast-parser': 1.7.11
+      '@webassemblyjs/helper-module-context': 1.8.3
+      '@webassemblyjs/helper-wasm-bytecode': 1.8.3
+      '@webassemblyjs/wast-parser': 1.8.3
     dev: false
     resolution:
-      integrity: sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==
-  /@webassemblyjs/floating-point-hex-parser/1.7.11:
+      integrity: sha512-xy3m06+Iu4D32+6soz6zLnwznigXJRuFNTovBX2M4GqVqLb0dnyWLbPnpcXvUSdEN+9DVyDeaq2jyH1eIL2LZQ==
+  /@webassemblyjs/floating-point-hex-parser/1.8.3:
     dev: false
     resolution:
-      integrity: sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==
-  /@webassemblyjs/helper-api-error/1.7.11:
+      integrity: sha512-vq1TISG4sts4f0lDwMUM0f3kpe0on+G3YyV5P0IySHFeaLKRYZ++n2fCFfG4TcCMYkqFeTUYFxm75L3ddlk2xA==
+  /@webassemblyjs/helper-api-error/1.8.3:
     dev: false
     resolution:
-      integrity: sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==
-  /@webassemblyjs/helper-buffer/1.7.11:
+      integrity: sha512-BmWEynI4FnZbjk8CaYZXwcv9a6gIiu+rllRRouQUo73hglanXD3AGFJE7Q4JZCoVE0p5/jeX6kf5eKa3D4JxwQ==
+  /@webassemblyjs/helper-buffer/1.8.3:
     dev: false
     resolution:
-      integrity: sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==
-  /@webassemblyjs/helper-code-frame/1.7.11:
+      integrity: sha512-iVIMhWnNHoFB94+/2l7LpswfCsXeMRnWfExKtqsZ/E2NxZyUx9nTeKK/MEMKTQNEpyfznIUX06OchBHQ+VKi/Q==
+  /@webassemblyjs/helper-code-frame/1.8.3:
     dependencies:
-      '@webassemblyjs/wast-printer': 1.7.11
+      '@webassemblyjs/wast-printer': 1.8.3
     dev: false
     resolution:
-      integrity: sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==
-  /@webassemblyjs/helper-fsm/1.7.11:
+      integrity: sha512-K1UxoJML7GKr1QXR+BG7eXqQkvu+eEeTjlSl5wUFQ6W6vaOc5OwSxTcb3oE9x/3+w4NHhrIKD4JXXCZmLdL2cg==
+  /@webassemblyjs/helper-fsm/1.8.3:
     dev: false
     resolution:
-      integrity: sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==
-  /@webassemblyjs/helper-module-context/1.7.11:
-    dev: false
-    resolution:
-      integrity: sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==
-  /@webassemblyjs/helper-wasm-bytecode/1.7.11:
-    dev: false
-    resolution:
-      integrity: sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==
-  /@webassemblyjs/helper-wasm-section/1.7.11:
+      integrity: sha512-387zipfrGyO77/qm7/SDUiZBjQ5KGk4qkrVIyuoubmRNIiqn3g+6ijY8BhnlGqsCCQX5bYKOnttJobT5xoyviA==
+  /@webassemblyjs/helper-module-context/1.8.3:
     dependencies:
-      '@webassemblyjs/ast': 1.7.11
-      '@webassemblyjs/helper-buffer': 1.7.11
-      '@webassemblyjs/helper-wasm-bytecode': 1.7.11
-      '@webassemblyjs/wasm-gen': 1.7.11
+      '@webassemblyjs/ast': 1.8.3
+      mamacro: 0.0.3
     dev: false
     resolution:
-      integrity: sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==
-  /@webassemblyjs/ieee754/1.7.11:
+      integrity: sha512-lPLFdQfaRssfnGEJit5Sk785kbBPPPK4ZS6rR5W/8hlUO/5v3F+rN8XuUcMj/Ny9iZiyKhhuinWGTUuYL4VKeQ==
+  /@webassemblyjs/helper-wasm-bytecode/1.8.3:
+    dev: false
+    resolution:
+      integrity: sha512-R1nJW7bjyJLjsJQR5t3K/9LJ0QWuZezl8fGa49DZq4IVaejgvkbNlKEQxLYTC579zgT4IIIVHb5JA59uBPHXyw==
+  /@webassemblyjs/helper-wasm-section/1.8.3:
+    dependencies:
+      '@webassemblyjs/ast': 1.8.3
+      '@webassemblyjs/helper-buffer': 1.8.3
+      '@webassemblyjs/helper-wasm-bytecode': 1.8.3
+      '@webassemblyjs/wasm-gen': 1.8.3
+    dev: false
+    resolution:
+      integrity: sha512-P6F7D61SJY73Yz+fs49Q3+OzlYAZP86OfSpaSY448KzUy65NdfzDmo2NPVte+Rw4562MxEAacvq/mnDuvRWOcg==
+  /@webassemblyjs/ieee754/1.8.3:
     dependencies:
       '@xtuc/ieee754': 1.2.0
     dev: false
     resolution:
-      integrity: sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==
-  /@webassemblyjs/leb128/1.7.11:
+      integrity: sha512-UD4HuLU99hjIvWz1pD68b52qsepWQlYCxDYVFJQfHh3BHyeAyAlBJ+QzLR1nnS5J6hAzjki3I3AoJeobNNSZlg==
+  /@webassemblyjs/leb128/1.8.3:
     dependencies:
-      '@xtuc/long': 4.2.1
+      '@xtuc/long': 4.2.2
     dev: false
     resolution:
-      integrity: sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==
-  /@webassemblyjs/utf8/1.7.11:
+      integrity: sha512-XXd3s1BmkC1gpGABuCRLqCGOD6D2L+Ma2BpwpjrQEHeQATKWAQtxAyU9Z14/z8Ryx6IG+L4/NDkIGHrccEhRUg==
+  /@webassemblyjs/utf8/1.8.3:
     dev: false
     resolution:
-      integrity: sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==
-  /@webassemblyjs/wasm-edit/1.7.11:
+      integrity: sha512-Wv/WH9Zo5h5ZMyfCNpUrjFsLZ3X1amdfEuwdb7MLdG3cPAjRS6yc6ElULlpjLiiBTuzvmLhr3ENsuGyJ3wyCgg==
+  /@webassemblyjs/wasm-edit/1.8.3:
     dependencies:
-      '@webassemblyjs/ast': 1.7.11
-      '@webassemblyjs/helper-buffer': 1.7.11
-      '@webassemblyjs/helper-wasm-bytecode': 1.7.11
-      '@webassemblyjs/helper-wasm-section': 1.7.11
-      '@webassemblyjs/wasm-gen': 1.7.11
-      '@webassemblyjs/wasm-opt': 1.7.11
-      '@webassemblyjs/wasm-parser': 1.7.11
-      '@webassemblyjs/wast-printer': 1.7.11
+      '@webassemblyjs/ast': 1.8.3
+      '@webassemblyjs/helper-buffer': 1.8.3
+      '@webassemblyjs/helper-wasm-bytecode': 1.8.3
+      '@webassemblyjs/helper-wasm-section': 1.8.3
+      '@webassemblyjs/wasm-gen': 1.8.3
+      '@webassemblyjs/wasm-opt': 1.8.3
+      '@webassemblyjs/wasm-parser': 1.8.3
+      '@webassemblyjs/wast-printer': 1.8.3
     dev: false
     resolution:
-      integrity: sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==
-  /@webassemblyjs/wasm-gen/1.7.11:
+      integrity: sha512-nB19eUx3Yhi1Vvv3yev5r+bqQixZprMtaoCs1brg9Efyl8Hto3tGaUoZ0Yb4Umn/gQCyoEGFfUxPLp1/8+Jvnw==
+  /@webassemblyjs/wasm-gen/1.8.3:
     dependencies:
-      '@webassemblyjs/ast': 1.7.11
-      '@webassemblyjs/helper-wasm-bytecode': 1.7.11
-      '@webassemblyjs/ieee754': 1.7.11
-      '@webassemblyjs/leb128': 1.7.11
-      '@webassemblyjs/utf8': 1.7.11
+      '@webassemblyjs/ast': 1.8.3
+      '@webassemblyjs/helper-wasm-bytecode': 1.8.3
+      '@webassemblyjs/ieee754': 1.8.3
+      '@webassemblyjs/leb128': 1.8.3
+      '@webassemblyjs/utf8': 1.8.3
     dev: false
     resolution:
-      integrity: sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==
-  /@webassemblyjs/wasm-opt/1.7.11:
+      integrity: sha512-sDNmu2nLBJZ/huSzlJvd9IK8B1EjCsOl7VeMV9VJPmxKYgTJ47lbkSP+KAXMgZWGcArxmcrznqm7FrAPQ7vVGg==
+  /@webassemblyjs/wasm-opt/1.8.3:
     dependencies:
-      '@webassemblyjs/ast': 1.7.11
-      '@webassemblyjs/helper-buffer': 1.7.11
-      '@webassemblyjs/wasm-gen': 1.7.11
-      '@webassemblyjs/wasm-parser': 1.7.11
+      '@webassemblyjs/ast': 1.8.3
+      '@webassemblyjs/helper-buffer': 1.8.3
+      '@webassemblyjs/wasm-gen': 1.8.3
+      '@webassemblyjs/wasm-parser': 1.8.3
     dev: false
     resolution:
-      integrity: sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==
-  /@webassemblyjs/wasm-parser/1.7.11:
+      integrity: sha512-j8lmQVFR+FR4/645VNgV4R/Jz8i50eaPAj93GZyd3EIJondVshE/D9pivpSDIXyaZt+IkCodlzOoZUE4LnQbeA==
+  /@webassemblyjs/wasm-parser/1.8.3:
     dependencies:
-      '@webassemblyjs/ast': 1.7.11
-      '@webassemblyjs/helper-api-error': 1.7.11
-      '@webassemblyjs/helper-wasm-bytecode': 1.7.11
-      '@webassemblyjs/ieee754': 1.7.11
-      '@webassemblyjs/leb128': 1.7.11
-      '@webassemblyjs/utf8': 1.7.11
+      '@webassemblyjs/ast': 1.8.3
+      '@webassemblyjs/helper-api-error': 1.8.3
+      '@webassemblyjs/helper-wasm-bytecode': 1.8.3
+      '@webassemblyjs/ieee754': 1.8.3
+      '@webassemblyjs/leb128': 1.8.3
+      '@webassemblyjs/utf8': 1.8.3
     dev: false
     resolution:
-      integrity: sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==
-  /@webassemblyjs/wast-parser/1.7.11:
+      integrity: sha512-NBI3SNNtRoy4T/KBsRZCAWUzE9lI94RH2nneLwa1KKIrt/2zzcTavWg6oY05ArCbb/PZDk3OUi63CD1RYtN65w==
+  /@webassemblyjs/wast-parser/1.8.3:
     dependencies:
-      '@webassemblyjs/ast': 1.7.11
-      '@webassemblyjs/floating-point-hex-parser': 1.7.11
-      '@webassemblyjs/helper-api-error': 1.7.11
-      '@webassemblyjs/helper-code-frame': 1.7.11
-      '@webassemblyjs/helper-fsm': 1.7.11
-      '@xtuc/long': 4.2.1
+      '@webassemblyjs/ast': 1.8.3
+      '@webassemblyjs/floating-point-hex-parser': 1.8.3
+      '@webassemblyjs/helper-api-error': 1.8.3
+      '@webassemblyjs/helper-code-frame': 1.8.3
+      '@webassemblyjs/helper-fsm': 1.8.3
+      '@xtuc/long': 4.2.2
     dev: false
     resolution:
-      integrity: sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==
-  /@webassemblyjs/wast-printer/1.7.11:
+      integrity: sha512-gZPst4CNcmGtKC1eYQmgCx6gwQvxk4h/nPjfPBbRoD+Raw3Hs+BS3yhrfgyRKtlYP+BJ8LcY9iFODEQofl2qbg==
+  /@webassemblyjs/wast-printer/1.8.3:
     dependencies:
-      '@webassemblyjs/ast': 1.7.11
-      '@webassemblyjs/wast-parser': 1.7.11
-      '@xtuc/long': 4.2.1
+      '@webassemblyjs/ast': 1.8.3
+      '@webassemblyjs/wast-parser': 1.8.3
+      '@xtuc/long': 4.2.2
     dev: false
     resolution:
-      integrity: sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==
+      integrity: sha512-DTA6kpXuHK4PHu16yAD9QVuT1WZQRT7079oIFFmFSjqjLWGXS909I/7kiLTn931mcj7wGsaUNungjwNQ2lGQ3Q==
   /@xtuc/ieee754/1.2.0:
     dev: false
     resolution:
       integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==
-  /@xtuc/long/4.2.1:
+  /@xtuc/long/4.2.2:
     dev: false
     resolution:
-      integrity: sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
+      integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
   /JSONStream/1.3.5:
     dependencies:
       jsonparse: 1.3.1
@@ -1910,9 +1963,9 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-63d99gEXI6OxTopywIBcjoZ0a9I=
-  /acorn-dynamic-import/4.0.0/acorn@6.0.7:
+  /acorn-dynamic-import/4.0.0/acorn@6.1.0:
     dependencies:
-      acorn: 6.0.7
+      acorn: 6.1.0
     dev: false
     id: registry.npmjs.org/acorn-dynamic-import/4.0.0
     peerDependencies:
@@ -1946,6 +1999,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-HNJNgE60C9eOTgn974Tlp3dpLZdUr+SoxxDwPaY9J/kDNOLQTkaDgwBUXAF4SSsrAwD9RpdxuHK/EbuF+W9Ahw==
+  /acorn/6.1.0:
+    dev: false
+    engines:
+      node: '>=0.4.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==
   /address/1.0.3:
     dev: false
     engines:
@@ -1968,24 +2028,24 @@ packages:
       node: '>= 4.0.0'
     resolution:
       integrity: sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==
-  /ajv-errors/1.0.1/ajv@6.8.1:
+  /ajv-errors/1.0.1/ajv@6.9.1:
     dependencies:
-      ajv: 6.8.1
+      ajv: 6.9.1
     dev: false
     id: registry.npmjs.org/ajv-errors/1.0.1
     peerDependencies:
       ajv: '>=5.0.0'
     resolution:
       integrity: sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
-  /ajv-keywords/3.3.0/ajv@6.8.1:
+  /ajv-keywords/3.4.0/ajv@6.9.1:
     dependencies:
-      ajv: 6.8.1
+      ajv: 6.9.1
     dev: false
-    id: registry.npmjs.org/ajv-keywords/3.3.0
+    id: registry.npmjs.org/ajv-keywords/3.4.0
     peerDependencies:
-      ajv: ^6.0.0
+      ajv: ^6.9.1
     resolution:
-      integrity: sha512-CMzN9S62ZOO4sA/mJZIO4S++ZM7KFWzH3PPWkveLhy4OZ9i1/VatgwWMD46w/XbGCBy7Ye0gCk+Za6mmyfKK7g==
+      integrity: sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
   /ajv/6.8.1:
     dependencies:
       fast-deep-equal: 2.0.1
@@ -1995,6 +2055,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==
+  /ajv/6.9.1:
+    dependencies:
+      fast-deep-equal: 2.0.1
+      fast-json-stable-stringify: 2.0.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.2.2
+    dev: false
+    resolution:
+      integrity: sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==
   /alphanum-sort/1.0.2:
     dev: false
     resolution:
@@ -2749,7 +2818,7 @@ packages:
   /browserify-rsa/4.0.1:
     dependencies:
       bn.js: 4.11.8
-      randombytes: 2.0.6
+      randombytes: 2.1.0
     dev: false
     resolution:
       integrity: sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
@@ -2761,7 +2830,7 @@ packages:
       create-hmac: 1.1.7
       elliptic: 6.4.1
       inherits: 2.0.3
-      parse-asn1: 5.1.3
+      parse-asn1: 5.1.4
     dev: false
     resolution:
       integrity: sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=
@@ -3064,7 +3133,7 @@ packages:
       fsevents: 1.2.7
     resolution:
       integrity: sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=
-  /chokidar/2.0.4:
+  /chokidar/2.1.2:
     dependencies:
       anymatch: 2.0.0
       async-each: 1.0.1
@@ -3073,8 +3142,7 @@ packages:
       inherits: 2.0.3
       is-binary-path: 1.0.1
       is-glob: 4.0.0
-      lodash.debounce: 4.0.8
-      normalize-path: 2.1.1
+      normalize-path: 3.0.0
       path-is-absolute: 1.0.1
       readdirp: 2.2.1
       upath: 1.1.0
@@ -3082,7 +3150,7 @@ packages:
     optionalDependencies:
       fsevents: 1.2.7
     resolution:
-      integrity: sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==
+      integrity: sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==
   /chownr/1.1.1:
     dev: false
     resolution:
@@ -3533,7 +3601,7 @@ packages:
       inherits: 2.0.3
       pbkdf2: 3.0.17
       public-encrypt: 4.0.3
-      randombytes: 2.0.6
+      randombytes: 2.1.0
       randomfill: 1.0.4
     dev: false
     resolution:
@@ -4011,7 +4079,7 @@ packages:
     dependencies:
       bn.js: 4.11.8
       miller-rabin: 4.0.1
-      randombytes: 2.0.6
+      randombytes: 2.1.0
     dev: false
     resolution:
       integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
@@ -6888,10 +6956,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=
-  /lodash.debounce/4.0.8:
-    dev: false
-    resolution:
-      integrity: sha1-gteb/zCmfEAF/9XiUVMArZyk168=
   /lodash.defaults/4.2.0:
     dev: false
     resolution:
@@ -7062,6 +7126,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
+  /mamacro/0.0.3:
+    dev: false
+    resolution:
+      integrity: sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
   /map-age-cleaner/0.1.3:
     dependencies:
       p-defer: 1.0.0
@@ -7561,6 +7629,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
+  /normalize-path/3.0.0:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
   /normalize-range/0.1.2:
     dev: false
     engines:
@@ -7760,10 +7834,18 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-FbDUIfiy+X9+rYg4r2FWWem2Y9bdiqYDHv+qRY9kW5FYA30mb4VjlByLnJZnm4erKm0i/RCLUWJ5+TP88PgdeA==
-  /office-ui-fabric-react/6.133.0/react-dom@16.7.0:
+  /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0
-      react-dom: 16.7.0
+      '@microsoft/load-themed-styles': 1.8.56
+      '@uifabric/icons': 6.3.0
+      '@uifabric/merge-styles': 6.15.2
+      '@uifabric/set-version': 1.1.3
+      '@uifabric/styling': 6.41.0
+      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0
+      prop-types: 15.6.2
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/office-ui-fabric-react/6.133.0
     peerDependencies:
@@ -8034,7 +8116,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=
-  /parse-asn1/5.1.3:
+  /parse-asn1/5.1.4:
     dependencies:
       asn1.js: 4.10.1
       browserify-aes: 1.2.0
@@ -8044,7 +8126,7 @@ packages:
       safe-buffer: 5.1.2
     dev: false
     resolution:
-      integrity: sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==
+      integrity: sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==
   /parse-glob/3.0.4:
     dependencies:
       glob-base: 0.3.0
@@ -8589,8 +8671,8 @@ packages:
       bn.js: 4.11.8
       browserify-rsa: 4.0.1
       create-hash: 1.2.0
-      parse-asn1: 5.1.3
-      randombytes: 2.0.6
+      parse-asn1: 5.1.4
+      randombytes: 2.1.0
       safe-buffer: 5.1.2
     dev: false
     resolution:
@@ -8702,15 +8784,15 @@ packages:
       node: '>= 0.10.0'
     resolution:
       integrity: sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==
-  /randombytes/2.0.6:
+  /randombytes/2.1.0:
     dependencies:
       safe-buffer: 5.1.2
     dev: false
     resolution:
-      integrity: sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==
+      integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   /randomfill/1.0.4:
     dependencies:
-      randombytes: 2.0.6
+      randombytes: 2.1.0
       safe-buffer: 5.1.2
     dev: false
     resolution:
@@ -8782,6 +8864,7 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.6.2
+      react: 16.7.0
       scheduler: 0.12.0
     dev: false
     id: registry.npmjs.org/react-dom/16.7.0
@@ -9248,20 +9331,11 @@ packages:
     dev: false
     resolution:
       integrity: sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
-  /schema-utils/0.4.7:
-    dependencies:
-      ajv: 6.8.1
-      ajv-keywords: /ajv-keywords/3.3.0/ajv@6.8.1
-    dev: false
-    engines:
-      node: '>= 4'
-    resolution:
-      integrity: sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
   /schema-utils/1.0.0:
     dependencies:
-      ajv: 6.8.1
-      ajv-errors: /ajv-errors/1.0.1/ajv@6.8.1
-      ajv-keywords: /ajv-keywords/3.3.0/ajv@6.8.1
+      ajv: 6.9.1
+      ajv-errors: /ajv-errors/1.0.1/ajv@6.9.1
+      ajv-keywords: /ajv-keywords/3.4.0/ajv@6.9.1
     dev: false
     engines:
       node: '>= 4'
@@ -10225,6 +10299,27 @@ packages:
       jest: '>=22 <24'
     resolution:
       integrity: sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==
+  /ts-jest/23.10.5/jest@23.6.0:
+    dependencies:
+      bs-logger: 0.2.6
+      buffer-from: 1.1.1
+      fast-json-stable-stringify: 2.0.0
+      jest: 23.6.0
+      json5: 2.1.0
+      make-error: 1.3.5
+      mkdirp: 0.5.1
+      resolve: 1.10.0
+      semver: 5.6.0
+      yargs-parser: 10.1.0
+    dev: false
+    engines:
+      node: '>= 6'
+    hasBin: true
+    id: registry.npmjs.org/ts-jest/23.10.5
+    peerDependencies:
+      jest: '>=22 <24'
+    resolution:
+      integrity: sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==
   /ts-loader/5.3.3:
     dependencies:
       chalk: 2.4.2
@@ -10235,6 +10330,22 @@ packages:
     dev: false
     engines:
       node: '>=6.11.5'
+    peerDependencies:
+      typescript: '*'
+    resolution:
+      integrity: sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==
+  /ts-loader/5.3.3/typescript@3.3.3:
+    dependencies:
+      chalk: 2.4.2
+      enhanced-resolve: 4.1.0
+      loader-utils: 1.2.3
+      micromatch: 3.1.10
+      semver: 5.6.0
+      typescript: 3.3.3
+    dev: false
+    engines:
+      node: '>=6.11.5'
+    id: registry.npmjs.org/ts-loader/5.3.3
     peerDependencies:
       typescript: '*'
     resolution:
@@ -10278,13 +10389,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-  /typescript/3.3.1:
+  /typescript/3.3.3:
     dev: false
     engines:
       node: '>=4.2.0'
     hasBin: true
     resolution:
-      integrity: sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==
+      integrity: sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==
   /uglify-js/3.4.9:
     dependencies:
       commander: 2.17.1
@@ -10583,7 +10694,7 @@ packages:
       integrity: sha1-KAlUdsbffJDJYxOJkMClQj60uYY=
   /watchpack/1.6.0:
     dependencies:
-      chokidar: 2.0.4
+      chokidar: 2.1.2
       graceful-fs: 4.1.15
       neo-async: 2.6.0
     dev: false
@@ -10617,6 +10728,32 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-jeJveHwz/vwpJ3B8bxEL5a/rVKIpRNJDsKggfKnxuYeohNDW4Y/wB9N/XHJA093qZyS0r6mYL+/crLsIol4WKA==
+  /webpack-cli/3.2.1/webpack@4.29.5:
+    dependencies:
+      chalk: 2.4.2
+      cross-spawn: 6.0.5
+      enhanced-resolve: 4.1.0
+      findup-sync: 2.0.0
+      global-modules: 1.0.0
+      global-modules-path: 2.3.1
+      import-local: 2.0.0
+      interpret: 1.2.0
+      lightercollective: 0.1.0
+      loader-utils: 1.2.3
+      supports-color: 5.5.0
+      v8-compile-cache: 2.0.2
+      webpack: 4.29.5
+      yargs: 12.0.5
+    dev: false
+    engines:
+      node: '>=6.11.5'
+    hasBin: true
+    id: registry.npmjs.org/webpack-cli/3.2.1
+    peerDependencies:
+      webpack: 4.x.x
+    requiresBuild: true
+    resolution:
+      integrity: sha512-jeJveHwz/vwpJ3B8bxEL5a/rVKIpRNJDsKggfKnxuYeohNDW4Y/wB9N/XHJA093qZyS0r6mYL+/crLsIol4WKA==
   /webpack-merge/4.2.1:
     dependencies:
       lodash: 4.17.11
@@ -10630,16 +10767,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==
-  /webpack/4.29.1:
+  /webpack/4.29.5:
     dependencies:
-      '@webassemblyjs/ast': 1.7.11
-      '@webassemblyjs/helper-module-context': 1.7.11
-      '@webassemblyjs/wasm-edit': 1.7.11
-      '@webassemblyjs/wasm-parser': 1.7.11
-      acorn: 6.0.7
-      acorn-dynamic-import: /acorn-dynamic-import/4.0.0/acorn@6.0.7
-      ajv: 6.8.1
-      ajv-keywords: /ajv-keywords/3.3.0/ajv@6.8.1
+      '@webassemblyjs/ast': 1.8.3
+      '@webassemblyjs/helper-module-context': 1.8.3
+      '@webassemblyjs/wasm-edit': 1.8.3
+      '@webassemblyjs/wasm-parser': 1.8.3
+      acorn: 6.1.0
+      acorn-dynamic-import: /acorn-dynamic-import/4.0.0/acorn@6.1.0
+      ajv: 6.9.1
+      ajv-keywords: /ajv-keywords/3.4.0/ajv@6.9.1
       chrome-trace-event: 1.0.0
       enhanced-resolve: 4.1.0
       eslint-scope: 4.0.0
@@ -10651,7 +10788,7 @@ packages:
       mkdirp: 0.5.1
       neo-async: 2.6.0
       node-libs-browser: 2.2.0
-      schema-utils: 0.4.7
+      schema-utils: 1.0.0
       tapable: 1.1.1
       terser-webpack-plugin: 1.2.2
       watchpack: 1.6.0
@@ -10661,7 +10798,7 @@ packages:
       node: '>=6.11.5'
     hasBin: true
     resolution:
-      integrity: sha512-dY3KyQIVeg6cDPj9G5Bnjy9Pt9SoCpbNWl0RDKHstbd3MWe0dG9ri4RQRpCm43iToy3zoA1IMOpFkJ8Clnc7FQ==
+      integrity: sha512-DuWlYUT982c7XVHodrLO9quFbNpVq5FNxLrMUfYUTlgKW0+yPimynYf1kttSQpEneAL1FH3P3OLNgkyImx8qIQ==
   /websocket-driver/0.7.0:
     dependencies:
       http-parser-js: 0.5.0
@@ -10881,24 +11018,24 @@ packages:
       '@types/yargs': 12.0.1
       fs-extra: 7.0.1
       prompts: 2.0.1
-      ts-loader: 5.3.3
-      typescript: 3.3.1
-      webpack: 4.29.1
-      webpack-cli: 3.2.1
+      ts-loader: /ts-loader/5.3.3/typescript@3.3.3
+      typescript: 3.3.3
+      webpack: 4.29.5
+      webpack-cli: /webpack-cli/3.2.1/webpack@4.29.5
       yargs: 12.0.5
     dev: false
     name: '@rush-temp/create-just'
     resolution:
-      integrity: sha512-zAhGZAI3cbOWwRQ3bcPQI/67XvumsQP/7zYr0Elx68oBkRDKjCPkct6Mv9+4sFtghJebBLP1CxDicatAtC93rw==
+      integrity: sha512-1PnWy5a+9ktkfBKL3z+0CFof7CCvVaLFJN1tyFzOxwWEBe4rLogH1hEuIL2EzdQOez1bzOaRwEU8Vayd5mT1+Q==
       tarball: 'file:projects/create-just.tgz'
     version: 0.0.0
   'file:projects/example-lib.tgz':
     dependencies:
-      typescript: 3.3.1
+      typescript: 3.3.3
     dev: false
     name: '@rush-temp/example-lib'
     resolution:
-      integrity: sha512-UNV/hag8AuP0x1l5vJo8NOfjHGtOaemfzOwxGJ+I8D0FamzAxgVWBLc0FpgbhCKOrcOzabKdaEIN6UgrjZWlZg==
+      integrity: sha512-2+Cfe9ochsapDvalBC98dyIASJFhDetr6FKyZIM3j439g+1MEk1UMMNptx6Y+4aMUOAoxkbum5Q5Uaep8x0eAw==
       tarball: 'file:projects/example-lib.tgz'
     version: 0.0.0
   'file:projects/just-scripts-utils.tgz':
@@ -10906,6 +11043,7 @@ packages:
       '@types/fs-extra': 5.0.4
       '@types/glob': 7.1.1
       '@types/handlebars': 4.0.40
+      '@types/jest': 23.3.13
       '@types/jju': 1.4.0
       '@types/marked': 0.6.0
       '@types/marked-terminal': 3.1.1
@@ -10913,20 +11051,24 @@ packages:
       '@types/node': 10.12.21
       '@types/semver': 5.5.0
       '@types/tar': 4.0.0
+      '@types/yargs': 12.0.1
       chalk: 2.4.2
       fs-extra: 7.0.1
       glob: 7.1.3
       handlebars: 4.0.12
+      jest: 23.6.0
       jju: 1.4.0
       marked: 0.6.0
       marked-terminal: /marked-terminal/3.2.0/marked@0.6.0
       mock-fs: 4.8.0
       semver: 5.6.0
       tar: 4.4.8
+      ts-jest: /ts-jest/23.10.5/jest@23.6.0
+      yargs: 12.0.5
     dev: false
     name: '@rush-temp/just-scripts-utils'
     resolution:
-      integrity: sha512-ozXFDpHhjUFn4XvVn154k+25DK9uGuJGI99vdulBVw/qFnqCqvHn/kxejaZPLzYODHxFO1PC/NAhRbiwRyRI3g==
+      integrity: sha512-//P/9UIZoMZ/jXrHOzliDpUC1b+u8lFvySOeWmmt5MW1EpDY9ODbC0BkVeBlIWtNafrElVuF38sudAbKpm3PvA==
       tarball: 'file:projects/just-scripts-utils.tgz'
     version: 0.0.0
   'file:projects/just-scripts.tgz':
@@ -10941,18 +11083,20 @@ packages:
       chalk: 2.4.2
       fs-extra: 7.0.1
       glob: 7.1.3
+      jest: 23.6.0
+      jest-cli: 23.6.0
       npm-registry-fetch: 3.9.0
       prompts: 2.0.1
       run-parallel-limit: 1.0.5
-      ts-loader: 5.3.3
-      typescript: 3.3.1
-      webpack: 4.29.1
+      ts-loader: /ts-loader/5.3.3/typescript@3.3.3
+      typescript: 3.3.3
+      webpack: 4.29.5
       webpack-cli: 3.2.1
       webpack-merge: 4.2.1
     dev: false
     name: '@rush-temp/just-scripts'
     resolution:
-      integrity: sha512-hcg+Qw/l4APA47kKbZTqrrmmkuusmBlxZQCMtP3tfYo6/EPwQEORg8EAngWqYBCvWWB/3jZ7SbAudLXc9KUxuw==
+      integrity: sha512-M+7k62YSlwCbvAiS0LryPIMA9jlhE25N9CHpcripbymo4dxuOh1eXDmEO+sVWKo4pkwmuDL4xSXVb4CWt9EinQ==
       tarball: 'file:projects/just-scripts.tgz'
     version: 0.0.0
   'file:projects/just-stack-monorepo.tgz':
@@ -10965,7 +11109,7 @@ packages:
     dev: false
     name: '@rush-temp/just-stack-monorepo'
     resolution:
-      integrity: sha512-rH7WWrx57Z9xRulDYMpMwJ0qKhvFitBy8BVmofl2gsNFMf9UeXelXbsRzLqWSVBioYPU2Y+y29AuQcc0H4DY4g==
+      integrity: sha512-uA3SznVlyblvLzdHQDt5hcb0iBd/GYQmSMXcINfIWPlTvbIrhY17nHfBNumYwzY/XC/7NUppz8IGmL3NrM+KRg==
       tarball: 'file:projects/just-stack-monorepo.tgz'
     version: 0.0.0
   'file:projects/just-stack-single-lib.tgz':
@@ -10978,7 +11122,7 @@ packages:
     dev: false
     name: '@rush-temp/just-stack-single-lib'
     resolution:
-      integrity: sha512-v441k2MpNnIIjrl73gc6MyQmp8iVTy6E8lTd7NXUnCs8HuwsEqmG/gE9rMzTtYXZ18xeNbxlL2u88oKnvvJxIA==
+      integrity: sha512-o52aWVhjnvZ7DPHLeTSktxlAse3CzyX0Wf4bX5kRDR7ctqxNUkiN5O3pQ6P1aGyZmh3s0/UVdL2g+xYqYqKv7Q==
       tarball: 'file:projects/just-stack-single-lib.tgz'
     version: 0.0.0
   'file:projects/just-stack-uifabric.tgz':
@@ -10991,26 +11135,26 @@ packages:
     dev: false
     name: '@rush-temp/just-stack-uifabric'
     resolution:
-      integrity: sha512-X0f3cRWanbMIbKJ/XZsP6FtFzrw5ynBNSZe0GgeSwGdej2JXkt8AKO2wwz/uteRZoJfzVR2akAhUPE0ShgxwyQ==
+      integrity: sha512-QnkhtPFAKaAHXC52n8ly65epIuvC/rslRdm6uQFv/dtV07tqt4l7TmaU3B8HP/iN9jvAdJ7fFZc5OcXGnJg2qw==
       tarball: 'file:projects/just-stack-uifabric.tgz'
     version: 0.0.0
   'file:projects/just-task-docs.tgz':
     dependencies:
       '@babel/core': 7.2.2
-      '@babel/plugin-proposal-class-properties': 7.3.0
-      '@babel/plugin-proposal-object-rest-spread': 7.3.2
+      '@babel/plugin-proposal-class-properties': /@babel/plugin-proposal-class-properties/7.3.0/@babel!core@7.2.2
+      '@babel/plugin-proposal-object-rest-spread': /@babel/plugin-proposal-object-rest-spread/7.3.2/@babel!core@7.2.2
       '@babel/polyfill': 7.2.5
-      '@babel/preset-env': 7.3.1
-      '@babel/preset-react': 7.0.0
-      '@babel/register': 7.0.0
+      '@babel/preset-env': /@babel/preset-env/7.3.1/@babel!core@7.2.2
+      '@babel/preset-react': /@babel/preset-react/7.0.0/@babel!core@7.2.2
+      '@babel/register': /@babel/register/7.0.0/@babel!core@7.2.2
       '@babel/traverse': 7.2.3
       '@babel/types': 7.3.2
-      '@uifabric/experiments': /@uifabric/experiments/6.54.2/react-dom@16.7.0
+      '@uifabric/experiments': /@uifabric/experiments/6.54.2/react-dom@16.7.0+react@16.7.0
       cpx: 1.5.0
       docusaurus: 1.7.2
-      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0
+      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0
       react: 16.7.0
-      react-dom: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
     dev: false
     name: '@rush-temp/just-task-docs'
     resolution:
@@ -11037,15 +11181,15 @@ packages:
       chalk: 2.4.2
       jest: 23.6.0
       resolve: 1.10.0
-      ts-jest: 23.10.5
-      typescript: 3.3.1
+      ts-jest: /ts-jest/23.10.5/jest@23.6.0
+      typescript: 3.3.3
       undertaker: 1.2.0
       undertaker-registry: 1.0.1
       yargs: 12.0.5
     dev: false
     name: '@rush-temp/just-task'
     resolution:
-      integrity: sha512-cIS4eO8K59vQGtxtH1R9rTBrrPEDEM5GFWhYmCvYMbNtBX8ueU+ckTjSjaXYfY8hR7zspUG4hJSwWyzKF1BnsQ==
+      integrity: sha512-ftQH/SirMHc0CrcywoCtI4qFWdBNz1t/F9vJs/YLXQ/NrwfcPz8+qZa+y96qiNL4dwASiQZFtxpLak3p39zLOw==
       tarball: 'file:projects/just-task.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'
@@ -11097,6 +11241,7 @@ specifiers:
   glob: ^7.1.3
   handlebars: ^4.0.12
   jest: ^23.6.0
+  jest-cli: ^23.0.0
   jest-expect-message: ^1.0.2
   jju: ^1.4.0
   json5: ^2.1.0
@@ -11114,10 +11259,10 @@ specifiers:
   tar: ^4.4.8
   ts-jest: ^23.10.5
   ts-loader: ^5.3.3
-  typescript: ^3.2.4
+  typescript: ~3.3.3
   undertaker: ^1.2.0
   undertaker-registry: ^1.0.1
-  webpack: ^4.28.4
+  webpack: ~4.29.5
   webpack-cli: ^3.2.1
   webpack-merge: ^4.2.1
   yargs: ^12.0.5

--- a/packages/create-just/package.json
+++ b/packages/create-just/package.json
@@ -17,11 +17,11 @@
     "@types/prompts": "^1.2.0",
     "@types/yargs": "12.0.1",
     "@types/fs-extra": "^5.0.4",
-    "typescript": "^3.2.4",
+    "typescript": "~3.3.3",
     "fs-extra": "^7.0.1",
     "prompts": "^2.0.1",
     "yargs": "^12.0.5",
-    "webpack": "^4.28.4",
+    "webpack": "~4.29.5",
     "webpack-cli": "^3.2.1",
     "ts-loader": "^5.3.3",
     "just-scripts-utils": ">=0.4.0 <1.0.0"

--- a/packages/example-lib/package.json
+++ b/packages/example-lib/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "just-task": ">=0.7.6 <1.0.0",
     "just-scripts": ">=0.7.6 <1.0.0",
-    "typescript": "^3.2.4"
+    "typescript": "~3.3.3"
   }
 }

--- a/packages/just-scripts/package.json
+++ b/packages/just-scripts/package.json
@@ -18,14 +18,15 @@
     "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
     "jest": "^23.6.0",
+    "jest-cli": "^23.0.0",
     "just-scripts-utils": ">=0.4.0 <1.0.0",
     "just-task": ">=0.7.6 <1.0.0",
     "npm-registry-fetch": "^3.9.0",
     "prompts": "^2.0.1",
     "run-parallel-limit": "^1.0.5",
     "ts-loader": "^5.3.3",
-    "typescript": "^3.2.4",
-    "webpack": "^4.28.4",
+    "typescript": "~3.3.3",
+    "webpack": "~4.29.5",
     "webpack-merge": "^4.2.1"
   },
   "scripts": {

--- a/packages/just-stack-monorepo/template/.gitignore.hbs
+++ b/packages/just-stack-monorepo/template/.gitignore.hbs
@@ -16,6 +16,8 @@ coverage
 dist
 temp
 
+*.scss.ts
+
 documentation/lib/core/metadata.js
 documentation/lib/core/MetadataBlog.js
 

--- a/packages/just-stack-single-lib/template/.gitignore.hbs
+++ b/packages/just-stack-single-lib/template/.gitignore.hbs
@@ -16,6 +16,8 @@ coverage
 dist
 temp
 
+*.scss.ts
+
 documentation/lib/core/metadata.js
 documentation/lib/core/MetadataBlog.js
 

--- a/packages/just-stack-uifabric/template/.gitignore.hbs
+++ b/packages/just-stack-uifabric/template/.gitignore.hbs
@@ -16,6 +16,8 @@ coverage
 dist
 temp
 
+*.scss.ts
+
 documentation/lib/core/metadata.js
 documentation/lib/core/MetadataBlog.js
 

--- a/packages/just-task/package.json
+++ b/packages/just-task/package.json
@@ -26,9 +26,9 @@
     "@types/undertaker": "^1.2.0",
     "@types/undertaker-registry": "^1.0.1",
     "@types/yargs": "12.0.1",
+    "jest": "^23.6.0",
     "ts-jest": "^23.10.5",
-    "typescript": "^3.2.4",
-    "jest": "^23.6.0"
+    "typescript": "~3.3.3"
   },
   "keywords": [],
   "author": "Ken Chau <kchau@microsoft.com>",


### PR DESCRIPTION
Lock versions of ts and webpack to ~ rather than ^

Add generated *.scss.ts files to templates' gitignores