### PR TITLE
Fix return types of task factories

### DIFF
--- a/common/changes/just-scripts/ecraig-task-types_2019-02-22-02-23.json
+++ b/common/changes/just-scripts/ecraig-task-types_2019-02-22-02-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "Fix return types of task factories",
+      "type": "minor"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/just-scripts/src/task-presets/lib.ts
+++ b/packages/just-scripts/src/task-presets/lib.ts
@@ -17,5 +17,5 @@ export function lib() {
   task('start', series('clean', 'ts:watch'));
   task('start-test', series('clean', 'jest:watch'));
 
-  task('upgrade-stack', upgradeStackTask);
+  task('upgrade-stack', upgradeStackTask());
 }

--- a/packages/just-scripts/src/task-presets/webapp.ts
+++ b/packages/just-scripts/src/task-presets/webapp.ts
@@ -1,5 +1,12 @@
 import { task, series, parallel } from 'just-task';
-import { cleanTask, tscTask, jestTask, webpackTask, upgradeStackTask, webpackDevServerTask } from '../tasks';
+import {
+  cleanTask,
+  tscTask,
+  jestTask,
+  webpackTask,
+  upgradeStackTask,
+  webpackDevServerTask
+} from '../tasks';
 
 export function webapp() {
   task('clean', cleanTask());
@@ -20,5 +27,5 @@ export function webapp() {
   task('start', series('clean', 'webpack:watch'));
   task('start-test', series('clean', 'jest:watch'));
 
-  task('upgrade-stack', upgradeStackTask);
+  task('upgrade-stack', upgradeStackTask());
 }

--- a/packages/just-scripts/src/tasks/addPackageTask.ts
+++ b/packages/just-scripts/src/tasks/addPackageTask.ts
@@ -11,22 +11,28 @@ import prompts from 'prompts';
 import fse from 'fs-extra';
 import { argv } from 'just-task';
 import { findInstalledStacks } from '../monorepo/findInstalledStacks';
+import { TaskFunction } from 'just-task/lib/task';
 
-export async function addPackageTask() {
-  const args = argv();
-  const rootPath = findMonoRepoRootPath();
+export function addPackageTask(): TaskFunction {
+  return async function addPackage() {
+    const args = argv();
+    const rootPath = findMonoRepoRootPath();
 
-  const name =
-    args.name ||
-    (await prompts({
-      type: 'text',
-      name: 'name',
-      message: 'What is the name of the package?'
-    })).name;
+    const name =
+      args.name ||
+      (await prompts({
+        type: 'text',
+        name: 'name',
+        message: 'What is the name of the package?'
+      })).name;
 
-  logger.info(`Creating a package called: ${name}`);
+    logger.info(`Creating a package called: ${name}`);
 
-  if (rootPath) {
+    if (!rootPath) {
+      logger.warn('Cannot determine the root path to the mono repo');
+      return;
+    }
+
     // TODO: do validation that the path is indeed a monorepo
 
     const installedStacks = findInstalledStacks(rootPath);
@@ -65,7 +71,5 @@ export async function addPackageTask() {
         logger.info('\n' + prettyPrintMarkdown(fse.readFileSync(readmeFile).toString()));
       }
     }
-  } else {
-    logger.warn('Cannot determine the root path to the mono repo');
-  }
+  };
 }

--- a/packages/just-scripts/src/tasks/apiExtractorTask.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTask.ts
@@ -1,6 +1,7 @@
 import { logger } from 'just-task';
+import { TaskFunction } from 'just-task/lib/task';
 
-export function apiExtractorVerifyTask(config: any, options: any) {
+export function apiExtractorVerifyTask(config: any, options: any): TaskFunction {
   return function apiExtractorVerify() {
     if (!apiExtractorWrapper(config, options)) {
       throw 'The public API file is out of date. Please run "npm run update-api" and commit the updated API file.';
@@ -8,7 +9,7 @@ export function apiExtractorVerifyTask(config: any, options: any) {
   };
 }
 
-export function apiExtractorUpdateTask(config: any, options: any) {
+export function apiExtractorUpdateTask(config: any, options: any): TaskFunction {
   return function apiExtractorUpdate() {
     if (!apiExtractorWrapper(config, options)) {
       logger.warn(`- Update API: API file is out of date, updating...`);
@@ -18,7 +19,9 @@ export function apiExtractorUpdateTask(config: any, options: any) {
       if (!apiExtractorWrapper(config, options)) {
         throw Error(`- Update API: failed to update API file.`);
       } else {
-        logger.info(`- Update API: successully verified API file. ` + `Please commit API file as part of your changes.`);
+        logger.info(
+          `- Update API: successully verified API file. Please commit API file as part of your changes.`
+        );
       }
     } else {
       logger.info(`- Update API: API file is already up to date, no update needed.`);

--- a/packages/just-scripts/src/tasks/cleanTask.ts
+++ b/packages/just-scripts/src/tasks/cleanTask.ts
@@ -2,8 +2,9 @@ import fse from 'fs-extra';
 import parallelLimit from 'run-parallel-limit';
 import path from 'path';
 import { logger } from 'just-task';
+import { TaskFunction } from 'just-task/lib/task';
 
-export function cleanTask(paths: string[] = [], limit: number = 5) {
+export function cleanTask(paths: string[] = [], limit: number = 5): TaskFunction {
   if (paths.length === 0) {
     paths = ['lib', 'temp', 'dist', 'coverage'];
   }

--- a/packages/just-scripts/src/tasks/copyTask.ts
+++ b/packages/just-scripts/src/tasks/copyTask.ts
@@ -3,10 +3,13 @@ import fse from 'fs-extra';
 import path from 'path';
 import parallelLimit from 'run-parallel-limit';
 import { logger } from 'just-task';
+import { TaskFunction } from 'just-task/lib/task';
 
-export function copyTask(paths: string[] = [], dest: string, limit: number = 15) {
+export function copyTask(paths: string[] = [], dest: string, limit: number = 15): TaskFunction {
   return function copy(done: (err?: Error) => void) {
-    logger.info(`Copying [${paths.map(p => path.relative(process.cwd(), p)).join(', ')}] to '${dest}'`);
+    logger.info(
+      `Copying [${paths.map(p => path.relative(process.cwd(), p)).join(', ')}] to '${dest}'`
+    );
 
     if (!fse.existsSync(dest)) {
       fse.mkdirpSync(dest);

--- a/packages/just-scripts/src/tasks/jestTask.ts
+++ b/packages/just-scripts/src/tasks/jestTask.ts
@@ -1,6 +1,7 @@
 import { resolve, logger, resolveCwd } from 'just-task';
 import { spawn, encodeArgs } from './exec';
 import { existsSync } from 'fs';
+import { TaskFunction } from 'just-task/lib/task';
 
 export interface IJestTaskOptions {
   config?: string;
@@ -12,7 +13,7 @@ export interface IJestTaskOptions {
   _?: string[];
 }
 
-export function jestTask(options: IJestTaskOptions = {}) {
+export function jestTask(options: IJestTaskOptions = {}): TaskFunction {
   const jestConfigFile = resolveCwd('./jest.config.js');
 
   return function jest() {

--- a/packages/just-scripts/src/tasks/sassTask.ts
+++ b/packages/just-scripts/src/tasks/sassTask.ts
@@ -3,9 +3,13 @@ import path from 'path';
 import fs from 'fs';
 import { resolveCwd } from 'just-task';
 import parallelLimit from 'run-parallel-limit';
+import { TaskFunction } from 'just-task/lib/task';
 
 // Because we do not statically import postcssPlugin package, we cannot enforce type of postcssPlugins
-export function sassTask(createSourceModule: (fileName: string, css: string) => string, postcssPlugins: any[] = []) {
+export function sassTask(
+  createSourceModule: (fileName: string, css: string) => string,
+  postcssPlugins: any[] = []
+): TaskFunction {
   const nodeSass = require('node-sass');
   const postcss = require('postcss');
   const autoprefixer = require('autoprefixer');
@@ -53,7 +57,10 @@ export function sassTask(createSourceModule: (fileName: string, css: string) => 
 
 function requireResolvePackageUrl(packageUrl: string) {
   const fullName = packageUrl + (packageUrl.endsWith('.scss') ? '' : '.scss');
-  return resolveCwd(fullName) || resolveCwd(path.join(path.dirname(fullName), `_${path.basename(fullName)}`));
+  return (
+    resolveCwd(fullName) ||
+    resolveCwd(path.join(path.dirname(fullName), `_${path.basename(fullName)}`))
+  );
 }
 
 function patchSassUrl(url: string, prev: string, done: any) {

--- a/packages/just-scripts/src/tasks/tscTask.ts
+++ b/packages/just-scripts/src/tasks/tscTask.ts
@@ -1,11 +1,12 @@
-import * as ts from 'typescript';
+import ts from 'typescript';
 import { resolve, logger, resolveCwd } from 'just-task';
 import { exec, encodeArgs, spawn } from './exec';
 import fs from 'fs';
+import { TaskFunction } from 'just-task/lib/task';
 
 type CompilerOptions = { [key in keyof ts.CompilerOptions]: string | boolean };
 
-export function tscTask(options: CompilerOptions) {
+export function tscTask(options: CompilerOptions): TaskFunction {
   const tsConfigFile = resolveCwd('./tsconfig.json');
   const tscCmd = resolve('typescript/lib/tsc.js');
 
@@ -41,7 +42,7 @@ export function tscTask(options: CompilerOptions) {
   };
 }
 
-export function tscWatchTask(options: CompilerOptions) {
+export function tscWatchTask(options: CompilerOptions): TaskFunction {
   const tsConfigFile = resolveCwd('./tsconfig.json');
   const tscCmd = resolve('typescript/lib/tsc.js');
 

--- a/packages/just-scripts/src/tasks/tslintTask.ts
+++ b/packages/just-scripts/src/tasks/tslintTask.ts
@@ -2,12 +2,13 @@ import { resolve, logger, resolveCwd } from 'just-task';
 import { exec, encodeArgs } from './exec';
 import path from 'path';
 import fs from 'fs';
+import { TaskFunction } from 'just-task/lib/task';
 
 export interface ITsLintTaskOptions {
   config?: string;
 }
 
-export function tslintTask(options: ITsLintTaskOptions = {}) {
+export function tslintTask(options: ITsLintTaskOptions = {}): TaskFunction {
   const projectFile = resolveCwd('./tsconfig.json');
 
   return function tslint() {
@@ -16,7 +17,14 @@ export function tslintTask(options: ITsLintTaskOptions = {}) {
     if (projectFile && tslintCmd && fs.existsSync(projectFile)) {
       logger.info(`Running tslint`);
 
-      const args = ['--project', projectFile, '-t', 'stylish', '-r', path.dirname(resolve('tslint-microsoft-contrib') || '')];
+      const args = [
+        '--project',
+        projectFile,
+        '-t',
+        'stylish',
+        '-r',
+        path.dirname(resolve('tslint-microsoft-contrib') || '')
+      ];
 
       const cmd = encodeArgs([process.execPath, tslintCmd, ...args]).join(' ');
       logger.info(cmd);

--- a/packages/just-scripts/src/tasks/upgradeRepoTask.ts
+++ b/packages/just-scripts/src/tasks/upgradeRepoTask.ts
@@ -10,51 +10,54 @@ import {
 } from 'just-scripts-utils';
 import { getOutdatedStacks } from '../monorepo/getOutdatedStacks';
 import { argv } from 'just-task';
+import { TaskFunction } from 'just-task/lib/task';
 
-export async function upgradeRepoTask() {
-  const rootPath = findMonoRepoRootPath();
-  if (!rootPath) {
-    logger.error('Could not find monorepo root path. Not upgrading anything.');
-    return;
-  }
-
-  const scriptsPath = path.join(rootPath, 'scripts');
-  const scriptsPackageJsonPath = path.join(scriptsPath, 'package.json');
-  const scriptsPackageJson = readPackageJson(scriptsPath);
-  if (!scriptsPackageJson) {
-    logger.error(`Could not read ${scriptsPackageJsonPath}. Not upgrading anything.`);
-    return;
-  }
-
-  const rushConfig = readRushJson(rootPath);
-  if (!rushConfig) {
-    logger.error(`Could not read rush.json under ${rootPath}. Not upgrading anything.`);
-    return;
-  }
-
-  process.chdir(rootPath);
-  const outdatedStacks = await getOutdatedStacks(rootPath);
-  const latest = argv().latest;
-
-  outdatedStacks.forEach(stack => {
-    const { dependencies = {}, devDependencies = {} } = scriptsPackageJson;
-    if (devDependencies[stack.name]) {
-      devDependencies[stack.name] = latest ? `^${stack.latest}` : `^${stack.wanted}`;
-    } else if (dependencies[stack.name]) {
-      dependencies[stack.name] = latest ? `^${stack.latest}` : `^${stack.wanted}`;
+export function upgradeRepoTask(): TaskFunction {
+  return async function upgradeRepo() {
+    const rootPath = findMonoRepoRootPath();
+    if (!rootPath) {
+      logger.error('Could not find monorepo root path. Not upgrading anything.');
+      return;
     }
-  });
 
-  fse.writeJsonSync(scriptsPackageJsonPath, scriptsPackageJson, { spaces: 2 });
+    const scriptsPath = path.join(rootPath, 'scripts');
+    const scriptsPackageJsonPath = path.join(scriptsPath, 'package.json');
+    const scriptsPackageJson = readPackageJson(scriptsPath);
+    if (!scriptsPackageJson) {
+      logger.error(`Could not read ${scriptsPackageJsonPath}. Not upgrading anything.`);
+      return;
+    }
 
-  rushUpdate(rootPath);
+    const rushConfig = readRushJson(rootPath);
+    if (!rushConfig) {
+      logger.error(`Could not read rush.json under ${rootPath}. Not upgrading anything.`);
+      return;
+    }
 
-  let promise = Promise.resolve();
-  for (const project of rushConfig.projects) {
-    const projectPath = path.join(rootPath, project.projectFolder);
-    promise = promise.then(() =>
-      upgradeStackPackageJsonFile(projectPath, path.join(scriptsPath, 'node_modules'))
-    );
-  }
-  return promise;
+    process.chdir(rootPath);
+    const outdatedStacks = await getOutdatedStacks(rootPath);
+    const latest = argv().latest;
+
+    outdatedStacks.forEach(stack => {
+      const { dependencies = {}, devDependencies = {} } = scriptsPackageJson;
+      if (devDependencies[stack.name]) {
+        devDependencies[stack.name] = latest ? `^${stack.latest}` : `^${stack.wanted}`;
+      } else if (dependencies[stack.name]) {
+        dependencies[stack.name] = latest ? `^${stack.latest}` : `^${stack.wanted}`;
+      }
+    });
+
+    fse.writeJsonSync(scriptsPackageJsonPath, scriptsPackageJson, { spaces: 2 });
+
+    rushUpdate(rootPath);
+
+    let promise = Promise.resolve();
+    for (const project of rushConfig.projects) {
+      const projectPath = path.join(rootPath, project.projectFolder);
+      promise = promise.then(() =>
+        upgradeStackPackageJsonFile(projectPath, path.join(scriptsPath, 'node_modules'))
+      );
+    }
+    return promise;
+  };
 }

--- a/packages/just-scripts/src/tasks/upgradeStackTask.ts
+++ b/packages/just-scripts/src/tasks/upgradeStackTask.ts
@@ -10,10 +10,13 @@ import {
   readPackageJson,
   IPackageJson
 } from 'just-scripts-utils';
+import { TaskFunction } from 'just-task/lib/task';
 
-export async function upgradeStackTask(): Promise<void> {
+export function upgradeStackTask(): TaskFunction {
   const { projectPath } = paths;
-  return upgradeStackPackageJsonFile(projectPath);
+  return function upgradeStack() {
+    upgradeStackPackageJsonFile(projectPath);
+  };
 }
 
 /**

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -2,6 +2,7 @@ import { logger, argv, resolve, resolveCwd } from 'just-task';
 import fs from 'fs';
 import { encodeArgs, spawn } from './exec';
 import webpackMerge from 'webpack-merge';
+import { TaskFunction } from 'just-task/lib/task';
 
 declare var __non_webpack_require__: any;
 
@@ -10,7 +11,7 @@ export interface WebpackTaskOptions {
   mode?: 'production' | 'development';
 }
 
-export function webpackTask(options?: WebpackTaskOptions) {
+export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
   const wp = require('webpack');
 
   return function webpack() {


### PR DESCRIPTION
The task factories should all return `TaskFunction`. This PR makes that explicit.

I also converted `addPackageTask`, `upgradeRepoTask`, and `upgradeStackTask` to return `TaskFunction`s. This is technically a breaking change, but I think that's okay since we're in version 0 and those functions are especially experimental.