### PR TITLE
Switch microsoft in repo URL to lowercase

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ steps:
   - script: |
       git config user.email "kchau@microsoft.com"
       git config user.name "kchau@microsoft.com"
-      git remote set-url origin https://$(github.user):$(github.pat)@github.com/Microsoft/just.git
+      git remote set-url origin https://$(github.user):$(github.pat)@github.com/microsoft/just.git
     displayName: 'git config'
 
   - script: |

--- a/common/changes/create-just/ecraig-microsoft_2019-05-15-18-36.json
+++ b/common/changes/create-just/ecraig-microsoft_2019-05-15-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "create-just",
+      "comment": "Switch microsoft in repo URL to lowercase",
+      "type": "patch"
+    }
+  ],
+  "packageName": "create-just",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/create-uifabric/ecraig-microsoft_2019-05-15-18-36.json
+++ b/common/changes/create-uifabric/ecraig-microsoft_2019-05-15-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "create-uifabric",
+      "comment": "Switch microsoft in repo URL to lowercase",
+      "type": "patch"
+    }
+  ],
+  "packageName": "create-uifabric",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-scripts-utils/ecraig-microsoft_2019-05-15-18-36.json
+++ b/common/changes/just-scripts-utils/ecraig-microsoft_2019-05-15-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts-utils",
+      "comment": "Switch microsoft in repo URL to lowercase",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-scripts-utils",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-scripts/ecraig-microsoft_2019-05-15-18-36.json
+++ b/common/changes/just-scripts/ecraig-microsoft_2019-05-15-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "Switch microsoft in repo URL to lowercase",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-monorepo/ecraig-microsoft_2019-05-15-18-36.json
+++ b/common/changes/just-stack-monorepo/ecraig-microsoft_2019-05-15-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-monorepo",
+      "comment": "Switch microsoft in repo URL to lowercase",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-stack-monorepo",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-single-lib/ecraig-microsoft_2019-05-15-18-36.json
+++ b/common/changes/just-stack-single-lib/ecraig-microsoft_2019-05-15-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-single-lib",
+      "comment": "Switch microsoft in repo URL to lowercase",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-stack-single-lib",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-stack-uifabric/ecraig-microsoft_2019-05-15-18-36.json
+++ b/common/changes/just-stack-uifabric/ecraig-microsoft_2019-05-15-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-stack-uifabric",
+      "comment": "Switch microsoft in repo URL to lowercase",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-stack-uifabric",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-task-logger/ecraig-microsoft_2019-05-15-18-36.json
+++ b/common/changes/just-task-logger/ecraig-microsoft_2019-05-15-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-task-logger",
+      "comment": "Switch microsoft in repo URL to lowercase",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-task-logger",
+  "email": "elcraig@microsoft.com"
+}

--- a/common/changes/just-task/ecraig-microsoft_2019-05-15-18-36.json
+++ b/common/changes/just-task/ecraig-microsoft_2019-05-15-18-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-task",
+      "comment": "Switch microsoft in repo URL to lowercase",
+      "type": "patch"
+    }
+  ],
+  "packageName": "just-task",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/create-just/package.json
+++ b/packages/create-just/package.json
@@ -4,7 +4,7 @@
   "description": "Create a new repository using Just",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/just"
+    "url": "https://github.com/microsoft/just"
   },
   "main": "dist/create-just.js",
   "bin": {

--- a/packages/create-uifabric/package.json
+++ b/packages/create-uifabric/package.json
@@ -4,7 +4,7 @@
   "description": "Create a new UI Fabric repository using Just",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/just"
+    "url": "https://github.com/microsoft/just"
   },
   "scripts": {
     "build": ""

--- a/packages/just-scripts-utils/package.json
+++ b/packages/just-scripts-utils/package.json
@@ -4,7 +4,7 @@
   "description": "Utilities for Just stack scripts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/just"
+    "url": "https://github.com/microsoft/just"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/just-scripts/package.json
+++ b/packages/just-scripts/package.json
@@ -4,7 +4,7 @@
   "description": "Just Stack Scripts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/just"
+    "url": "https://github.com/microsoft/just"
   },
   "bin": {
     "just-scripts": "bin/just-scripts.js"

--- a/packages/just-stack-monorepo/package.json
+++ b/packages/just-stack-monorepo/package.json
@@ -5,7 +5,7 @@
   "description": "Just stack for monorepo using Rush",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/just"
+    "url": "https://github.com/microsoft/just"
   },
   "main": "index.js",
   "keywords": [

--- a/packages/just-stack-monorepo/template/rush.json.hbs
+++ b/packages/just-stack-monorepo/template/rush.json.hbs
@@ -182,7 +182,7 @@
      * It specifies the remote url for the official Git repository.  If this URL is provided,
      * "rush change" will use it to find the right remote to compare against.
      */
-    // "url": "https://github.com/Microsoft/rush-example"
+    // "url": "https://github.com/microsoft/rush-example"
   },
 
   /**

--- a/packages/just-stack-single-lib/package.json
+++ b/packages/just-stack-single-lib/package.json
@@ -5,7 +5,7 @@
   "description": "Just stack for basic Node library",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/just"
+    "url": "https://github.com/microsoft/just"
   },
   "main": "index.js",
   "keywords": [

--- a/packages/just-stack-uifabric/package.json
+++ b/packages/just-stack-uifabric/package.json
@@ -5,7 +5,7 @@
   "description": "Just stack for UI Fabric application with React",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/just"
+    "url": "https://github.com/microsoft/just"
   },
   "main": "index.js",
   "keywords": [

--- a/packages/just-task-logger/package.json
+++ b/packages/just-task-logger/package.json
@@ -4,7 +4,7 @@
   "description": "Logger for Just scripts and tasks",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/just"
+    "url": "https://github.com/microsoft/just"
   },
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/just-task/package.json
+++ b/packages/just-task/package.json
@@ -4,7 +4,7 @@
   "description": "Build task definition library",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/just"
+    "url": "https://github.com/microsoft/just"
   },
   "main": "lib/index.js",
   "typing": "lib/index.d.ts",

--- a/rush.json
+++ b/rush.json
@@ -39,7 +39,7 @@
      * It specifies the remote url for the official Git repository.  If this URL is provided,
      * "rush change" will use it to find the right remote to compare against.
      */
-    "url": "https://github.com/Microsoft/just.git"
+    "url": "https://github.com/microsoft/just.git"
   },
 
   "eventHooks": {


### PR DESCRIPTION
Apparently the Microsoft GitHub org's URL was just converted to lowercase. Update it everywhere.