### PR TITLE
Add ability to pass options to task presets

### DIFF
--- a/common/changes/just-scripts/ecraig-taskOptions_2019-05-16-22-08.json
+++ b/common/changes/just-scripts/ecraig-taskOptions_2019-05-16-22-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "Add ability to pass options to task presets, and switch clean task to use options object",
+      "type": "minor"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com"
+}

--- a/packages/just-scripts/src/tasks/cleanTask.ts
+++ b/packages/just-scripts/src/tasks/cleanTask.ts
@@ -3,14 +3,35 @@ import parallelLimit from 'run-parallel-limit';
 import path from 'path';
 import { logger, TaskFunction } from 'just-task';
 
+export interface CleanTaskOptions {
+  /**
+   * Paths to clean
+   * @default defaultCleanPaths()
+   */
+  paths?: string[];
+  /**
+   * Limit on number of simultaneous processes for cleaning
+   * @default 5
+   */
+  limit?: number;
+}
+
 export function defaultCleanPaths(): string[] {
   return ['lib', 'temp', 'dist', 'coverage'];
 }
 
-export function cleanTask(paths: string[] = [], limit: number = 5): TaskFunction {
-  if (paths.length === 0) {
-    paths = defaultCleanPaths();
+export function cleanTask(options?: CleanTaskOptions): TaskFunction;
+/** @deprecated Use object param version */
+export function cleanTask(paths?: string[], limit?: number): TaskFunction;
+export function cleanTask(pathsOrOptions: string[] | CleanTaskOptions = {}, limit?: number): TaskFunction {
+  let paths: string[];
+  if (Array.isArray(pathsOrOptions)) {
+    paths = pathsOrOptions;
+  } else {
+    paths = pathsOrOptions.paths || defaultCleanPaths();
+    limit = limit || pathsOrOptions.limit;
   }
+  limit = limit || 5;
 
   return function clean(done: (err?: Error) => void) {
     logger.info(`Removing [${paths.map(p => path.relative(process.cwd(), p)).join(', ')}]`);
@@ -22,6 +43,6 @@ export function cleanTask(paths: string[] = [], limit: number = 5): TaskFunction
         }
     );
 
-    parallelLimit(cleanTasks, limit, done);
+    parallelLimit(cleanTasks, limit!, done);
   };
 }

--- a/packages/just-scripts/src/tasks/tscTask.ts
+++ b/packages/just-scripts/src/tasks/tscTask.ts
@@ -3,9 +3,9 @@ import { resolve, logger, resolveCwd, TaskFunction } from 'just-task';
 import { exec, encodeArgs, spawn } from 'just-scripts-utils';
 import fs from 'fs';
 
-type CompilerOptions = { [key in keyof ts.CompilerOptions]: string | boolean };
+export type TscTaskOptions = { [key in keyof ts.CompilerOptions]?: string | boolean };
 
-export function tscTask(options: CompilerOptions): TaskFunction {
+export function tscTask(options: TscTaskOptions): TaskFunction {
   const tsConfigFile = resolveCwd('./tsconfig.json');
   const tscCmd = resolve('typescript/lib/tsc.js');
 
@@ -42,7 +42,7 @@ export function tscTask(options: CompilerOptions): TaskFunction {
   };
 }
 
-export function tscWatchTask(options: CompilerOptions): TaskFunction {
+export function tscWatchTask(options: TscTaskOptions): TaskFunction {
   const tsConfigFile = resolveCwd('./tsconfig.json');
   const tscCmd = resolve('typescript/lib/tsc.js');
 


### PR DESCRIPTION
Make the lib and webapp presets more useful by allowing users to pass in options for each task.

Also added the ability to pass an options object to the clean task, which makes passing options through the presets tidier. (I kept the old signature too for now.)