### PR TITLE
Invalidate cache when a dependent or dep of dep package had changed

### DIFF
--- a/change/just-scripts-2019-06-13-14-01-51-cache-tree.json
+++ b/change/just-scripts-2019-06-13-14-01-51-cache-tree.json
@@ -1,0 +1,8 @@
+{
+  "comment": "fixes the running message",
+  "type": "patch",
+  "packageName": "just-scripts",
+  "email": "kchau@microsoft.com",
+  "commit": "fd73fc1618d327e026b8aba49933c11d49c7eba9",
+  "date": "2019-06-13T21:01:47.444Z"
+}

--- a/change/just-task-2019-06-13-14-01-51-cache-tree.json
+++ b/change/just-task-2019-06-13-14-01-51-cache-tree.json
@@ -1,0 +1,8 @@
+{
+  "comment": "adds a bit more rigor to support build deps invalidation of cache",
+  "type": "minor",
+  "packageName": "just-task",
+  "email": "kchau@microsoft.com",
+  "commit": "fd73fc1618d327e026b8aba49933c11d49c7eba9",
+  "date": "2019-06-13T21:01:51.898Z"
+}

--- a/packages/just-scripts/src/tasks/tscTask.ts
+++ b/packages/just-scripts/src/tasks/tscTask.ts
@@ -6,7 +6,6 @@ import fs from 'fs';
 export type TscTaskOptions = { [key in keyof ts.CompilerOptions]?: string | boolean };
 
 export function tscTask(options: TscTaskOptions): TaskFunction {
-  const tsConfigFile = resolveCwd('./tsconfig.json');
   const tscCmd = resolve('typescript/lib/tsc.js');
 
   if (!tscCmd) {
@@ -18,7 +17,7 @@ export function tscTask(options: TscTaskOptions): TaskFunction {
     options = { ...options, ...getProjectOrBuildOptions(options) };
 
     if (isValidProject(options)) {
-      logger.info(`Running ${tscCmd} with ${options.project}`);
+      logger.info(`Running ${tscCmd} with ${options.project || options.build}`);
 
       const args = Object.keys(options).reduce(
         (args, option) => {
@@ -53,7 +52,7 @@ export function tscWatchTask(options: TscTaskOptions): TaskFunction {
 
   return function tscWatch() {
     if (isValidProject(options)) {
-      logger.info(`Running ${tscCmd} with ${options.project} in watch mode`);
+      logger.info(`Running ${tscCmd} with ${options.project || options.build} in watch mode`);
 
       const args = Object.keys(options).reduce(
         (args, option) => {
@@ -78,13 +77,13 @@ export function tscWatchTask(options: TscTaskOptions): TaskFunction {
 }
 
 function getProjectOrBuildOptions(options: TscTaskOptions) {
-  const tsConfigFile = resolveCwd('./tsconfig.json');
+  const tsConfigFile = resolveCwd('./tsconfig.json') || 'tsconfig.json';
   const result: { [option: string]: string | boolean } = {};
 
   if (options.project) {
-    result.project = options && typeof options.project === 'string' ? options.project : tsConfigFile || true;
+    result.project = options && typeof options.project === 'string' ? options.project : tsConfigFile;
   } else if (options.build) {
-    result.build = options && typeof options.build === 'string' ? options.build : tsConfigFile || true;
+    result.build = options && typeof options.build === 'string' ? options.build : tsConfigFile;
   } else if (tsConfigFile) {
     result.project = tsConfigFile;
   }

--- a/packages/just-task/src/package/findDependents.ts
+++ b/packages/just-task/src/package/findDependents.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+import { resolveCwd } from '../resolve';
+import { findPackageRoot } from './findPackageRoot';
+import { logger } from 'just-task-logger';
+
+interface DepInfo {
+  name: string;
+  path: string;
+}
+
+export function findDependents() {
+  return collectAllDependentPaths(findPackageRoot());
+}
+
+function getDepsPaths(pkgPath: string): DepInfo[] {
+  const packageJsonFile = path.join(pkgPath, 'package.json');
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonFile).toString());
+
+    let deps: string[] = [];
+    deps = [
+      ...deps,
+      ...(packageJson.dependencies ? Object.keys(packageJson.dependencies) : []),
+      ...(packageJson.devDependencies ? Object.keys(packageJson.devDependencies) : [])
+    ];
+
+    return deps
+      .map(dep => {
+        const depPackageJson = resolveCwd(path.join(dep, 'package.json'))!;
+        return { name: dep, path: path.dirname(fs.realpathSync(depPackageJson)) };
+      })
+      .filter(p => p.path.indexOf('node_modules') === -1);
+  } catch (e) {
+    logger.error(`Invalid package.json detected at ${packageJsonFile} `, e);
+    return [];
+  }
+}
+
+function collectAllDependentPaths(pkgPath: string, collected: Set<DepInfo> = new Set<DepInfo>()) {
+  let depPaths = getDepsPaths(pkgPath);
+
+  for (let depPath of depPaths) {
+    collectAllDependentPaths(depPath.name, collected);
+  }
+
+  collected = new Set([...depPaths, ...collected]);
+
+  return collected;
+}

--- a/packages/just-task/src/package/findGitRoot.ts
+++ b/packages/just-task/src/package/findGitRoot.ts
@@ -1,0 +1,28 @@
+import path from 'path';
+import fs from 'fs-extra';
+
+let gitRootCache: string = '';
+
+export function findGitRoot() {
+  if (gitRootCache) {
+    return gitRootCache;
+  }
+
+  let cwd = process.cwd();
+  let root = path.parse(cwd).root;
+  let found = false;
+  while (!found && cwd !== root) {
+    if (fs.pathExistsSync(path.join(cwd, '.git'))) {
+      found = true;
+      break;
+    }
+
+    cwd = path.dirname(cwd);
+  }
+
+  if (found) {
+    gitRootCache = path.join(cwd);
+  }
+
+  return gitRootCache;
+}

--- a/packages/just-task/src/package/findPackageRoot.ts
+++ b/packages/just-task/src/package/findPackageRoot.ts
@@ -1,0 +1,7 @@
+import path from 'path';
+import { resolveCwd } from '../resolve';
+
+export function findPackageRoot() {
+  const packageJsonFilePath = resolveCwd('package.json')!;
+  return path.dirname(packageJsonFilePath);
+}


### PR DESCRIPTION
This change adds a bit of info to the "hash" file that respects the dep of dep case.