### PR TITLE
Fix #78 by using Spawn instead of Exec

### DIFF
--- a/common/changes/just-scripts-utils/patch-1_2019-04-25-17-39.json
+++ b/common/changes/just-scripts-utils/patch-1_2019-04-25-17-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts-utils",
+      "comment": "Fix #78 by using Spawn instead of Exec",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-scripts-utils",
+  "email": "reli@microsoft.com"
+}

--- a/packages/just-scripts-utils/src/rush.ts
+++ b/packages/just-scripts-utils/src/rush.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import jju from 'jju';
@@ -10,8 +10,7 @@ import { RushJson } from './interfaces/RushJson';
  * @param cwd Working directory in which to run the command.
  */
 export function rushUpdate(cwd: string): void {
-  // TODO: does this work on Windows?
-  execSync(`${process.execPath} common/scripts/install-run-rush.js update`, {
+  spawnSync(process.execPath, ['common/scripts/install-run-rush.js', 'update'], {
     cwd,
     stdio: 'inherit'
   });


### PR DESCRIPTION
In the script there's a `execSync` call which doesn't properly escape arguments that contain spaces. This change used `spawnSync` instead to do it properly.