### PR TITLE
Template fixes

### DIFF
--- a/common/changes/just-scripts/ecraig-version_2019-02-21-02-08.json
+++ b/common/changes/just-scripts/ecraig-version_2019-02-21-02-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "addPackageTask: Remove extra files from template before running rush update",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-monorepo/ecraig-stuff_2019-02-21-01-56.json
+++ b/common/changes/just-stack-monorepo/ecraig-stuff_2019-02-21-01-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "just-stack-monorepo",
-      "comment": "Uncomment version-policies to fix validation error",
+      "comment": "Fix validation error with version-policies",
       "type": "patch"
     }
   ],

--- a/common/changes/just-stack-monorepo/ecraig-stuff_2019-02-21-01-56.json
+++ b/common/changes/just-stack-monorepo/ecraig-stuff_2019-02-21-01-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-monorepo",
+      "comment": "Uncomment version-policies to fix validation error",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-stack-monorepo",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-uifabric/ecraig-version_2019-02-21-02-03.json
+++ b/common/changes/just-stack-uifabric/ecraig-version_2019-02-21-02-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-uifabric",
+      "comment": "Fix webpack version",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-stack-uifabric",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/just-scripts/src/tasks/addPackageTask.ts
+++ b/packages/just-scripts/src/tasks/addPackageTask.ts
@@ -49,14 +49,14 @@ export async function addPackageTask() {
         name
       });
 
-      rushAddPackage(name, rootPath);
-      logger.info('Running rush update');
-      rushUpdate(rootPath);
-
       // Remove some files that aren't relevant for an individual project within a monorepo
       fse.removeSync(path.join(packagePath, '.gitignore'));
       fse.removeSync(path.join(packagePath, '.gitattributes'));
       fse.removeSync(path.join(packagePath, '.vscode'));
+
+      rushAddPackage(name, rootPath);
+      logger.info('Running rush update');
+      rushUpdate(rootPath);
 
       logger.info('All Set!');
 

--- a/packages/just-stack-monorepo/template/common/config/rush/version-policies.json
+++ b/packages/just-stack-monorepo/template/common/config/rush/version-policies.json
@@ -9,28 +9,26 @@
  * to a set of projects that are specified using the "versionPolicyName" field in rush.json.
  */
 [
-  {
-    /**
-     * (Required) Indicates the kind of version policy being defined ("lockStepVersion" or "individualVersion").
-     *
-     * The "individualVersion" mode specifies that the projects will use "individual versioning".
-     * This is the typical NPM model where each package has an independent version number
-     * and CHANGELOG.md file.  Although a single CI definition is responsible for publishing the
-     * packages, they otherwise don't have any special relationship.  The version bumping will
-     * depend on how developers answer the "rush change" questions for each package that
-     * is changed.
-     */
-    "definitionName": "individualVersion",
-
-    "policyName": "RepoPolicy",
-
-    /**
-     * (Optional) This can be used to enforce that all packages in the set must share a common
-     * major version number, e.g. because they are from the same major release branch.
-     * It can also be used to discourage people from accidentally making "MAJOR" SemVer changes
-     * inappropriately.  The minor/patch version parts will be bumped independently according
-     * to the types of changes made to each project, according to the "rush change" command.
-     */
-    "lockedMajor": 0
-  }
+  // {
+  //   /**
+  //    * (Required) Indicates the kind of version policy being defined ("lockStepVersion" or "individualVersion").
+  //    *
+  //    * The "individualVersion" mode specifies that the projects will use "individual versioning".
+  //    * This is the typical NPM model where each package has an independent version number
+  //    * and CHANGELOG.md file.  Although a single CI definition is responsible for publishing the
+  //    * packages, they otherwise don't have any special relationship.  The version bumping will
+  //    * depend on how developers answer the "rush change" questions for each package that
+  //    * is changed.
+  //    */
+  //   "definitionName": "individualVersion",
+  //   "policyName": "RepoPolicy",
+  //   /**
+  //    * (Optional) This can be used to enforce that all packages in the set must share a common
+  //    * major version number, e.g. because they are from the same major release branch.
+  //    * It can also be used to discourage people from accidentally making "MAJOR" SemVer changes
+  //    * inappropriately.  The minor/patch version parts will be bumped independently according
+  //    * to the types of changes made to each project, according to the "rush change" command.
+  //    */
+  //   "lockedMajor": 0
+  // }
 ]

--- a/packages/just-stack-monorepo/template/common/config/rush/version-policies.json
+++ b/packages/just-stack-monorepo/template/common/config/rush/version-policies.json
@@ -20,9 +20,9 @@
      * depend on how developers answer the "rush change" questions for each package that
      * is changed.
      */
-    // "definitionName": "individualVersion",
+    "definitionName": "individualVersion",
 
-    // "policyName": "RepoPolicy",
+    "policyName": "RepoPolicy",
 
     /**
      * (Optional) This can be used to enforce that all packages in the set must share a common
@@ -31,6 +31,6 @@
      * inappropriately.  The minor/patch version parts will be bumped independently according
      * to the types of changes made to each project, according to the "rush change" command.
      */
-    // "lockedMajor": 3
+    "lockedMajor": 0
   }
 ]

--- a/packages/just-stack-uifabric/template/package.json.hbs
+++ b/packages/just-stack-uifabric/template/package.json.hbs
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "^23.3.13",
-    "@types/react-dom": "^16.0.11",
+    "@types/react-dom": "~16.0.11",
     "@types/react": "~16.7.0",
     "autoprefixer": "^9.4.5",
     "css-loader": "^2.1.0",
@@ -42,7 +42,7 @@
     "typescript": "~3.2.4",
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.1.14",
-    "webpack": "~4.28.5"
+    "webpack": "~4.29.5"
   },
   "just": {
     "stack": "just-stack-uifabric"


### PR DESCRIPTION
- Apparently having the only version-policies.json entry in the monorepo template be commented out causes a validation error in rush?
- Fix webpack and types/react-dom versions in templates
- Remove extra files from template *before* running `rush update` (mainly in case the rush command fails)