### PR TITLE
Fix jest tests for just-task. Also adds npm test in PR builds

### DIFF
--- a/azure-pipelines.pr.yml
+++ b/azure-pipelines.pr.yml
@@ -18,6 +18,16 @@ steps:
   - script: |
       git config user.email "kchau@microsoft.com"
       git config user.name "kchau@microsoft.com"
+    displayName: git config
+
+  - script: |
       npm install
+    displayName: 'npm install'
+
+  - script: |
       npm run build
-    displayName: 'npm install and build'
+    displayName: 'build'
+
+  - script: |
+      npm test
+    displayName: 'test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,20 @@ steps:
       git config user.email "kchau@microsoft.com"
       git config user.name "kchau@microsoft.com"
       git remote set-url origin https://$(github.user):$(github.pat)@github.com/Microsoft/just.git
+    displayName: 'git config'
+
+  - script: |
       npm install
+    displayName: 'npm install'
+
+  - script: |
       npm run build
+    displayName: 'build'
+
+  - script: |
+      npm test
+    displayName: 'test'
+
+  - script: |
       node ./common/scripts/install-run-rush.js publish -a -p -b master -n $(npm.authtoken)
-    displayName: 'npm install and build'
+    displayName: 'rush publish'

--- a/common/changes/just-scripts/fix-test_2019-03-29-20-07.json
+++ b/common/changes/just-scripts/fix-test_2019-03-29-20-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "just-scripts",
+      "type": "none"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "kchau@microsoft.com"
+}

--- a/common/changes/just-task/fix-test_2019-03-29-20-07.json
+++ b/common/changes/just-task/fix-test_2019-03-29-20-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "just-task",
+      "type": "none"
+    }
+  ],
+  "packageName": "just-task",
+  "email": "kchau@microsoft.com"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -61,6 +61,15 @@
     },
 
     {
+      "commandKind": "bulk",
+      "name": "test",
+      "summary": "Test",
+      "description": "Runs tests in every project if available",
+      "enableParallelism": true,
+      "ignoreMissingScript": true
+    },
+
+    {
       /**
        * (Required) Determines the type of custom command.
        * Rush's "global" commands are invoked once for the entire repo.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:docs": "node ./common/scripts/install-run-rush.js build -t just-task-docs",
     "postbuild": "node ./scripts/copyReadme.js",
     "start": "node ./scripts/watch.js",
+    "test": "node ./common/scripts/install-run-rush.js test",
     "deploy": "node ./common/scripts/install-run-rush.js build && node ./common/scripts/install-run-rush.js publish -a -p -b master"
   },
   "keywords": [],

--- a/packages/just-scripts/package.json
+++ b/packages/just-scripts/package.json
@@ -36,6 +36,6 @@
   "scripts": {
     "build": "webpack --mode production",
     "start": "webpack --watch --progress --mode development",
-    "test": "jest"
+    "test": "jest --passWithNoTests"
   }
 }

--- a/packages/just-task/src/__tests__/__mocks__/yargs/yargs.ts
+++ b/packages/just-task/src/__tests__/__mocks__/yargs/yargs.ts
@@ -1,0 +1,15 @@
+// This is a clone of the ../yargs.ts file but exported as a commonjs module, simulating yargs/yargs
+
+const yargs = () => yargs;
+
+yargs.argv = {
+  config: undefined
+} as { config: string | undefined };
+
+yargs.command = () => yargs;
+
+yargs.demandCommand = () => yargs;
+
+yargs.help = () => yargs;
+
+export = yargs;

--- a/packages/just-task/src/__tests__/resolve.spec.ts
+++ b/packages/just-task/src/__tests__/resolve.spec.ts
@@ -137,7 +137,7 @@ describe('resolve', () => {
     expect(resolve('b.txt', 'a')).toContain('a/b.txt');
   });
 
-  fit('uses dirname of --config arg', () => {
+  it('uses dirname of --config arg', () => {
     mockfs({
       a: { 'b.txt': '' }
     });

--- a/packages/just-task/src/__tests__/resolve.spec.ts
+++ b/packages/just-task/src/__tests__/resolve.spec.ts
@@ -1,5 +1,5 @@
 import mockfs from 'mock-fs';
-import yargsMock from './__mocks__/yargs';
+import yargsMock from './__mocks__/yargs/yargs';
 import {
   _isFileNameLike,
   _tryResolve,
@@ -137,7 +137,7 @@ describe('resolve', () => {
     expect(resolve('b.txt', 'a')).toContain('a/b.txt');
   });
 
-  it('uses dirname of --config arg', () => {
+  fit('uses dirname of --config arg', () => {
     mockfs({
       a: { 'b.txt': '' }
     });


### PR DESCRIPTION
One of my fixes actually fixed the runtime, but broke tests. Since our PR status checks didn't have tests running, it slipped through without notice. This enables it.