### PR TITLE
Exec error handling improvements

### DIFF
--- a/common/changes/just-scripts-utils/ecraig-exitcode_2019-03-12-19-54.json
+++ b/common/changes/just-scripts-utils/ecraig-exitcode_2019-03-12-19-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts-utils",
+      "comment": "Exec error handling improvements",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-scripts-utils",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/just-scripts-utils/src/__tests__/exec.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/exec.spec.ts
@@ -1,4 +1,6 @@
-import { encodeArgs } from '../exec';
+import { encodeArgs, exec, ExecError } from '../exec';
+import cp from 'child_process';
+import { Readable } from 'stream';
 
 describe('encodeArgs', () => {
   it('encodes things with spaces with double quotes', () => {
@@ -14,5 +16,77 @@ describe('encodeArgs', () => {
   it('leaves normal args alone', () => {
     const args = encodeArgs(['this-is-normal']);
     expect(args[0]).toBe('this-is-normal');
+  });
+});
+
+describe('exec', () => {
+  let execResult: [cp.ExecException | null, string | undefined, string | undefined] | undefined;
+  const stdoutPipe = jest.fn();
+  const stderrPipe = jest.fn();
+  beforeAll(() => {
+    jest.spyOn(cp, 'exec').mockImplementation(
+      (cmd: any, opts: any, callback: Function): Partial<cp.ChildProcess> => {
+        setTimeout(() => {
+          callback(...execResult!);
+        }, 0);
+        return {
+          stdout: ({ pipe: stdoutPipe } as any) as Readable,
+          stderr: ({ pipe: stderrPipe } as any) as Readable
+        };
+      }
+    );
+  });
+
+  afterEach(() => {
+    execResult = undefined;
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('handles success case', () => {
+    execResult = [null, 'success', undefined];
+    return exec('something', {}).then((result: string | undefined) => {
+      expect(result).toBe('success');
+    });
+  });
+
+  it('handles error case', () => {
+    const error: cp.ExecException = new Error('error');
+    error.code = 3;
+    execResult = [error, 'log message', 'oh no'];
+    let succeeded = false;
+    return exec('something', {})
+      .then(
+        () => {
+          succeeded = true;
+        },
+        (result: ExecError) => {
+          expect(result.stdout).toBe('log message');
+          expect(result.stderr).toBe('oh no');
+          expect(result.message).toBe('error');
+          expect(result.code).toBe(3);
+        }
+      )
+      .catch(() => {
+        // If this fails, it means the promise was resolved not rejected
+        expect(succeeded).toBe(false);
+      });
+  });
+
+  it('pipes stdout', async () => {
+    execResult = [null, 'success', undefined];
+    await exec('something', { stdout: process.stdout });
+    expect(stdoutPipe).toHaveBeenCalled();
+    expect(stderrPipe).toHaveBeenCalledTimes(0);
+  });
+
+  it('pipes stderr', async () => {
+    execResult = [null, 'success', undefined];
+    await exec('something', { stderr: process.stderr });
+    expect(stderrPipe).toHaveBeenCalled();
+    expect(stdoutPipe).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
Make `exec` return stdout and stderr as part of the error object (and add tests). Also make `spawn` return a full error object (with code set) rather than just a code.

Motivation: For awhile I was wondering if the reason for exit codes not getting passed through in our build was the way the exec helper handled errors. That turned out to probably not be the case, but I'd already done this so...