### PR TITLE
Add a `fix` option to tslintTask

### DIFF
--- a/common/changes/just-scripts/tslint-fix_2019-05-24-01-01.json
+++ b/common/changes/just-scripts/tslint-fix_2019-05-24-01-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-scripts",
+      "comment": "Add a `fix` option to tslintTask",
+      "type": "minor"
+    }
+  ],
+  "packageName": "just-scripts",
+  "email": "rezha@microsoft.com"
+}

--- a/packages/just-scripts/src/tasks/tslintTask.ts
+++ b/packages/just-scripts/src/tasks/tslintTask.ts
@@ -26,7 +26,7 @@ export function tslintTask(options: TsLintTaskOptions = {}): TaskFunction {
         path.dirname(resolve('tslint-microsoft-contrib') || '')
       ];
 
-      if (options.fix === true) {
+      if (options.fix) {
         args.push('--fix');
       }
 

--- a/packages/just-scripts/src/tasks/tslintTask.ts
+++ b/packages/just-scripts/src/tasks/tslintTask.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 
 export interface TsLintTaskOptions {
   config?: string;
+  fix?: boolean;
 }
 
 export function tslintTask(options: TsLintTaskOptions = {}): TaskFunction {
@@ -24,6 +25,10 @@ export function tslintTask(options: TsLintTaskOptions = {}): TaskFunction {
         '-r',
         path.dirname(resolve('tslint-microsoft-contrib') || '')
       ];
+
+      if (options.fix === true) {
+        args.push('--fix');
+      }
 
       const cmd = encodeArgs([process.execPath, tslintCmd, ...args]).join(' ');
       logger.info(cmd);


### PR DESCRIPTION
... so that consumers of this task can choose to auto-fix tslint issues with `tslintTask({fix: true})`.

Addressing #52 