### PR TITLE
Update task presets to clean all the output dirs they create

### DIFF
--- a/common/changes/just-scripts/ecraig-clean_2019-05-15-18-32.json
+++ b/common/changes/just-scripts/ecraig-clean_2019-05-15-18-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "Update task presets to clean all the output dirs they create",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/just-scripts/src/task-presets/lib.ts
+++ b/packages/just-scripts/src/task-presets/lib.ts
@@ -1,8 +1,8 @@
 import { task, series, parallel } from 'just-task';
-import { cleanTask, tscTask, jestTask, upgradeStackTask } from '../tasks';
+import { cleanTask, tscTask, jestTask, upgradeStackTask, defaultCleanPaths } from '../tasks';
 
 export function lib() {
-  task('clean', cleanTask());
+  task('clean', cleanTask([...defaultCleanPaths(), 'lib-commonjs']));
 
   task('ts:commonjs', tscTask({ module: 'commonjs', outDir: 'lib-commonjs' }));
   task('ts:esm', tscTask({ module: 'esnext', outDir: 'lib' }));

--- a/packages/just-scripts/src/task-presets/webapp.ts
+++ b/packages/just-scripts/src/task-presets/webapp.ts
@@ -1,8 +1,8 @@
 import { task, series, parallel } from 'just-task';
-import { cleanTask, tscTask, jestTask, webpackTask, webpackDevServerTask, upgradeStackTask } from '../tasks';
+import { cleanTask, tscTask, jestTask, webpackTask, webpackDevServerTask, upgradeStackTask, defaultCleanPaths } from '../tasks';
 
 export function webapp() {
-  task('clean', cleanTask());
+  task('clean', cleanTask([...defaultCleanPaths(), 'lib-commonjs']));
 
   task('ts:commonjs', tscTask({ module: 'commonjs', outDir: 'lib-commonjs' }));
   task('ts:esm', tscTask({ module: 'esnext', outDir: 'lib' }));

--- a/packages/just-scripts/src/tasks/cleanTask.ts
+++ b/packages/just-scripts/src/tasks/cleanTask.ts
@@ -3,9 +3,13 @@ import parallelLimit from 'run-parallel-limit';
 import path from 'path';
 import { logger, TaskFunction } from 'just-task';
 
+export function defaultCleanPaths(): string[] {
+  return ['lib', 'temp', 'dist', 'coverage'];
+}
+
 export function cleanTask(paths: string[] = [], limit: number = 5): TaskFunction {
   if (paths.length === 0) {
-    paths = ['lib', 'temp', 'dist', 'coverage'];
+    paths = defaultCleanPaths();
   }
 
   return function clean(done: (err?: Error) => void) {


### PR DESCRIPTION
Presets that create `lib-commonjs` should also remove it in the clean step.