### PR TITLE
Add custom reporter and shared config for tests

### DIFF
--- a/packages/just-scripts-utils/jest.config.js
+++ b/packages/just-scripts-utils/jest.config.js
@@ -1,6 +1,1 @@
-module.exports = {
-  roots: ['<rootDir>/src'],
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/?(*.)+(spec|test).ts']
-};
+module.exports = require('../../scripts/jest.config');

--- a/packages/just-stack-monorepo/jest.config.js
+++ b/packages/just-stack-monorepo/jest.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  verbose: true,
-  testEnvironment: 'node',
-  setupTestFrameworkScriptFile: 'jest-expect-message'
-};
+module.exports = require('../../scripts/jest.template.config');

--- a/packages/just-stack-single-lib/jest.config.js
+++ b/packages/just-stack-single-lib/jest.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  verbose: true,
-  testEnvironment: 'node',
-  setupTestFrameworkScriptFile: 'jest-expect-message'
-};
+module.exports = require('../../scripts/jest.template.config');

--- a/packages/just-stack-uifabric/jest.config.js
+++ b/packages/just-stack-uifabric/jest.config.js
@@ -1,5 +1,1 @@
-module.exports = {
-  verbose: true,
-  testEnvironment: 'node',
-  setupTestFrameworkScriptFile: 'jest-expect-message'
-};
+module.exports = require('../../scripts/jest.template.config');

--- a/packages/just-task-logger/jest.config.js
+++ b/packages/just-task-logger/jest.config.js
@@ -1,6 +1,1 @@
-module.exports = {
-  roots: ['<rootDir>/src'],
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/?(*.)+(spec|test).ts']
-};
+module.exports = require('../../scripts/jest.config');

--- a/packages/just-task/jest.config.js
+++ b/packages/just-task/jest.config.js
@@ -1,6 +1,1 @@
-module.exports = {
-  roots: ['<rootDir>/src'],
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/?(*.)+(spec|test).(j|t)s?(x)']
-};
+module.exports = require('../../scripts/jest.config');

--- a/scripts/jest-reporter.js
+++ b/scripts/jest-reporter.js
@@ -1,0 +1,13 @@
+const DefaultReporter = require('jest-cli/build/reporters/default_reporter').default;
+
+/**
+ * The purpose of this custom reporter is to prevent Jest from logging to stderr
+ * when there are no errors.
+ */
+class JestReporter extends DefaultReporter {
+  log(message) {
+    process.stdout.write(message + '\n');
+  }
+}
+
+module.exports = JestReporter;

--- a/scripts/jest.config.js
+++ b/scripts/jest.config.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+/** Jest config for packages within the just monorepo */
+module.exports = {
+  roots: ['<rootDir>/src'],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).[jt]s'],
+  reporters: [path.resolve(__dirname, './jest-reporter.js')],
+  verbose: true
+};

--- a/scripts/jest.template.config.js
+++ b/scripts/jest.template.config.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+/** Jest config for template packages within the just monorepo */
+module.exports = {
+  testEnvironment: 'node',
+  reporters: [path.resolve(__dirname, './jest-reporter.js')],
+  setupTestFrameworkScriptFile: 'jest-expect-message',
+  verbose: true
+};

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -9,6 +9,7 @@
   "keywords": [],
   "author": "",
   "dependencies": {
-    "cpx": "^1.5.0"
+    "cpx": "^1.5.0",
+    "jest-cli": "^23.0.0"
   }
 }


### PR DESCRIPTION
Add a custom jest reporter under `/scripts` which prevents normal output from going to stderr (related to #28).

Add shared `jest.config.js` (for most projects) and `jest.template.config.js` (for building template projects) under `/scripts` to make all projects use the reporter and to de-duplicate the config.

We'll eventually want to add a similar custom reporter for the projects generated from templates, but that needs more discussion to determine the right approach.