### PR TITLE
Fix just-task not building

### DIFF
--- a/common/changes/just-task/fix-break_2019-02-24-04-00.json
+++ b/common/changes/just-task/fix-break_2019-02-24-04-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-task",
+      "comment": "Fix breaks caused by just-task resolve using the same yargs instance to check config path",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-task",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/just-task/src/resolve.ts
+++ b/packages/just-task/src/resolve.ts
@@ -1,6 +1,12 @@
 import { sync as resolveSync } from 'resolve';
 import path from 'path';
-import yargs from 'yargs';
+
+// It is important to keep this line like this:
+// 1. it cannot be an import because TS will try to do type checks which isn't available in @types/yargs
+// 2. this breaks a require.cache, which is needed because we need a new instance of yargs to check the config
+//    - this is because of the timing of when tasks are defined vs when this resolve is called the first time
+//      to figure out config path)
+const yargsFn = require('yargs/yargs');
 
 let resolvePaths: string[] = [];
 
@@ -56,7 +62,7 @@ export function resolve(moduleName: string, cwd?: string): string | null {
   if (!cwd) {
     cwd = process.cwd();
   }
-  const configArg = yargs(process.argv.slice(1).filter(a => a !== '--help')).argv.config;
+  const configArg = yargsFn(process.argv.slice(1).filter(a => a !== '--help')).argv.config;
   const configFilePath = configArg ? path.resolve(path.dirname(configArg)) : undefined;
 
   const allResolvePaths = [cwd, ...(configFilePath ? [configFilePath] : []), ...resolvePaths];


### PR DESCRIPTION
Fix breaks caused by just-task resolve using the same yargs instance to check config path