### PR TITLE
Feature to add stats output along with the display bailout reasons

### DIFF
--- a/common/changes/just-scripts/stats_2019-05-21-21-17.json
+++ b/common/changes/just-scripts/stats_2019-05-21-21-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "add flag to write output stats",
+      "type": "minor"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "kchau@microsoft.com"
+}

--- a/packages/just-scripts/src/index.ts
+++ b/packages/just-scripts/src/index.ts
@@ -11,12 +11,14 @@ import { tsOverlay } from './webpack/overlays/tsOverlay';
 import { htmlOverlay } from './webpack/overlays/htmlOverlay';
 import { stylesOverlay } from './webpack/overlays/stylesOverlay';
 import { fileOverlay } from './webpack/overlays/fileOverlay';
+import { displayBailoutOverlay } from './webpack/overlays/displayBailoutOverlay';
 
 export const webpackOverlays = {
   typescript: tsOverlay,
   html: htmlOverlay,
   styles: stylesOverlay,
-  file: fileOverlay
+  file: fileOverlay,
+  displayBailout: displayBailoutOverlay
 };
 
 import webpackMerge from 'webpack-merge';

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -5,7 +5,12 @@ import webpackMerge from 'webpack-merge';
 
 export interface WebpackTaskOptions {
   config?: string;
+
+  /** true to output to stats.json; a string to output to a file */
+  outputStats?: boolean | string;
+
   mode?: 'production' | 'development';
+
   // can contain other config values which are passed on to webpack
   [key: string]: any;
 }
@@ -45,6 +50,11 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
           webpackConfigs = webpackConfigs.map(webpackConfig => webpackMerge(webpackConfig, restConfig));
 
           wp(webpackConfigs, (err: Error, stats: any) => {
+            if (options && options.outputStats) {
+              const statsFile = options.outputStats === true ? 'stats.json' : options.outputStats;
+              fs.writeFileSync();
+            }
+
             if (err || stats.hasErrors()) {
               let errorStats = stats.toJson('errors-only');
               errorStats.errors.forEach((error: any) => {

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -52,7 +52,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
           wp(webpackConfigs, (err: Error, stats: any) => {
             if (options && options.outputStats) {
               const statsFile = options.outputStats === true ? 'stats.json' : options.outputStats;
-              fs.writeFileSync();
+              fs.writeFileSync(statsFile, JSON.stringify(stats.toJson(), null, 2));
             }
 
             if (err || stats.hasErrors()) {

--- a/packages/just-scripts/src/webpack/overlays/displayBailoutOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/displayBailoutOverlay.ts
@@ -1,0 +1,8 @@
+export const displayBailoutOverlay = {
+  stats: {
+    // Examine all modules
+    maxModules: Infinity,
+    // Display bailout reasons
+    optimizationBailout: true
+  }
+};

--- a/packages/just-scripts/src/webpack/webpack.config.ts
+++ b/packages/just-scripts/src/webpack/webpack.config.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import merge from 'webpack-merge';
 import { tsOverlay } from './overlays/tsOverlay';
 import { fileOverlay } from './overlays/fileOverlay';
+import { displayBailoutOverlay } from './overlays/displayBailoutOverlay';
 
 export const webpackConfig: any = merge(
   {
@@ -13,5 +14,6 @@ export const webpackConfig: any = merge(
     }
   },
   tsOverlay,
-  fileOverlay
+  fileOverlay,
+  displayBailoutOverlay
 );


### PR DESCRIPTION
Fixes #108 - this allows us to display optimization bailout reasons. We also make sure that we don't get rid of the stats - but actually write it out!