### PR TITLE
`jestTask()` now has a nodeArgs to pass to its child process

### DIFF
--- a/common/changes/just-scripts/nodeargs_2019-05-17-17-47.json
+++ b/common/changes/just-scripts/nodeargs_2019-05-17-17-47.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "Adds a nodeArgs to jestTask",
+      "type": "minor"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/just-scripts/src/tasks/jestTask.ts
+++ b/packages/just-scripts/src/tasks/jestTask.ts
@@ -10,6 +10,11 @@ export interface JestTaskOptions {
   watch?: boolean;
   u?: boolean;
   _?: string[];
+
+  /**
+   * Arguments to be passed into a spawn call for jest
+   */
+  nodeArgs?: string[];
 }
 
 export function jestTask(options: JestTaskOptions = {}): TaskFunction {
@@ -24,16 +29,17 @@ export function jestTask(options: JestTaskOptions = {}): TaskFunction {
       const cmd = process.execPath;
 
       const args = [
+        ...(options.nodeArgs || []),
         jestCmd,
         '--config',
         configFile,
         '--passWithNoTests',
         '--colors',
-        options.runInBand ? '--runInBand' : '',
-        options.coverage ? '--coverage' : '',
-        options.watch ? '--watch' : '',
-        options.u || options.updateSnapshot ? '--updateSnapshot' : '',
-        ...(options._ ? options._ : [])
+        ...(options.runInBand ? ['--runInBand'] : []),
+        ...(options.coverage ? ['--coverage'] : []),
+        ...(options.watch ? ['--watch'] : []),
+        ...(options.u || options.updateSnapshot ? ['--updateSnapshot'] : ['']),
+        ...(options._ || [])
       ].filter(arg => !!arg) as Array<string>;
 
       logger.info(cmd, encodeArgs(args).join(' '));


### PR DESCRIPTION
For example, this can allow jestTask to pass in params for experimental workers and increased memory limits.