### PR TITLE
dont knock out webpack's default extensions

### DIFF
--- a/packages/just-scripts/src/webpack/overlays/tsOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/tsOverlay.ts
@@ -4,7 +4,7 @@ const ForkTsCheckerPlugin = tryRequire('fork-ts-checker-webpack-plugin');
 
 export const tsOverlay = {
   resolve: {
-    extensions: ['.js', '.ts', '.tsx']
+    extensions: ['.wasm', '.mjs', '.js', '.ts', '.tsx', '.json']
   },
   module: {
     rules: [


### PR DESCRIPTION
dont knock out webpack's default extensions