### PR TITLE
introduce eslint to the repo

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+packages/*/lib
+packages/*/dist
+jest.config.js
+packages/just-stack-monorepo/template/common/scripts

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ packages/*/lib
 packages/*/dist
 jest.config.js
 packages/just-stack-monorepo/template/common/scripts
+packages/example-lib

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ packages/*/dist
 jest.config.js
 packages/just-stack-monorepo/template/common/scripts
 packages/example-lib
+packages/documentation/website/build

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,7 @@
     ],
     "prefer-rest-params": "off",
     "no-useless-escape": "off",
-    "@typescript-eslint/indent": ["error", 2],
+    "@typescript-eslint/indent": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,9 +32,7 @@
     "@typescript-eslint/no-object-literal-type-assertion": "off",
     "@typescript-eslint/array-type": "off",
     "@typescript-eslint/no-var-requires": "off",
-    "@typescript-eslint/no-unused-vars": ["error", {
-      "argsIgnorePattern": "^_"
-    }]
+    "@typescript-eslint/no-unused-vars": "off"
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,48 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "indent": "off",
+    "no-unused-vars": "off",
+    "quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true,
+        "allowTemplateLiterals": true
+      }
+    ],
+    "@typescript-eslint/indent": ["error", 2],
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-use-before-define": "off"
+  },
+  "overrides": [
+    {
+      "files": "*.js",
+      "parserOptions": {
+        "sourceType": "script"
+      },
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off"
+      }
+    },
+    {
+      "files": "*.spec.js",
+      "env": {
+        "jest": true
+      }
+    }
+  ]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     ],
     "prefer-rest-params": "off",
     "no-useless-escape": "off",
+    "require-atomic-updates": "off",
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-function-return-type": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,25 +23,36 @@
         "allowTemplateLiterals": true
       }
     ],
+    "prefer-rest-params": "off",
+    "no-useless-escape": "off",
     "@typescript-eslint/indent": ["error", 2],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-use-before-define": "off"
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/no-object-literal-type-assertion": "off",
+    "@typescript-eslint/array-type": "off",
+    "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/no-unused-vars": ["error", {
+      "argsIgnorePattern": "^_"
+    }]
   },
   "overrides": [
     {
       "files": "*.js",
       "parserOptions": {
         "sourceType": "script"
-      },
-      "rules": {
-        "@typescript-eslint/no-var-requires": "off"
       }
     },
     {
       "files": "*.spec.js",
       "env": {
         "jest": true
+      }
+    },
+    {
+      "files": "*.spec.{ts,js}",
+      "rules": {
+        "@typescript-eslint/no-non-null-assertion": "off"
       }
     }
   ]

--- a/change/create-just-2019-06-30-21-03-35-eslint.json
+++ b/change/create-just-2019-06-30-21-03-35-eslint.json
@@ -1,0 +1,8 @@
+{
+  "comment": "introduce ESLint to sources",
+  "type": "none",
+  "packageName": "create-just",
+  "email": "43081j@users.noreply.github.com",
+  "commit": "19211c379e02315b1e6b542544ab5e424148b162",
+  "date": "2019-06-30T21:00:45.880Z"
+}

--- a/change/just-scripts-2019-06-30-21-03-35-eslint.json
+++ b/change/just-scripts-2019-06-30-21-03-35-eslint.json
@@ -1,0 +1,8 @@
+{
+  "comment": "introduce ESLint to sources",
+  "type": "patch",
+  "packageName": "just-scripts",
+  "email": "43081j@users.noreply.github.com",
+  "commit": "19211c379e02315b1e6b542544ab5e424148b162",
+  "date": "2019-06-30T21:02:26.758Z"
+}

--- a/change/just-scripts-utils-2019-06-30-21-03-35-eslint.json
+++ b/change/just-scripts-utils-2019-06-30-21-03-35-eslint.json
@@ -1,0 +1,8 @@
+{
+  "comment": "introduce ESLint to sources",
+  "type": "patch",
+  "packageName": "just-scripts-utils",
+  "email": "43081j@users.noreply.github.com",
+  "commit": "19211c379e02315b1e6b542544ab5e424148b162",
+  "date": "2019-06-30T21:01:37.155Z"
+}

--- a/change/just-task-2019-06-30-21-03-35-eslint.json
+++ b/change/just-task-2019-06-30-21-03-35-eslint.json
@@ -1,0 +1,8 @@
+{
+  "comment": "introduce ESLint to sources",
+  "type": "patch",
+  "packageName": "just-task",
+  "email": "43081j@users.noreply.github.com",
+  "commit": "19211c379e02315b1e6b542544ab5e424148b162",
+  "date": "2019-06-30T21:03:35.508Z"
+}

--- a/change/just-task-logger-2019-06-30-21-03-35-eslint.json
+++ b/change/just-task-logger-2019-06-30-21-03-35-eslint.json
@@ -1,0 +1,8 @@
+{
+  "comment": "introduce ESLint to sources",
+  "type": "none",
+  "packageName": "just-task-logger",
+  "email": "43081j@users.noreply.github.com",
+  "commit": "19211c379e02315b1e6b542544ab5e424148b162",
+  "date": "2019-06-30T21:02:39.858Z"
+}

--- a/disabled/just-scenario-tests/tsconfig.json
+++ b/disabled/just-scenario-tests/tsconfig.json
@@ -1,13 +1,7 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
-    "module": "commonjs",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "lib",
-    "strict": true,
-    "strictBindCallApply": false,
-    "esModuleInterop": true
+    "outDir": "lib"
   },
   "include": ["src"]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "checkchange": "beachball check",
     "publish:beachball": "beachball publish",
     "start": "node ./scripts/watch.js",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "lint": "eslint packages --ext .ts,.js"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,11 @@
     "test": "lerna run test"
   },
   "devDependencies": {
-    "lerna": "^3.13.2",
-    "beachball": "^1.6.4"
+    "@typescript-eslint/eslint-plugin": "^1.11.0",
+    "@typescript-eslint/parser": "^1.11.0",
+    "beachball": "^1.6.4",
+    "eslint": "^6.0.1",
+    "lerna": "^3.13.2"
   },
   "workspaces": {
     "packages": [

--- a/packages/create-just/src/commands/initCommand.ts
+++ b/packages/create-just/src/commands/initCommand.ts
@@ -42,15 +42,16 @@ export async function initCommand(argv: yargs.Arguments) {
     argv.stack = stack;
   }
 
-  let name: string = '';
+  let name = '';
   if (!argv.name && !checkEmptyRepo(paths.projectPath)) {
-    let response = await prompts({
+    const response = await prompts({
       type: 'text',
       name: 'name',
       message: 'What is the name of the repo to create?',
       validate: (name) => !name ? false : true
     });
     name = response.name;
+    // eslint-disable-next-line require-atomic-updates
     paths.projectPath = path.join(paths.projectPath, name);
   } else if (!argv.name) {
     name = path.basename(paths.projectPath);

--- a/packages/create-just/src/commands/initCommand.ts
+++ b/packages/create-just/src/commands/initCommand.ts
@@ -51,7 +51,6 @@ export async function initCommand(argv: yargs.Arguments) {
       validate: (name) => !name ? false : true
     });
     name = response.name;
-    // eslint-disable-next-line require-atomic-updates
     paths.projectPath = path.join(paths.projectPath, name);
   } else if (!argv.name) {
     name = path.basename(paths.projectPath);

--- a/packages/create-just/tsconfig.json
+++ b/packages/create-just/tsconfig.json
@@ -1,11 +1,7 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "outDir": "lib",
-    "strict": true,
-    "esModuleInterop": true
+    "outDir": "lib"
   },
   "include": ["src/index.ts"]
 }

--- a/packages/documentation/.eslintrc.json
+++ b/packages/documentation/.eslintrc.json
@@ -3,8 +3,5 @@
     "ecmaFeatures": {
       "jsx": true
     }
-  },
-  "rules": {
-    "@typescript-eslint/no-unused-vars": "off"
   }
 }

--- a/packages/documentation/.eslintrc.json
+++ b/packages/documentation/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "rules": {
+    "@typescript-eslint/no-unused-vars": "off"
+  }
+}

--- a/packages/just-scripts-utils/src/__tests__/downloadPackage.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/downloadPackage.spec.ts
@@ -1,7 +1,8 @@
+/*eslint @typescript-eslint/camelcase: ["error", {allow: ["child_process"]}]*/
 import mockfs from 'mock-fs';
 import fs from 'fs';
 import path from 'path';
-import child_process, { SpawnSyncOptions } from 'child_process';
+import child_process from 'child_process';
 import tar from 'tar';
 import { paths } from '../paths';
 import { logger } from '../logger';

--- a/packages/just-scripts-utils/src/__tests__/downloadPackage.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/downloadPackage.spec.ts
@@ -82,7 +82,7 @@ describe('downloadPackage', () => {
     });
     // cause npm pack to "error"
     jest.spyOn(child_process, 'spawnSync').mockImplementationOnce(
-      (cmd: string, args?: readonly string[]): ReturnType<typeof child_process.spawnSync> => {
+      (_cmd: string, args?: readonly string[]): ReturnType<typeof child_process.spawnSync> => {
         expect(args).toContain(`${pkg}@latest`);
         return { error: new Error('fail'), pid: 100, output: [], signal: '', status: 1, stderr: Buffer.from(''), stdout: Buffer.from('') };
       }
@@ -112,7 +112,7 @@ describe('downloadPackage', () => {
     });
 
     // fake the result of npm pack
-    jest.spyOn(child_process, 'spawnSync').mockImplementationOnce((cmd: string, args?: readonly string[]) => {
+    jest.spyOn(child_process, 'spawnSync').mockImplementationOnce((_cmd: string, args?: readonly string[]) => {
       expect(args).toContain(`${pkg}@${version}`);
       // instead of downloading a tarball, create one in the expected spot
       tar.create({ sync: true, gzip: true, file: path.join(fakeTemp, pkg, 'result.tgz') }, [pkg]);

--- a/packages/just-scripts-utils/src/__tests__/exec.spec.ts
+++ b/packages/just-scripts-utils/src/__tests__/exec.spec.ts
@@ -25,7 +25,7 @@ describe('exec', () => {
   const stderrPipe = jest.fn();
   beforeAll(() => {
     jest.spyOn(cp, 'exec').mockImplementation(
-      (cmd: string, opts: any, callback: any): cp.ChildProcess => {
+      (_cmd: string, _opts: any, callback: any): cp.ChildProcess => {
         setTimeout(() => {
           callback(...execResult!);
         }, 0);

--- a/packages/just-scripts-utils/src/downloadPackage.ts
+++ b/packages/just-scripts-utils/src/downloadPackage.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import { readPackageJson } from './readPackageJson';
 import { logger } from './logger';
 
-let dirname: string = '';
+let dirname = '';
 /** For testing purposes only. */
 export function _setMockDirname(dir: string): void {
   dirname = dir;

--- a/packages/just-scripts-utils/src/findMonoRepoRootPath.ts
+++ b/packages/just-scripts-utils/src/findMonoRepoRootPath.ts
@@ -12,12 +12,11 @@ import { readPackageJson } from './readPackageJson';
  */
 export function findMonoRepoRootPath(): string | null {
   const { projectPath } = paths;
-  let found = false;
   let currentPath = projectPath;
 
   const { root } = path.parse(projectPath);
 
-  while (!found && currentPath !== root) {
+  while (currentPath !== root) {
     const rushConfigFile = path.join(currentPath, 'rush.json');
 
     // Determine the monorepo by either presence of rush.json or package.json that has a just.stack of just-stack-monorepo

--- a/packages/just-scripts-utils/src/paths.ts
+++ b/packages/just-scripts-utils/src/paths.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import os from 'os';
 
-let projectPath: string = '';
+let projectPath = '';
 
 export const paths = {
   /**

--- a/packages/just-scripts-utils/src/readPackageJson.ts
+++ b/packages/just-scripts-utils/src/readPackageJson.ts
@@ -12,4 +12,5 @@ export function readPackageJson(folderPath: string): PackageJson | undefined {
   if (fse.existsSync(packageJsonPath)) {
     return fse.readJsonSync(packageJsonPath, { throws: false }) || undefined;
   }
+  return undefined;
 }

--- a/packages/just-scripts-utils/src/rush.ts
+++ b/packages/just-scripts-utils/src/rush.ts
@@ -24,6 +24,7 @@ export function rushUpdate(cwd: string): void {
 export function readRushJson(rootPath: string): RushJson | undefined {
   const rushJsonPath = path.join(rootPath, 'rush.json');
   const contents = _justReadRushJson(rushJsonPath);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return _parseRushJson(contents!);
 }
 
@@ -34,6 +35,7 @@ export function readRushJson(rootPath: string): RushJson | undefined {
  */
 export function rushAddPackage(packageName: string, rootPath: string): void {
   const rushJsonPath = path.join(rootPath, 'rush.json');
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const oldContents = _justReadRushJson(rushJsonPath)!;
   const rushJson = _parseRushJson(oldContents);
   if (!rushJson) {

--- a/packages/just-scripts-utils/tsconfig.json
+++ b/packages/just-scripts-utils/tsconfig.json
@@ -1,14 +1,7 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "lib",
-    "strict": true,
-    "strictBindCallApply": false,
-    "esModuleInterop": true
+    "outDir": "lib"
   },
   "include": ["src"]
 }

--- a/packages/just-scripts/src/monorepo/findInstalledStacks.ts
+++ b/packages/just-scripts/src/monorepo/findInstalledStacks.ts
@@ -14,8 +14,10 @@ export function findInstalledStacks(rootPath: string) {
     .map(stack => [stack, path.join(scriptsPath, 'node_modules', stack)]);
 
   return stacks.map<StackInfo>(([stack, stackPath]) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const packageJson = readPackageJson(stackPath)!; // already checked existence above
     return {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       description: packageJson.description!,
       name: stack,
       version: packageJson.version,

--- a/packages/just-scripts/src/stack/DiffInfo.ts
+++ b/packages/just-scripts/src/stack/DiffInfo.ts
@@ -1,3 +1,4 @@
+/*eslint @typescript-eslint/camelcase: ["error", {allow: ["patch_obj"]}]*/
 import { patch_obj } from 'diff-match-patch';
 
 export interface DiffInfo {

--- a/packages/just-scripts/src/stack/getAvailableStacks.ts
+++ b/packages/just-scripts/src/stack/getAvailableStacks.ts
@@ -8,10 +8,11 @@ export function getAvailableStacks(rootPath: string) {
     throw new Error(`not able to read package.json from ${rootPath}`);
   }
 
-  let stackDeps: { [key: string]: string } = {};
+  const stackDeps: { [key: string]: string } = {};
 
   const devDeps = packageJson.devDependencies || {};
   Object.keys(devDeps).forEach(dep => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const depPackageJson = readPackageJson(path.join(rootPath, 'node_modules', dep))!;
     if (dep.includes('just-stack') || (depPackageJson && depPackageJson.keywords && depPackageJson.keywords.includes('just-stack'))) {
       stackDeps[dep] = devDeps[dep];

--- a/packages/just-scripts/src/stack/getStackDiffs.ts
+++ b/packages/just-scripts/src/stack/getStackDiffs.ts
@@ -17,7 +17,9 @@ export async function getSingleStackDiffs(stack: string, fromVersion: string, to
     toVersion
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const fromPath = packagePaths[0]!;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const toPath = packagePaths[1]!;
   const globbedFiles = glob.sync('**/*', { cwd: toPath, nodir: true, dot: true });
   const dmp = new DiffMatchPatch();

--- a/packages/just-scripts/src/task-presets/lib.ts
+++ b/packages/just-scripts/src/task-presets/lib.ts
@@ -1,4 +1,4 @@
-import { task, series, parallel, chain } from 'just-task';
+import { task, series, parallel } from 'just-task';
 import { cleanTask, tscTask, jestTask, upgradeStackTask, defaultCleanPaths } from '../tasks';
 
 export function lib() {

--- a/packages/just-scripts/src/tasks/addPackageTask.ts
+++ b/packages/just-scripts/src/tasks/addPackageTask.ts
@@ -36,15 +36,16 @@ export function addPackageTask(): TaskFunction {
     // TODO: do validation that the path is indeed a monorepo
     const installedStacks = findInstalledStacks(rootPath);
 
-    let response = args.stack
+    const response = args.stack
       ? { stack: args.stack }
       : await prompts({
-          type: 'select',
-          name: 'stack',
-          message: 'What type of package to add to the repo?',
-          choices: installedStacks.map(stack => ({ title: stack.description, value: stack.name }))
-        });
+        type: 'select',
+        name: 'stack',
+        message: 'What type of package to add to the repo?',
+        choices: installedStacks.map(stack => ({ title: stack.description, value: stack.name }))
+      });
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const selectedStack = installedStacks.find(stack => stack.name === response.stack)!;
 
     if (!selectedStack) {

--- a/packages/just-scripts/src/tasks/apiExtractorTask.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTask.ts
@@ -1,6 +1,5 @@
-import { logger, TaskFunction, resolveCwd } from 'just-task';
+import { logger, TaskFunction } from 'just-task';
 import { tryRequire } from '../tryRequire';
-import { fstat } from 'fs';
 
 /** Subset of the options from IExtractorConfigOptions that are exposed via this just task */
 interface ApiExtractorOptions {

--- a/packages/just-scripts/src/tasks/cleanTask.ts
+++ b/packages/just-scripts/src/tasks/cleanTask.ts
@@ -48,6 +48,7 @@ export function cleanTask(pathsOrOptions: string[] | CleanTaskOptions = {}, limi
         cb(null);
       });
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     parallelLimit(cleanTasks, limit!, done);
   };
 }

--- a/packages/just-scripts/src/tasks/copyTask.ts
+++ b/packages/just-scripts/src/tasks/copyTask.ts
@@ -16,6 +16,7 @@ export interface CopyTaskOptions {
   limit?: number;
 }
 
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 export function copyTask(options: CopyTaskOptions): TaskFunction;
 /** @deprecated Use object param version */
 export function copyTask(paths: string[] | undefined, dest: string, limit?: number): TaskFunction;
@@ -72,6 +73,7 @@ export function copyTask(optionsOrPaths: CopyTaskOptions | string[] | undefined,
     parallelLimit(copyTasks, limit!, done);
   };
 }
+/* eslint-enable @typescript-eslint/no-non-null-assertion */
 
 function getBasePath(pattern: string) {
   const parts = path.resolve(pattern).split(/[\/\\]/g);

--- a/packages/just-scripts/src/tasks/sassTask.ts
+++ b/packages/just-scripts/src/tasks/sassTask.ts
@@ -60,6 +60,7 @@ export function sassTask(
                 } else {
                   const css = result.css.toString();
 
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                   postcss([autoprefixerFn, ...postcssPlugins!])
                     .process(css, { from: fileName })
                     .then((result: { css: string }) => {
@@ -84,7 +85,7 @@ function requireResolvePackageUrl(packageUrl: string) {
   return resolveCwd(fullName) || resolveCwd(path.join(path.dirname(fullName), `_${path.basename(fullName)}`));
 }
 
-function patchSassUrl(url: string, prev: string, done: any) {
+function patchSassUrl(url: string, _prev: string, _done: any) {
   let newUrl: string = url;
 
   if (url[0] === '~') {

--- a/packages/just-scripts/src/tasks/tscTask.ts
+++ b/packages/just-scripts/src/tasks/tscTask.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import { resolve, logger, resolveCwd, TaskFunction, option } from 'just-task';
+import { resolve, logger, resolveCwd, TaskFunction } from 'just-task';
 import { exec, encodeArgs, spawn } from 'just-scripts-utils';
 import fs from 'fs';
 

--- a/packages/just-scripts/src/tasks/tscTask.ts
+++ b/packages/just-scripts/src/tasks/tscTask.ts
@@ -38,6 +38,8 @@ export function tscTask(options: TscTaskOptions): TaskFunction {
     } else {
       Promise.resolve();
     }
+
+    return;
   };
 }
 
@@ -73,6 +75,8 @@ export function tscWatchTask(options: TscTaskOptions): TaskFunction {
     } else {
       Promise.resolve();
     }
+
+    return;
   };
 }
 

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -76,6 +76,8 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
     } else {
       logger.info('webpack.config.js not found, skipping webpack');
     }
+
+    return;
   };
 }
 

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -5,16 +5,13 @@ import webpackMerge from 'webpack-merge';
 import { Configuration } from 'webpack';
 import { tryRequire } from '../tryRequire';
 
-export interface WebpackTaskOptions {
+export interface WebpackTaskOptions extends Configuration {
   config?: string;
 
   /** true to output to stats.json; a string to output to a file */
   outputStats?: boolean | string;
 
   mode?: 'production' | 'development';
-
-  // can contain other config values which are passed on to webpack
-  [key: string]: any;
 }
 
 export function webpackTask(options?: WebpackTaskOptions): TaskFunction {

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -2,6 +2,7 @@ import { logger, argv, resolve, resolveCwd, TaskFunction } from 'just-task';
 import fs from 'fs';
 import { encodeArgs, spawn } from 'just-scripts-utils';
 import webpackMerge from 'webpack-merge';
+import { Configuration } from 'webpack';
 import { tryRequire } from '../tryRequire';
 
 export interface WebpackTaskOptions {
@@ -38,7 +39,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
 
           const configLoader = require(webpackConfigPath);
 
-          let webpackConfigs;
+          let webpackConfigs: Configuration[];
 
           // If the loaded webpack config is a function
           // call it with the original process.argv arguments from build.js.
@@ -52,7 +53,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
             webpackConfigs = [webpackConfigs];
           }
 
-          const { ...restConfig } = options || { config: null };
+          const { ...restConfig } = options || {};
           webpackConfigs = webpackConfigs.map(webpackConfig => webpackMerge(webpackConfig, restConfig));
 
           wp(webpackConfigs, (err: Error, stats: any) => {

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -52,7 +52,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
             webpackConfigs = [webpackConfigs];
           }
 
-          const { config, ...restConfig } = options || { config: null };
+          const { ...restConfig } = options || { config: null };
           webpackConfigs = webpackConfigs.map(webpackConfig => webpackMerge(webpackConfig, restConfig));
 
           wp(webpackConfigs, (err: Error, stats: any) => {
@@ -62,7 +62,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
             }
 
             if (err || stats.hasErrors()) {
-              let errorStats = stats.toJson('errors-only');
+              const errorStats = stats.toJson('errors-only');
               errorStats.errors.forEach((error: any) => {
                 logger.error(error);
               });

--- a/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/indent */
 import { resolve } from 'just-task';
 import { tryRequire } from '../../tryRequire';
 

--- a/packages/just-scripts/tsconfig.json
+++ b/packages/just-scripts/tsconfig.json
@@ -1,13 +1,7 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "declaration": true,
     "outDir": "lib",
-    "strict": true,
-    "strictBindCallApply": false,
-    "esModuleInterop": true,
     "sourceMap": true
   },
   "include": ["src", "typings/*.d.ts"]

--- a/packages/just-scripts/typings/npm-registry-fetch.d.ts
+++ b/packages/just-scripts/typings/npm-registry-fetch.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
 // TODO: fill out the typing for this
 declare module 'npm-registry-fetch' {
   interface Options {}

--- a/packages/just-task-logger/tsconfig.json
+++ b/packages/just-task-logger/tsconfig.json
@@ -1,14 +1,7 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "lib",
-    "strict": true,
-    "strictBindCallApply": false,
-    "esModuleInterop": true
+    "outDir": "lib"
   },
   "include": ["src"]
 }

--- a/packages/just-task/example/just-task.fail.js
+++ b/packages/just-task/example/just-task.fail.js
@@ -17,9 +17,7 @@ module.exports = () => {
   });
 
   task('webpack', () => {
-    const someVar = Math.random();
-
-    return function(done) {
+    return function() {
       return new Promise((resolve, reject) => {
         cp.exec('node ./longprocess.js', (error, stdout, stderr) => (error ? reject(stderr) : resolve(stdout)));
       });

--- a/packages/just-task/example/just-task.js
+++ b/packages/just-task/example/just-task.js
@@ -29,7 +29,7 @@ module.exports = () => {
   task('webpack:promise', () => {
     const someVar = Math.random();
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       logger.info('Webpack bundling files', someVar);
       setTimeout(() => {
         resolve();

--- a/packages/just-task/src/JustTaskRegistry.ts
+++ b/packages/just-task/src/JustTaskRegistry.ts
@@ -9,11 +9,11 @@ import { resolve } from './resolve';
 export class JustTaskRegistry extends UndertakerRegistry {
   private hasDefault: boolean = false;
 
-  init(taker: Undertaker) {
+  public init(taker: Undertaker) {
     super.init(taker);
 
     // uses a separate instance of yargs to first parse the config (without the --help in the way) so we can parse the configFile first regardless
-    let configFile = [yargs.argv.config, './just.config.js', './just-task.js'].reduce((value, entry) => value || resolve(entry));
+    const configFile = [yargs.argv.config, './just.config.js', './just-task.js'].reduce((value, entry) => value || resolve(entry));
 
     if (configFile && fs.existsSync(configFile)) {
       try {
@@ -41,7 +41,7 @@ export class JustTaskRegistry extends UndertakerRegistry {
     }
   }
 
-  set<TTaskFunction>(taskName: string, fn: TTaskFunction): TTaskFunction {
+  public set<TTaskFunction>(taskName: string, fn: TTaskFunction): TTaskFunction {
     super.set(taskName, fn);
 
     if (taskName === 'default') {

--- a/packages/just-task/src/__tests__/resolve.spec.ts
+++ b/packages/just-task/src/__tests__/resolve.spec.ts
@@ -63,8 +63,10 @@ describe('_tryResolve', () => {
     mockfs({
       a: {
         'b.js': '', // wrong
+        // eslint-disable-next-line @typescript-eslint/camelcase
         node_modules: { 'b.js': '' } // right
       },
+      // eslint-disable-next-line @typescript-eslint/camelcase
       node_modules: { 'b.js': '' } // wrong
     });
     expect(_tryResolve('b', 'a')).toContain('a/node_modules/b.js');
@@ -72,6 +74,7 @@ describe('_tryResolve', () => {
 
   it('resolves path with /', () => {
     mockfs({
+      // eslint-disable-next-line @typescript-eslint/camelcase
       a: { node_modules: { b: { 'c.js': '' } } }
     });
     expect(_tryResolve('b/c', 'a')).toContain('a/node_modules/b/c.js');

--- a/packages/just-task/src/__tests__/task.spec.ts
+++ b/packages/just-task/src/__tests__/task.spec.ts
@@ -1,5 +1,5 @@
 import { task } from '../task';
-import { parallel, undertaker, series } from '../undertaker';
+import { parallel, undertaker } from '../undertaker';
 import { JustTaskRegistry } from '../JustTaskRegistry';
 import { logger } from '../logger';
 import yargsMock from './__mocks__/yargs';
@@ -51,7 +51,7 @@ describe('task', () => {
     const testFunction = jest.fn(() => {});
 
     task('test', function() {
-      let result = testFunction();
+      const result = testFunction();
       return Promise.resolve(result);
     });
 

--- a/packages/just-task/src/cache.ts
+++ b/packages/just-task/src/cache.ts
@@ -36,7 +36,7 @@ export function isCached(taskName: string) {
     return false;
   }
 
-  let shouldCache: boolean = false;
+  let shouldCache = false;
 
   try {
     const cachedHash = JSON.parse(fs.readFileSync(path.join(cachePath, CacheFileName)).toString());
@@ -69,6 +69,7 @@ export function saveCache(taskName: string) {
 }
 
 function getCachePath() {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const packageJsonFilePath = resolveCwd('package.json')!;
   const rootPath = path.dirname(packageJsonFilePath);
   return path.join(rootPath, 'node_modules/.just');
@@ -82,7 +83,7 @@ interface CacheHash {
 }
 
 function getHash(taskName: string): CacheHash | null {
-  const { $0: scriptNameArg, ...args } = argv();
+  const { ...args } = argv();
 
   const gitRoot = findGitRoot();
 

--- a/packages/just-task/src/cli.ts
+++ b/packages/just-task/src/cli.ts
@@ -4,7 +4,7 @@ import yargs from 'yargs';
 
 const originalEmitWarning = process.emitWarning;
 
-(process.emitWarning as any) = function emitWarning(this: any, warning: string, type: string, code: string, _ctor?: Function) {
+(process.emitWarning as any) = function emitWarning(this: any, _warning: string, _type: string, code: string, _ctor?: Function) {
   if (code === 'DEP0097') {
     // Undertaker uses a deprecated approach that causes NodeJS 10 to print
     // this warning to stderr:

--- a/packages/just-task/src/cli.ts
+++ b/packages/just-task/src/cli.ts
@@ -4,7 +4,7 @@ import yargs from 'yargs';
 
 const originalEmitWarning = process.emitWarning;
 
-(process.emitWarning as any) = function emitWarning(this: any, warning: string, type: string, code: string, ctor?: Function) {
+(process.emitWarning as any) = function emitWarning(this: any, warning: string, type: string, code: string, _ctor?: Function) {
   if (code === 'DEP0097') {
     // Undertaker uses a deprecated approach that causes NodeJS 10 to print
     // this warning to stderr:

--- a/packages/just-task/src/package/findDependents.ts
+++ b/packages/just-task/src/package/findDependents.ts
@@ -28,6 +28,7 @@ function getDepsPaths(pkgPath: string): DepInfo[] {
 
     return deps
       .map(dep => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const depPackageJson = resolveCwd(path.join(dep, 'package.json'))!;
 
         if (!depPackageJson) {
@@ -44,9 +45,9 @@ function getDepsPaths(pkgPath: string): DepInfo[] {
 }
 
 function collectAllDependentPaths(pkgPath: string, collected: Set<DepInfo> = new Set<DepInfo>()) {
-  let depPaths = getDepsPaths(pkgPath);
+  const depPaths = getDepsPaths(pkgPath);
 
-  for (let depPath of depPaths) {
+  for (const depPath of depPaths) {
     collectAllDependentPaths(depPath.path, collected);
   }
 

--- a/packages/just-task/src/package/findGitRoot.ts
+++ b/packages/just-task/src/package/findGitRoot.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs-extra';
 
-let gitRootCache: string = '';
+let gitRootCache = '';
 
 export function findGitRoot() {
   if (gitRootCache) {
@@ -9,7 +9,7 @@ export function findGitRoot() {
   }
 
   let cwd = process.cwd();
-  let root = path.parse(cwd).root;
+  const root = path.parse(cwd).root;
   let found = false;
   while (!found && cwd !== root) {
     if (fs.pathExistsSync(path.join(cwd, '.git'))) {

--- a/packages/just-task/src/package/findPackageRoot.ts
+++ b/packages/just-task/src/package/findPackageRoot.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { resolveCwd } from '../resolve';
 
 export function findPackageRoot() {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const packageJsonFilePath = resolveCwd('package.json')!;
   return path.dirname(packageJsonFilePath);
 }

--- a/packages/just-task/src/resolve.ts
+++ b/packages/just-task/src/resolve.ts
@@ -68,7 +68,7 @@ export function resolve(moduleName: string, cwd?: string): string | null {
   const allResolvePaths = [cwd, ...(configFilePath ? [configFilePath] : []), ...resolvePaths];
   let resolved: string | null = null;
 
-  for (let tryPath of allResolvePaths) {
+  for (const tryPath of allResolvePaths) {
     resolved = _tryResolve(moduleName, tryPath);
     if (resolved) {
       return resolved;

--- a/packages/just-task/src/task.ts
+++ b/packages/just-task/src/task.ts
@@ -61,7 +61,7 @@ function getCommandModule(taskName: string, describe?: string): yargs.CommandMod
     command: taskName,
     describe,
     ...(taskName === 'default' ? { aliases: ['*'] } : {}),
-    handler(argvParam: any) {
+    handler(_argvParam: any) {
       if (isCached(taskName)) {
         logger.info(`Skipped ${taskName} since it was cached`);
         return;

--- a/packages/just-task/src/undertaker.ts
+++ b/packages/just-task/src/undertaker.ts
@@ -9,8 +9,8 @@ const undertaker = new Undertaker();
 const NS_PER_SEC = 1e9;
 
 let topLevelTask: string | undefined = undefined;
-let errorReported: boolean = false;
-let tasksInProgress: { [key: string]: boolean } = {};
+let errorReported = false;
+const tasksInProgress: { [key: string]: boolean } = {};
 
 const colors = [chalk.cyanBright, chalk.magentaBright, chalk.blueBright, chalk.greenBright, chalk.yellowBright];
 const taskColor: { [taskName: string]: number } = {};

--- a/packages/just-task/src/wrapTask.ts
+++ b/packages/just-task/src/wrapTask.ts
@@ -10,7 +10,7 @@ export function wrapTask(fn: any): TaskFunction {
     if (origFn.length > 0) {
       (fn as any).call(null, done);
     } else {
-      let results = (origFn as any).call();
+      const results = (origFn as any).call();
 
       // The result is a function, we will assume that this is a task function to be called
       if (results && typeof results === 'function') {

--- a/packages/just-task/tsconfig.json
+++ b/packages/just-task/tsconfig.json
@@ -1,13 +1,7 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
-    "module": "commonjs",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "lib",
-    "strict": true,
-    "strictBindCallApply": false,
-    "esModuleInterop": true
+    "outDir": "lib"
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "strict": true,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1751,6 +1751,11 @@
   resolved "https://registry.yarnpkg.com/@types/diff-match-patch/-/diff-match-patch-1.0.32.tgz#d9c3b8c914aa8229485351db4865328337a3d09f"
   integrity sha512-bPYT5ECFiblzsVzyURaNhljBH2Gh1t9LowgUwciMrNAhFewLkHT2H0Mto07Y4/3KCOGZHRQll3CTtQZ0X11D/A==
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -1946,6 +1951,43 @@
   version "12.0.12"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
   integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
+
+"@typescript-eslint/eslint-plugin@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.11.0.tgz#870f752c520db04db6d3668af7479026a6f2fb9a"
+  integrity sha512-mXv9ccCou89C8/4avKHuPB2WkSZyY/XcTQUXd5LFZAcLw1I3mWYVjUu6eS9Ja0QkP/ClolbcW9tb3Ov/pMdcqw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "1.11.0"
+    eslint-utils "^1.3.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^2.0.1"
+    tsutils "^3.7.0"
+
+"@typescript-eslint/experimental-utils@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.11.0.tgz#594abe47091cbeabac1d6f9cfed06d0ad99eb7e3"
+  integrity sha512-7LbfaqF6B8oa8cp/315zxKk8FFzosRzzhF8Kn/ZRsRsnpm7Qcu25cR/9RnAQo5utZ2KIWVgaALr+ZmcbG47ruw==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "1.11.0"
+    eslint-scope "^4.0.0"
+
+"@typescript-eslint/parser@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.11.0.tgz#2f6d4f7e64eeb1e7c25b422f8df14d0c9e508e36"
+  integrity sha512-5xBExyXaxVyczrZvbRKEXvaTUFFq7gIM9BynXukXZE0zF3IQP/FxF4mPmmh3gJ9egafZFqByCpPTFm3dk4SY7Q==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "1.11.0"
+    "@typescript-eslint/typescript-estree" "1.11.0"
+    eslint-visitor-keys "^1.0.0"
+
+"@typescript-eslint/typescript-estree@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.11.0.tgz#b7b5782aab22e4b3b6d84633652c9f41e62d37d5"
+  integrity sha512-fquUHF5tAx1sM2OeRCC7wVxFd1iMELWMGCzOSmJ3pLzArj9+kRixdlC4d5MncuzXpjEqc6045p3KwM0o/3FuUA==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
 
 "@uifabric/azure-themes@^6.0.3":
   version "6.0.3"
@@ -2269,6 +2311,11 @@ acorn-globals@^4.1.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
+acorn-jsx@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
+  integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
+
 acorn-walk@^6.0.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
@@ -2279,7 +2326,7 @@ acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.0.0, acorn@^6.0.1, acorn@^6.0.5:
+acorn@^6.0.0, acorn@^6.0.1, acorn@^6.0.5, acorn@^6.0.7:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
@@ -2325,7 +2372,7 @@ ajv-keywords@^3.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
   integrity sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
 
-ajv@^6.1.0, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.5.5, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
@@ -3423,7 +3470,7 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4391,7 +4438,7 @@ debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -4711,6 +4758,13 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
+
 docusaurus@^1.5.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.11.1.tgz#786bae93946bc21ab7ef457c5672e2e2bd930b25"
@@ -4925,6 +4979,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -5081,13 +5140,74 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-scope@^4.0.0:
+eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
   integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+
+eslint@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.0.1.tgz#4a32181d72cb999d6f54151df7d337131f81cda7"
+  integrity sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.10.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^4.0.3"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^6.0.0"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^3.1.0"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.2.2"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.11"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+
+espree@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.0.0.tgz#716fc1f5a245ef5b9a7fdb1d7b0d3f02322e75f6"
+  integrity sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==
+  dependencies:
+    acorn "^6.0.7"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
 
 esprima@^3.1.3:
   version "3.1.3"
@@ -5099,6 +5219,13 @@ esprima@^4.0.0, esprima@~4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
+esquery@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
+  dependencies:
+    estraverse "^4.0.0"
+
 esrecurse@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
@@ -5106,7 +5233,7 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
@@ -5455,6 +5582,13 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
+
 file-loader@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-3.0.1.tgz#f8e0ba0b599918b51adfe45d66d1e771ad560faa"
@@ -5611,6 +5745,20 @@ findup-sync@^2.0.0:
     is-glob "^3.1.0"
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
+
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
+  integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -5780,6 +5928,11 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -6005,7 +6158,7 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
-globals@^11.1.0:
+globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
@@ -6497,6 +6650,11 @@ ignore@^3.3.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
 imagemin-gifsicle@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/imagemin-gifsicle/-/imagemin-gifsicle-6.0.1.tgz#6abad4e95566d52e5a104aba1c24b4f3b48581b3"
@@ -6558,6 +6716,14 @@ import-fresh@^2.0.0:
   dependencies:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
+
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-from@^2.1.0:
   version "2.1.0"
@@ -6680,6 +6846,25 @@ inquirer@^6.2.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
   integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.11"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
+
+inquirer@^6.2.2:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.4.1.tgz#7bd9e5ab0567cd23b41b0180b68e0cfa82fc3c0b"
+  integrity sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==
   dependencies:
     ansi-escapes "^3.2.0"
     chalk "^2.4.2"
@@ -7690,6 +7875,11 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -7849,7 +8039,7 @@ leven@^2.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
   integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
 
-levn@~0.3.0:
+levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
@@ -8047,6 +8237,11 @@ lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
   integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
+
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -9157,7 +9352,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
@@ -9410,6 +9605,13 @@ param-case@2.1.x:
   integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
   dependencies:
     no-case "^2.2.0"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-asn1@^5.0.0:
   version "5.1.4"
@@ -10051,6 +10253,11 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -10560,6 +10767,11 @@ regexp-tree@^0.1.6:
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.10.tgz#d837816a039c7af8a8d64d7a7c3cf6a1d93450bc"
   integrity sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ==
 
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
 regexpu-core@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.5.4.tgz#080d9d02289aa87fe1667a4f5136bc98a6aebaae"
@@ -10779,7 +10991,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@2, rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -10954,6 +11166,11 @@ semver-truncate@^1.1.2:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
 semver@^6.0.0, semver@^6.1.1:
   version "6.1.1"
@@ -11137,6 +11354,15 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
+    is-fullwidth-code-point "^2.0.0"
 
 slide@^1.1.6:
   version "1.1.6"
@@ -11506,6 +11732,15 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string_decoder@0.10:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -11587,7 +11822,7 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -11683,6 +11918,16 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
+
+table@^5.2.3:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.1.tgz#0691ae2ebe8259858efb63e550b6d5f9300171e8"
+  integrity sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==
+  dependencies:
+    ajv "^6.9.1"
+    lodash "^4.17.11"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
 tapable@^1.0.0, tapable@^1.1.0:
   version "1.1.3"
@@ -11798,7 +12043,7 @@ text-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-2.0.0.tgz#43eabd1b495482fae4a2bf65e5f56c29f69220f6"
   integrity sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==
 
-text-table@0.2.0:
+text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
@@ -12039,10 +12284,17 @@ ts-loader@^5.3.3:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
-tslib@^1.7.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsutils@^3.7.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.14.0.tgz#bf8d5a7bae5369331fa0f2b0a5a10bd7f7396c77"
+  integrity sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -12721,6 +12973,13 @@ write-pkg@^3.1.0:
   dependencies:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@^5.2.0:
   version "5.2.2"


### PR DESCRIPTION
here you go, let me know if you'd like this.

* added ESLint to the repo as a root dependency (as it is easier to lint all sources than have it in each package individually)
* disabled any rules which disagree with the code style in the existing sources
* enabled JSX linting for the documentation sources
* enabled jest globals for spec files
* fixed up all lint errors it found
* added flags to lines we want to ignore

Feedback needed:

* I had to add several eslint-ignore flags in individual files, one such example i saw often was `no-non-null-assertion` (as in `foo!`, the exclamation operator). is it better to keep the rule and ignore individual lines, or disable the rule, or change the code to do null checks?
* I am not a fan of rules such as `no-unused-vars`, I would prefer we use the compiler flags to achieve this (`noUnusedLocals` and friends), what do you think about turning that on for all packages?

I will do the change file tomorrow if I get chance