### PR TITLE
Assorted updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,10 @@ build
 dist
 temp
 
-# Rush files
+# Rush and npm files
 common/temp/**
 package-deps.json
+package-lock.json
 
 # Binary files
 *.tgz

--- a/common/changes/just-scripts-utils/ecraig-things_2019-04-04-22-48.json
+++ b/common/changes/just-scripts-utils/ecraig-things_2019-04-04-22-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts-utils",
+      "comment": "Add execSync",
+      "type": "minor"
+    }
+  ],
+  "packageName": "just-scripts-utils",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-scripts/ecraig-things_2019-04-04-22-48.json
+++ b/common/changes/just-scripts/ecraig-things_2019-04-04-22-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "Add custom Jest reporter",
+      "type": "minor"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-monorepo/ecraig-things_2019-04-04-22-48.json
+++ b/common/changes/just-stack-monorepo/ecraig-things_2019-04-04-22-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-monorepo",
+      "comment": "Update dep versions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-stack-monorepo",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-single-lib/ecraig-things_2019-04-04-22-48.json
+++ b/common/changes/just-stack-single-lib/ecraig-things_2019-04-04-22-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-single-lib",
+      "comment": "Add custom Jest reporter",
+      "type": "minor"
+    }
+  ],
+  "packageName": "just-stack-single-lib",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-uifabric/ecraig-things_2019-04-04-22-48.json
+++ b/common/changes/just-stack-uifabric/ecraig-things_2019-04-04-22-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-uifabric",
+      "comment": "Add custom Jest reporter and default to IE11-compatible libs",
+      "type": "minor"
+    }
+  ],
+  "packageName": "just-stack-uifabric",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/just-scripts-utils/src/exec.ts
+++ b/packages/just-scripts-utils/src/exec.ts
@@ -61,6 +61,27 @@ export function encodeArgs(cmdArgs: string[]) {
 }
 
 /**
+ * Execute a command synchronously.
+ *
+ * @param cmd  Command to execute
+ * @param cwd Working directory in which to run the command (default: `process.cwd()`)
+ * @param returnOutput If true, return the command's output. If false/unspecified,
+ * inherit stdio from the parent process (so the child's output goes to the console).
+ * @returns If `returnOutput` is true, returns the command's output. Otherwise returns undefined.
+ */
+export function execSync(cmd: string, cwd?: string, returnOutput?: boolean): string | undefined {
+  cwd = cwd || process.cwd();
+  const env = { ...process.env };
+
+  const output = cp.execSync(cmd, {
+    cwd,
+    env: env,
+    stdio: returnOutput ? undefined : 'inherit'
+  });
+  return returnOutput ? (output || '').toString('utf8') : undefined;
+}
+
+/**
  * Execute a command in a new process.
  *
  * @param cmd Command to execute

--- a/packages/just-scripts/src/jest/JestReporter.ts
+++ b/packages/just-scripts/src/jest/JestReporter.ts
@@ -1,3 +1,4 @@
+// This doesn't have types for some reason
 const DefaultReporter = require('jest-cli/build/reporters/default_reporter').default;
 
 /**
@@ -5,20 +6,23 @@ const DefaultReporter = require('jest-cli/build/reporters/default_reporter').def
  * when there are no errors.
  */
 class JestReporter extends DefaultReporter {
-  constructor(...args) {
+  private _isLoggingError: boolean;
+
+  constructor(...args: any[]) {
     super(...args);
 
     this._isLoggingError = false;
-    this.log = message => {
-      if (this._isLoggingError) {
-        process.stderr.write(message + '\n');
-      } else {
-        process.stdout.write(message + '\n');
-      }
-    };
   }
 
-  printTestFileFailureMessage(...args) {
+  public log = (message: string) => {
+    if (this._isLoggingError) {
+      process.stderr.write(message + '\n');
+    } else {
+      process.stdout.write(message + '\n');
+    }
+  };
+
+  public printTestFileFailureMessage(...args: any[]) {
     this._isLoggingError = true;
     super.printTestFileFailureMessage(...args);
     this._isLoggingError = false;

--- a/packages/just-stack-monorepo/template/.gitignore.hbs
+++ b/packages/just-stack-monorepo/template/.gitignore.hbs
@@ -29,3 +29,4 @@ documentation/website/i18n/*
 # Rush files
 common/temp/**
 package-deps.json
+package-lock.json

--- a/packages/just-stack-monorepo/template/rush.json.hbs
+++ b/packages/just-stack-monorepo/template/rush.json.hbs
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.6.3",
+  "rushVersion": "5.7.3",
 
   /**
    * The next field selects which package manager should be installed and determines its version.

--- a/packages/just-stack-monorepo/template/scripts/package.json.hbs
+++ b/packages/just-stack-monorepo/template/scripts/package.json.hbs
@@ -13,8 +13,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "just-task": "^0.9.0",
-    "just-scripts": "^0.14.0"
+    "just-task": "~0.9.8",
+    "just-scripts": "~0.15.2"
   },
   "devDependencies": {
     "just-stack-single-lib": ">=0.1.0",

--- a/packages/just-stack-single-lib/template/jest.config.js
+++ b/packages/just-stack-single-lib/template/jest.config.js
@@ -8,5 +8,6 @@ module.exports = {
     'ts-jest': {
       packageJson: path.resolve(__dirname, 'package.json')
     }
-  }
+  },
+  reporters: [path.resolve(__dirname, 'node_modules/just-scripts/lib/jest/JestReporter.js')]
 };

--- a/packages/just-stack-uifabric/template/jest.config.js
+++ b/packages/just-stack-uifabric/template/jest.config.js
@@ -8,5 +8,6 @@ module.exports = {
     'ts-jest': {
       packageJson: path.resolve(__dirname, 'package.json')
     }
-  }
+  },
+  reporters: [path.resolve(__dirname, 'node_modules/just-scripts/lib/jest/JestReporter.js')]
 };

--- a/packages/just-stack-uifabric/template/tsconfig.json
+++ b/packages/just-stack-uifabric/template/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "es2015",
     "outDir": "./lib",
+    "lib": ["es5", "dom"],
     "importHelpers": true,
     "downlevelIteration": true,
     "strict": true,

--- a/rush.json
+++ b/rush.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
-  "rushVersion": "5.7.0",
+  "rushVersion": "5.7.3",
   "pnpmVersion": "2.15.1",
 
   "pnpmOptions": {


### PR DESCRIPTION
- Add custom jest reporter for within this repo and for generated packages
- Check in execSync helper that I wrote a long time ago for some reason?
- gitignore package-lock.json in monorepos
- update rush, just-scripts, and just-task in templates
- in just-stack-uifabric, default to only allowing libs that work in IE 11