### PR TITLE
Adds the ability to add cache to a task

### DIFF
--- a/common/changes/just-task/cache_2019-06-03-22-46.json
+++ b/common/changes/just-task/cache_2019-06-03-22-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "just-task",
+      "comment": "Adds cache capability",
+      "type": "minor"
+    }
+  ],
+  "packageName": "just-task",
+  "email": "kchau@microsoft.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -8,6 +8,7 @@ dependencies:
   '@babel/register': 7.0.0
   '@babel/traverse': 7.2.3
   '@babel/types': 7.3.2
+  '@microsoft/package-deps-hash': 2.2.153
   '@rush-temp/create-just': 'file:projects/create-just.tgz'
   '@rush-temp/create-uifabric': 'file:projects/create-uifabric.tgz'
   '@rush-temp/example-lib': 'file:projects/example-lib.tgz'
@@ -53,7 +54,6 @@ dependencies:
   handlebars: 4.0.12
   html-webpack-plugin: 3.2.0
   jest: 24.7.1
-  jest-environment-jsdom: 24.8.0
   jest-expect-message: 1.0.2
   jju: 1.4.0
   json5: 2.1.0
@@ -451,6 +451,7 @@ packages:
       integrity: sha512-wNHxLkEKTQ2ay0tnsam2z7fGZUi+05ziDJflEt3AZTP3oXLKHJp9HqhfroB/vdMvt3sda9fAbq7FsG8QPDrZBg==
   /@babel/plugin-proposal-class-properties/7.3.0/@babel!core@7.2.2:
     dependencies:
+      '@babel/core': 7.2.2
       '@babel/helper-create-class-features-plugin': /@babel/helper-create-class-features-plugin/7.3.2/@babel!core@7.2.2
       '@babel/helper-plugin-utils': 7.0.0
     dev: false
@@ -490,6 +491,7 @@ packages:
       integrity: sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==
   /@babel/plugin-proposal-object-rest-spread/7.3.2/@babel!core@7.2.2:
     dependencies:
+      '@babel/core': 7.2.2
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.2.2
     dev: false
@@ -1353,6 +1355,7 @@ packages:
       integrity: sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==
   /@babel/preset-env/7.3.1/@babel!core@7.2.2:
     dependencies:
+      '@babel/core': 7.2.2
       '@babel/helper-module-imports': 7.0.0
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-proposal-async-generator-functions': /@babel/plugin-proposal-async-generator-functions/7.2.0/@babel!core@7.2.2
@@ -1416,6 +1419,7 @@ packages:
       integrity: sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==
   /@babel/preset-react/7.0.0/@babel!core@7.2.2:
     dependencies:
+      '@babel/core': 7.2.2
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-transform-react-display-name': /@babel/plugin-transform-react-display-name/7.2.0/@babel!core@7.2.2
       '@babel/plugin-transform-react-jsx': /@babel/plugin-transform-react-jsx/7.3.0/@babel!core@7.2.2
@@ -1443,6 +1447,7 @@ packages:
       integrity: sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==
   /@babel/register/7.0.0/@babel!core@7.2.2:
     dependencies:
+      '@babel/core': 7.2.2
       core-js: 2.6.3
       find-cache-dir: 1.0.0
       home-or-tmp: 3.0.0
@@ -1886,6 +1891,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-mnsL/1ikVWHl8sPNssavaAgtUaIM3hkQ8zeySuApU5dNmsMPzovJPfx9m5JGiMvs1v5QNAIVeiS9jnWwe/7anw==
+  /@microsoft/package-deps-hash/2.2.153:
+    dev: false
+    resolution:
+      integrity: sha512-784D6TtTHlVHVTwnq+W2xaw40Efjn/7pFyz8qDv6JDkA1g/HVsnk/NeRa/SKFnFE9cGWmooACFfJd1R4montoA==
   /@microsoft/ts-command-line/4.2.5:
     dependencies:
       '@types/argparse': 1.0.33
@@ -2286,10 +2295,28 @@ packages:
       react-dom: ^0.14.9 || ^15.0.1-0 || ^16.0.0-0
     resolution:
       integrity: sha512-iFwuoFUQoS6H6paxrRsVCxQnw2SqnxhS+EBh54Gb3A6HxS2IKzGAE5c4tnZcqjXNPxXTvXgt5iQg3xycIa95cg==
-  /@uifabric/charting/0.28.5/react-dom@16.7.0:
+  /@uifabric/charting/0.28.5/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0
-      react-dom: 16.7.0
+      '@microsoft/load-themed-styles': 1.8.56
+      '@types/d3-array': 1.2.1
+      '@types/d3-axis': 1.0.10
+      '@types/d3-scale': 2.0.0
+      '@types/d3-selection': 1.3.0
+      '@types/d3-shape': 1.3.0
+      '@types/d3-time-format': 2.1.0
+      '@uifabric/icons': 6.3.0
+      '@uifabric/set-version': 1.1.3
+      d3-array: 1.2.1
+      d3-axis: 1.0.8
+      d3-scale: 2.0.0
+      d3-selection: 1.3.0
+      d3-shape: 1.3.4
+      d3-time-format: 2.1.3
+      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0
+      prop-types: 15.6.2
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/@uifabric/charting/0.28.5
     peerDependencies:
@@ -2322,14 +2349,27 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-+1z5RUSP5gWfB5VIcD1A7O1ITbzwBEvCOOn0Md5vOhozrcDPxEAcoIve29Ckckd/05xmMAYTjgQVMjgE4y8Rng==
-  /@uifabric/experiments/6.54.2/react-dom@16.7.0:
+  /@uifabric/experiments/6.54.2/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      '@uifabric/charting': /@uifabric/charting/0.28.5/react-dom@16.7.0
-      '@uifabric/file-type-icons': /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0
-      '@uifabric/foundation': /@uifabric/foundation/0.7.1/react-dom@16.7.0
-      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0
-      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0
-      react-dom: 16.7.0
+      '@microsoft/load-themed-styles': 1.8.56
+      '@uifabric/azure-themes': 0.1.5
+      '@uifabric/charting': /@uifabric/charting/0.28.5/react-dom@16.7.0+react@16.7.0
+      '@uifabric/file-type-icons': /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0+react@16.7.0
+      '@uifabric/fluent-theme': 0.13.4
+      '@uifabric/foundation': /@uifabric/foundation/0.7.1/react-dom@16.7.0+react@16.7.0
+      '@uifabric/icons': 6.3.0
+      '@uifabric/merge-styles': 6.15.2
+      '@uifabric/set-version': 1.1.3
+      '@uifabric/styling': 6.41.0
+      '@uifabric/theme-samples': 0.1.4
+      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0
+      '@uifabric/variants': 6.14.0
+      deep-assign: 2.0.0
+      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0
+      prop-types: 15.6.2
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/@uifabric/experiments/6.54.2
     peerDependencies:
@@ -2348,9 +2388,13 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-T6wGiA/RjLqRE+P5RRObpcRJ+ejh4ZwZX584GgEymOCcU7kjzWSZR7imTA65FbUMUhXxR68b3oiWgPSaCAXE8w==
-  /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0:
+  /@uifabric/file-type-icons/6.4.1/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      react-dom: 16.7.0
+      '@uifabric/set-version': 1.1.3
+      '@uifabric/styling': 6.41.0
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/@uifabric/file-type-icons/6.4.1
     peerDependencies:
@@ -2381,10 +2425,14 @@ packages:
       react-dom: ^0.14.9 || ^15.0.1-0 || ^16.0.0-0
     resolution:
       integrity: sha512-YrdaJXAe4x7whaj7/x1fhFsBGao0vAec6mVIAYCvC09AK+puEYDahIloVWA6vLTRlWzzOZWsvN3S3Z1tzfhIRw==
-  /@uifabric/foundation/0.7.1/react-dom@16.7.0:
+  /@uifabric/foundation/0.7.1/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0
-      react-dom: 16.7.0
+      '@uifabric/set-version': 1.1.3
+      '@uifabric/styling': 6.41.0
+      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/@uifabric/foundation/0.7.1
     peerDependencies:
@@ -2444,9 +2492,14 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-2VKRadp+pGV5PFubSYCUTU4Sg3NdztECFiEvgyVDIrGYZhSwOVHMwAKb+I9hr990OLCb+gSK3rekJp/To9NZFQ==
-  /@uifabric/utilities/6.29.0/react-dom@16.7.0:
+  /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      react-dom: 16.7.0
+      '@uifabric/merge-styles': 6.15.2
+      '@uifabric/set-version': 1.1.3
+      prop-types: 15.6.2
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/@uifabric/utilities/6.29.0
     peerDependencies:
@@ -4662,6 +4715,28 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==
+  /css-loader/2.1.1/webpack@4.29.5:
+    dependencies:
+      camelcase: 5.3.1
+      icss-utils: 4.1.0
+      loader-utils: 1.2.3
+      normalize-path: 3.0.0
+      postcss: 7.0.14
+      postcss-modules-extract-imports: 2.0.0
+      postcss-modules-local-by-default: 2.0.6
+      postcss-modules-scope: 2.1.0
+      postcss-modules-values: 2.0.0
+      postcss-value-parser: 3.3.1
+      schema-utils: 1.0.0
+      webpack: 4.29.5
+    dev: false
+    engines:
+      node: '>= 6.9.0'
+    id: registry.npmjs.org/css-loader/2.1.1
+    peerDependencies:
+      webpack: ^4.0.0
+    resolution:
+      integrity: sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==
   /css-select-base-adapter/0.1.1:
     dev: false
     resolution:
@@ -6009,6 +6084,19 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==
+  /file-loader/3.0.1/webpack@4.29.5:
+    dependencies:
+      loader-utils: 1.2.3
+      schema-utils: 1.0.0
+      webpack: 4.29.5
+    dev: false
+    engines:
+      node: '>= 6.9.0'
+    id: registry.npmjs.org/file-loader/3.0.1
+    peerDependencies:
+      webpack: ^4.0.0
+    resolution:
+      integrity: sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==
   /file-type/10.7.1:
     dev: false
     engines:
@@ -6935,6 +7023,24 @@ packages:
     dev: false
     engines:
       node: '>=6.9'
+    peerDependencies:
+      webpack: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+    resolution:
+      integrity: sha1-sBq71yOsqqeze2r0SS69oD2d03s=
+  /html-webpack-plugin/3.2.0/webpack@4.29.5:
+    dependencies:
+      html-minifier: 3.5.21
+      loader-utils: 0.2.17
+      lodash: 4.17.11
+      pretty-error: 2.1.1
+      tapable: 1.1.3
+      toposort: 1.0.7
+      util.promisify: 1.0.0
+      webpack: 4.29.5
+    dev: false
+    engines:
+      node: '>=6.9'
+    id: registry.npmjs.org/html-webpack-plugin/3.2.0
     peerDependencies:
       webpack: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
     resolution:
@@ -9644,6 +9750,21 @@ packages:
       marked: ^0.4.0 || ^0.5.0 || ^0.6.0
     resolution:
       integrity: sha512-Yr1yVS0BbDG55vx7be1D0mdv+jGs9AW563o/Tt/7FTsId2J0yqhrTeXAqq/Q0DyyXltIn6CSxzesQuFqXgafjQ==
+  /marked-terminal/3.2.0/marked@0.6.0:
+    dependencies:
+      ansi-escapes: 3.2.0
+      cardinal: 2.1.1
+      chalk: 2.4.2
+      cli-table: 0.3.1
+      marked: 0.6.0
+      node-emoji: 1.8.1
+      supports-hyperlinks: 1.0.1
+    dev: false
+    id: registry.npmjs.org/marked-terminal/3.2.0
+    peerDependencies:
+      marked: ^0.4.0 || ^0.5.0 || ^0.6.0
+    resolution:
+      integrity: sha512-Yr1yVS0BbDG55vx7be1D0mdv+jGs9AW563o/Tt/7FTsId2J0yqhrTeXAqq/Q0DyyXltIn6CSxzesQuFqXgafjQ==
   /marked/0.6.0:
     dev: false
     engines:
@@ -10405,10 +10526,18 @@ packages:
       react-dom: '>=16.3.2-0 <17.0.0'
     resolution:
       integrity: sha512-FbDUIfiy+X9+rYg4r2FWWem2Y9bdiqYDHv+qRY9kW5FYA30mb4VjlByLnJZnm4erKm0i/RCLUWJ5+TP88PgdeA==
-  /office-ui-fabric-react/6.133.0/react-dom@16.7.0:
+  /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0:
     dependencies:
-      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0
-      react-dom: 16.7.0
+      '@microsoft/load-themed-styles': 1.8.56
+      '@uifabric/icons': 6.3.0
+      '@uifabric/merge-styles': 6.15.2
+      '@uifabric/set-version': 1.1.3
+      '@uifabric/styling': 6.41.0
+      '@uifabric/utilities': /@uifabric/utilities/6.29.0/react-dom@16.7.0+react@16.7.0
+      prop-types: 15.6.2
+      react: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
+      tslib: 1.9.3
     dev: false
     id: registry.npmjs.org/office-ui-fabric-react/6.133.0
     peerDependencies:
@@ -11611,6 +11740,7 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.6.2
+      react: 16.7.0
       scheduler: 0.12.0
     dev: false
     id: registry.npmjs.org/react-dom/16.7.0
@@ -13344,6 +13474,27 @@ packages:
       jest: '>=24 <25'
     resolution:
       integrity: sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==
+  /ts-jest/24.0.2/jest@24.7.1:
+    dependencies:
+      bs-logger: 0.2.6
+      buffer-from: 1.1.1
+      fast-json-stable-stringify: 2.0.0
+      jest: 24.7.1
+      json5: 2.1.0
+      make-error: 1.3.5
+      mkdirp: 0.5.1
+      resolve: 1.10.0
+      semver: 5.7.0
+      yargs-parser: 10.1.0
+    dev: false
+    engines:
+      node: '>= 6'
+    hasBin: true
+    id: registry.npmjs.org/ts-jest/24.0.2
+    peerDependencies:
+      jest: '>=24 <25'
+    resolution:
+      integrity: sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==
   /ts-loader/5.3.3:
     dependencies:
       chalk: 2.4.2
@@ -13365,6 +13516,7 @@ packages:
       loader-utils: 1.2.3
       micromatch: 3.1.10
       semver: 5.6.0
+      typescript: 3.4.4
     dev: false
     engines:
       node: '>=6.11.5'
@@ -13826,6 +13978,7 @@ packages:
       loader-utils: 1.2.3
       supports-color: 5.5.0
       v8-compile-cache: 2.0.2
+      webpack: 4.29.5
       yargs: 12.0.5
     dev: false
     engines:
@@ -13846,6 +13999,21 @@ packages:
     dev: false
     engines:
       node: '>= 6'
+    peerDependencies:
+      webpack: ^4.0.0
+    resolution:
+      integrity: sha512-A47I5SX60IkHrMmZUlB0ZKSWi29TZTcPz7cha1Z75yYOsgWh/1AcPmQEbC8ZIbU3A1ytSv1PMU0PyPz2Lmz2jg==
+  /webpack-dev-middleware/3.6.2/webpack@4.29.5:
+    dependencies:
+      memory-fs: 0.4.1
+      mime: 2.4.2
+      range-parser: 1.2.0
+      webpack: 4.29.5
+      webpack-log: 2.0.0
+    dev: false
+    engines:
+      node: '>= 6'
+    id: registry.npmjs.org/webpack-dev-middleware/3.6.2
     peerDependencies:
       webpack: ^4.0.0
     resolution:
@@ -13886,6 +14054,48 @@ packages:
     engines:
       node: '>= 6.11.5'
     hasBin: true
+    peerDependencies:
+      webpack: ^4.0.0
+    resolution:
+      integrity: sha512-jY09LikOyGZrxVTXK0mgIq9y2IhCoJ05848dKZqX1gAGLU1YDqgpOT71+W53JH/wI4v6ky4hm+KvSyW14JEs5A==
+  /webpack-dev-server/3.3.1/webpack@4.29.5:
+    dependencies:
+      ansi-html: 0.0.7
+      bonjour: 3.5.0
+      chokidar: 2.1.5
+      compression: 1.7.4
+      connect-history-api-fallback: 1.6.0
+      debug: 4.1.1
+      del: 4.1.0
+      express: 4.16.4
+      html-entities: 1.2.1
+      http-proxy-middleware: 0.19.1
+      import-local: 2.0.0
+      internal-ip: 4.3.0
+      ip: 1.1.5
+      killable: 1.0.1
+      loglevel: 1.6.1
+      opn: 5.5.0
+      portfinder: 1.0.20
+      schema-utils: 1.0.0
+      selfsigned: 1.10.4
+      semver: 6.0.0
+      serve-index: 1.9.1
+      sockjs: 0.3.19
+      sockjs-client: 1.3.0
+      spdy: 4.0.0
+      strip-ansi: 3.0.1
+      supports-color: 6.1.0
+      url: 0.11.0
+      webpack: 4.29.5
+      webpack-dev-middleware: /webpack-dev-middleware/3.6.2/webpack@4.29.5
+      webpack-log: 2.0.0
+      yargs: 12.0.5
+    dev: false
+    engines:
+      node: '>= 6.11.5'
+    hasBin: true
+    id: registry.npmjs.org/webpack-dev-server/3.3.1
     peerDependencies:
       webpack: ^4.0.0
     resolution:
@@ -14222,15 +14432,15 @@ packages:
       '@types/yargs': 12.0.1
       fs-extra: 7.0.1
       prompts: 2.0.1
-      ts-loader: 5.3.3
+      ts-loader: /ts-loader/5.3.3/typescript@3.4.4
       typescript: 3.4.4
       webpack: 4.29.5
-      webpack-cli: 3.2.1
+      webpack-cli: /webpack-cli/3.2.1/webpack@4.29.5
       yargs: 12.0.5
     dev: false
     name: '@rush-temp/create-just'
     resolution:
-      integrity: sha512-Hvpyf/VlsC4/Q+9iVzKzg9XWbCFlklx33LgaNVllDgCUexqGh0EU0faRTvkltBAYhsBObJRmiqMirbuqQ0EE3A==
+      integrity: sha512-VbaAAqs5s9LVbdxvO3HzrXexu6T6SEYRxmzmbR05jLHaShKFN7+sXxAPdRmU+LMpocpOTeHHr0asNS2melwt/Q==
       tarball: 'file:projects/create-just.tgz'
     version: 0.0.0
   'file:projects/create-uifabric.tgz':
@@ -14250,7 +14460,7 @@ packages:
     dev: false
     name: '@rush-temp/example-lib'
     resolution:
-      integrity: sha512-YZaWWhlwcmV7QAePOY/l8V8rsZPdC1qTPpNZuvpKrCXl0wpYpHKXlXNUOw/OGg5IHTMeKoXjQYbA4HvEu/ja6g==
+      integrity: sha512-HjidHX/f2DC+aLKO7Fb/baKUrF+lMFMViXwNUtmlNThJYFKvbJSrrBUl6rk4mhITczoEOnVe7fHb2CZJUSJ81g==
       tarball: 'file:projects/example-lib.tgz'
     version: 0.0.0
   'file:projects/just-scripts-utils.tgz':
@@ -14274,11 +14484,11 @@ packages:
       jest: 24.7.1
       jju: 1.4.0
       marked: 0.6.0
-      marked-terminal: 3.2.0
+      marked-terminal: /marked-terminal/3.2.0/marked@0.6.0
       mock-fs: 4.8.0
       semver: 5.6.0
       tar: 4.4.8
-      ts-jest: 24.0.2
+      ts-jest: /ts-jest/24.0.2/jest@24.7.1
       typescript: 3.4.4
       yargs: 12.0.5
     dev: false
@@ -14317,7 +14527,7 @@ packages:
     dev: false
     name: '@rush-temp/just-scripts'
     resolution:
-      integrity: sha512-6egyNYIic59x3TqgJHhM8jU7r+deSSQk2iqKZ2GVKFWX8DsZSgycuVvmjHTWVBlGVer1rbRHLkiOvI+Mqff25Q==
+      integrity: sha512-R43UcYvxpvhs19wr+Q4t1Mptv9LYlGrz2UBto69ClmC8i4DkH5LPC7Gp74to5ft0T1ek+FBA289zxm5CzRCSlA==
       tarball: 'file:projects/just-scripts.tgz'
     version: 0.0.0
   'file:projects/just-stack-monorepo.tgz':
@@ -14330,7 +14540,7 @@ packages:
     dev: false
     name: '@rush-temp/just-stack-monorepo'
     resolution:
-      integrity: sha512-8kzOoP1nU26I4aP3sHV3dV2Y5mJ3nuUp5G4/jdNKs+5v3tuic16W4+DYGePhNVwQ7fw9g72JaOR7Y9zgqBG5lQ==
+      integrity: sha512-pa1MPCfPlysCHedQEMaV199BNi4nAcj8X4P7AcAJGjJ70nKZ75u2qB7IZgR6+uyHls/VpYQMfYrwgfZLNDEd8A==
       tarball: 'file:projects/just-stack-monorepo.tgz'
     version: 0.0.0
   'file:projects/just-stack-single-lib.tgz':
@@ -14341,13 +14551,13 @@ packages:
       jest: 24.7.1
       jest-expect-message: 1.0.2
       json5: 2.1.0
-      ts-jest: 24.0.2
+      ts-jest: /ts-jest/24.0.2/jest@24.7.1
       tslib: 1.9.3
       typescript: 3.3.3
     dev: false
     name: '@rush-temp/just-stack-single-lib'
     resolution:
-      integrity: sha512-bZGnCfgSYc2wohEHU0ekrHpBdyRborHTruiUQweO4404GBeZ5G7RLa42gG7pIQ2xq5mz/WZvcpooQPqDGFWmtQ==
+      integrity: sha512-XjAQ+x3sZBgfPDc98EO3IToSONHkM+Et5P6K0k0Dp2lkju0KmoS7F33f/Ec06Oo7LZfQE9ALZ7PXLsaTvRGnUA==
       tarball: 'file:projects/just-stack-single-lib.tgz'
     version: 0.0.0
   'file:projects/just-stack-uifabric.tgz':
@@ -14357,12 +14567,12 @@ packages:
       '@types/react-dom': 16.0.11
       acorn: 6.1.1
       autoprefixer: 9.5.1
-      css-loader: 2.1.1
-      file-loader: 3.0.1
+      css-loader: /css-loader/2.1.1/webpack@4.29.5
+      file-loader: /file-loader/3.0.1/webpack@4.29.5
       fork-ts-checker-webpack-plugin: 1.2.0
       fs-extra: 7.0.1
       glob: 7.1.3
-      html-webpack-plugin: 3.2.0
+      html-webpack-plugin: /html-webpack-plugin/3.2.0/webpack@4.29.5
       jest: 24.7.1
       jest-expect-message: 1.0.2
       json5: 2.1.0
@@ -14370,36 +14580,36 @@ packages:
       postcss: 7.0.14
       postcss-loader: 3.0.0
       style-loader: 0.23.1
-      ts-jest: 24.0.2
-      ts-loader: 5.3.3
+      ts-jest: /ts-jest/24.0.2/jest@24.7.1
+      ts-loader: /ts-loader/5.3.3/typescript@3.4.4
       tslib: 1.9.3
       typescript: 3.4.4
       webpack: 4.29.5
-      webpack-cli: 3.2.1
-      webpack-dev-server: 3.3.1
+      webpack-cli: /webpack-cli/3.2.1/webpack@4.29.5
+      webpack-dev-server: /webpack-dev-server/3.3.1/webpack@4.29.5
     dev: false
     name: '@rush-temp/just-stack-uifabric'
     resolution:
-      integrity: sha512-KzfIh/VLI6IBn0gaH38XsWmOfVeo2UsvCtzR9/+PSjD7/+Mq4ZhL0cTddxisZclYS7GLoaojyl9LO7E/I7AtYw==
+      integrity: sha512-eEmuAVI+ZDZv2eUvpKiA2f8ELgzUTiAZ0Aa/CbCRQrgauQlvtKS6K2M5UusmnqT5UKu2Hp4aviXVLIvM+ggIHA==
       tarball: 'file:projects/just-stack-uifabric.tgz'
     version: 0.0.0
   'file:projects/just-task-docs.tgz':
     dependencies:
       '@babel/core': 7.2.2
-      '@babel/plugin-proposal-class-properties': 7.3.0
-      '@babel/plugin-proposal-object-rest-spread': 7.3.2
+      '@babel/plugin-proposal-class-properties': /@babel/plugin-proposal-class-properties/7.3.0/@babel!core@7.2.2
+      '@babel/plugin-proposal-object-rest-spread': /@babel/plugin-proposal-object-rest-spread/7.3.2/@babel!core@7.2.2
       '@babel/polyfill': 7.2.5
-      '@babel/preset-env': 7.3.1
-      '@babel/preset-react': 7.0.0
-      '@babel/register': 7.0.0
+      '@babel/preset-env': /@babel/preset-env/7.3.1/@babel!core@7.2.2
+      '@babel/preset-react': /@babel/preset-react/7.0.0/@babel!core@7.2.2
+      '@babel/register': /@babel/register/7.0.0/@babel!core@7.2.2
       '@babel/traverse': 7.2.3
       '@babel/types': 7.3.2
-      '@uifabric/experiments': /@uifabric/experiments/6.54.2/react-dom@16.7.0
+      '@uifabric/experiments': /@uifabric/experiments/6.54.2/react-dom@16.7.0+react@16.7.0
       cpx: 1.5.0
       docusaurus: 1.7.2
-      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0
+      office-ui-fabric-react: /office-ui-fabric-react/6.133.0/react-dom@16.7.0+react@16.7.0
       react: 16.7.0
-      react-dom: 16.7.0
+      react-dom: /react-dom/16.7.0/react@16.7.0
     dev: false
     name: '@rush-temp/just-task-docs'
     resolution:
@@ -14414,7 +14624,7 @@ packages:
       chalk: 2.4.2
       jest: 24.7.1
       mock-fs: 4.8.0
-      ts-jest: 24.0.2
+      ts-jest: /ts-jest/24.0.2/jest@24.7.1
       typescript: 3.4.4
       yargs: 12.0.5
     dev: false
@@ -14435,6 +14645,7 @@ packages:
     version: 0.0.0
   'file:projects/just-task.tgz':
     dependencies:
+      '@microsoft/package-deps-hash': 2.2.153
       '@types/jest': 23.3.13
       '@types/mock-fs': 3.6.30
       '@types/node': 10.12.21
@@ -14446,7 +14657,7 @@ packages:
       jest: 24.7.1
       mock-fs: 4.8.0
       resolve: 1.10.0
-      ts-jest: 24.0.2
+      ts-jest: /ts-jest/24.0.2/jest@24.7.1
       typescript: 3.4.4
       undertaker: 1.2.0
       undertaker-registry: 1.0.1
@@ -14454,7 +14665,7 @@ packages:
     dev: false
     name: '@rush-temp/just-task'
     resolution:
-      integrity: sha512-My81CT6VRuwoIcal1fo+ct4cW4/rHOObzhSQBGnhgiwwNoTrfnjRRDJ3ngkR4eXL9VaE6O9BSDMQQI3yQtt90Q==
+      integrity: sha512-kaV92p/weYE2+uUdmnFbQrN8X0ivxTEa56UXDjeOSf87G/Ebb7WdKhQaTnPAXUXkP14Zb6WFQSZiYtkEA1HAew==
       tarball: 'file:projects/just-task.tgz'
     version: 0.0.0
 registry: 'https://registry.npmjs.org/'
@@ -14470,6 +14681,7 @@ specifiers:
   '@babel/register': ^7.0.0
   '@babel/traverse': ^7.0.0
   '@babel/types': ^7.1.2
+  '@microsoft/package-deps-hash': ^2.2.153
   '@rush-temp/create-just': 'file:./projects/create-just.tgz'
   '@rush-temp/create-uifabric': 'file:./projects/create-uifabric.tgz'
   '@rush-temp/example-lib': 'file:./projects/example-lib.tgz'
@@ -14515,7 +14727,6 @@ specifiers:
   handlebars: ^4.0.12
   html-webpack-plugin: ^3.2.0
   jest: ^24.0.0
-  jest-environment-jsdom: ^24.8.0
   jest-expect-message: ^1.0.2
   jju: ^1.4.0
   json5: ^2.1.0

--- a/packages/just-task/package.json
+++ b/packages/just-task/package.json
@@ -2,23 +2,27 @@
   "name": "just-task",
   "version": "0.9.9",
   "description": "Build task definition library",
+  "keywords": [],
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/just"
   },
+  "license": "MIT",
+  "author": "Ken Chau <kchau@microsoft.com>",
   "main": "lib/index.js",
-  "typing": "lib/index.d.ts",
   "bin": {
     "just": "bin/just.js"
   },
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w --preserveWatchOutput",
-    "test": "jest",
-    "start-test": "jest --watch"
+    "start-test": "jest --watch",
+    "test": "jest"
   },
   "dependencies": {
+    "@microsoft/package-deps-hash": "^2.2.153",
     "chalk": "^2.4.1",
+    "fs-extra": "^7.0.1",
     "just-task-logger": ">=0.2.1 <1.0.0",
     "resolve": "^1.8.1",
     "undertaker": "^1.2.0",
@@ -26,6 +30,7 @@
     "yargs": "^12.0.5"
   },
   "devDependencies": {
+    "@types/fs-extra": "^5.0.4",
     "@types/jest": "^23.3.13",
     "@types/mock-fs": "^3.6.30",
     "@types/node": "^10.12.18",
@@ -38,7 +43,5 @@
     "ts-jest": "^24.0.1",
     "typescript": "~3.4.4"
   },
-  "keywords": [],
-  "author": "Ken Chau <kchau@microsoft.com>",
-  "license": "MIT"
+  "typing": "lib/index.d.ts"
 }

--- a/packages/just-task/src/cache.ts
+++ b/packages/just-task/src/cache.ts
@@ -12,8 +12,17 @@ export function registerCachedTask(taskName: string) {
 }
 
 export function isCached(taskName: string) {
+  if (cachedTask.indexOf(taskName) < 0) {
+    return false;
+  }
+
   const currentHash = getHash(taskName);
   const cachePath = getCachePath();
+  const cacheFile = path.join(cachePath, 'package-deps.json');
+
+  if (!fs.existsSync(cacheFile)) {
+    return false;
+  }
 
   if (!fs.pathExistsSync(cachePath)) {
     fs.mkdirpSync(cachePath);
@@ -32,6 +41,10 @@ export function isCached(taskName: string) {
 }
 
 export function saveCache(taskName: string) {
+  if (cachedTask.indexOf(taskName) < 0) {
+    return;
+  }
+
   const cachePath = getCachePath();
 
   if (!fs.pathExistsSync(cachePath)) {

--- a/packages/just-task/src/cache.ts
+++ b/packages/just-task/src/cache.ts
@@ -1,0 +1,59 @@
+import { getPackageDeps } from '@microsoft/package-deps-hash';
+import { argv } from './option';
+import { resolveCwd } from './resolve';
+import fs from 'fs-extra';
+import path from 'path';
+import { logger } from 'just-task-logger';
+
+const cachedTask: string[] = [];
+
+export function registerCachedTask(taskName: string) {
+  cachedTask.push(taskName);
+}
+
+export function isCached(taskName: string) {
+  const currentHash = getHash(taskName);
+  const cachePath = getCachePath();
+
+  if (!fs.pathExistsSync(cachePath)) {
+    fs.mkdirpSync(cachePath);
+  }
+
+  try {
+    const cachedHash = JSON.parse(fs.readFileSync(path.join(cachePath, 'package-deps.json')).toString());
+
+    // TODO: make a more robust comparison
+    return JSON.stringify(currentHash) === JSON.stringify(cachedHash);
+  } catch (e) {
+    logger.warn('Invalid package-deps.json detected');
+  }
+
+  return false;
+}
+
+export function saveCache(taskName: string) {
+  const cachePath = getCachePath();
+
+  if (!fs.pathExistsSync(cachePath)) {
+    fs.mkdirpSync(cachePath);
+  }
+
+  fs.writeFileSync(path.join(cachePath, 'package-deps.json'), JSON.stringify(getHash(taskName)));
+}
+
+function getCachePath() {
+  const packageJsonFilePath = resolveCwd('package.json')!;
+  const rootPath = path.dirname(packageJsonFilePath);
+  return path.join(rootPath, 'node_modules/.just');
+}
+
+function getHash(taskName: string) {
+  const { $0: scriptNameArg, ...args } = argv();
+  const hash = getPackageDeps();
+
+  return {
+    args,
+    taskName,
+    hash
+  };
+}

--- a/packages/just-task/src/cache.ts
+++ b/packages/just-task/src/cache.ts
@@ -91,7 +91,15 @@ function getHash(taskName: string): CacheHash | null {
   const files: typeof hash.files = {};
 
   Object.keys(hash.files).forEach(file => {
-    if (isChildOf(file, cwd) || file.indexOf('shrinkwrap.yml') || file.indexOf('package-lock.json') || file.indexOf('yarn.lock')) {
+    const basename = path.basename(file);
+
+    if (
+      isChildOf(file, cwd) ||
+      basename === 'shrinkwrap.yml' ||
+      basename === 'package-lock.json' ||
+      basename === 'yarn.lock' ||
+      basename === 'pnpmfile.js'
+    ) {
       files[file] = hash.files[file];
     }
   });

--- a/packages/just-task/src/interfaces.ts
+++ b/packages/just-task/src/interfaces.ts
@@ -12,4 +12,5 @@ export interface TaskContext {
 
 export interface TaskFunction extends Undertaker.TaskFunctionParams {
   (this: TaskContext, done: (error?: any) => void): void | Duplex | NodeJS.Process | Promise<never> | any;
+  cached?: () => void;
 }

--- a/packages/just-task/src/undertaker.ts
+++ b/packages/just-task/src/undertaker.ts
@@ -3,6 +3,7 @@ import { logger } from './logger';
 import chalk from 'chalk';
 import { wrapTask } from './wrapTask';
 import { Task } from './interfaces';
+import { clearCache } from './cache';
 
 const undertaker = new Undertaker();
 const NS_PER_SEC = 1e9;
@@ -82,6 +83,9 @@ undertaker.on('error', function(args: any) {
     }
 
     logger.error(chalk.yellow('------------------------------------'));
+
+    clearCache();
+
     process.exitCode = 1;
   } else if (shouldLog(args)) {
     const duration = args.duration;

--- a/packages/just-task/src/wrapTask.ts
+++ b/packages/just-task/src/wrapTask.ts
@@ -1,4 +1,6 @@
-export function wrapTask(fn: any) {
+import { TaskFunction } from './interfaces';
+
+export function wrapTask(fn: any): TaskFunction {
   return function _wrapFunction(done: any) {
     let origFn = fn;
     if (fn.unwrap) {


### PR DESCRIPTION
Adds an API that looks roughly like this:

```tsx
task('build', series('ts', 'test', 'bundle')).cached()
```

What it does:
1. Only top level tasks are cached. That means `just build` caches. If we added `cached()` for `ts` task, but called `just build`, no cache would be used.
2. Uses `@microsoft/package-deps-hash` to calculate input file changes
3. Uses `argv()` (minus the `$0` script name) for another input in hash file

Currently uses `JSON.stringify` to compare hashes, which can be improved with deep equality function. I consider this API to be pretty stable in terms of the API surface, but the functionality is going to be improved upon drastically.