### PR TITLE
Webpack task fix to use the correct require() 

### DIFF
--- a/common/changes/just-scripts/webpack_2019-04-15-21-15.json
+++ b/common/changes/just-scripts/webpack_2019-04-15-21-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "Fix the require statement of for webpack config since it no longer uses webpack to bundle the just-scripts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -3,8 +3,6 @@ import fs from 'fs';
 import { encodeArgs, spawn } from 'just-scripts-utils';
 import webpackMerge from 'webpack-merge';
 
-declare var __non_webpack_require__: any;
-
 export interface WebpackTaskOptions {
   config?: string;
   mode?: 'production' | 'development';
@@ -27,7 +25,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
             return reject(`Cannot find webpack configuration file`);
           }
 
-          const configLoader = __non_webpack_require__(webpackConfigPath);
+          const configLoader = require(webpackConfigPath);
 
           let webpackConfigs;
 


### PR DESCRIPTION
We no longer run webpack bundle on the `just-script` package. This means we need to use regular "require()". This changes back the require back to the normal one.