### PR TITLE
making build cache more accurately determine dep builds that aren't using just

### DIFF
--- a/change/just-task-2019-07-02-11-46-58-buildcache.json
+++ b/change/just-task-2019-07-02-11-46-58-buildcache.json
@@ -1,0 +1,8 @@
+{
+  "comment": "making build cache more accurately determine deps that aren't using just",
+  "type": "patch",
+  "packageName": "just-task",
+  "email": "kchau@microsoft.com",
+  "commit": "da5bb63fd925bea5a1344ce75a871af0df22742a",
+  "date": "2019-07-02T18:46:58.150Z"
+}

--- a/packages/just-task/src/cache.ts
+++ b/packages/just-task/src/cache.ts
@@ -138,6 +138,9 @@ function getDependentHashTimestamps() {
     if (fs.existsSync(depHashFile)) {
       const stat = fs.statSync(depHashFile);
       timestampsByPackage[pkgDepInfo.name] = stat.mtimeMs;
+    } else {
+      // always updated if no hash file is found for dependants
+      timestampsByPackage[pkgDepInfo.name] = new Date().getTime();
     }
   }
 

--- a/packages/just-task/src/package/findDependents.ts
+++ b/packages/just-task/src/package/findDependents.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { resolveCwd } from '../resolve';
 import { findPackageRoot } from './findPackageRoot';
 import { logger } from 'just-task-logger';
+import { findGitRoot } from './findGitRoot';
+import { isChildOf } from '../paths';
 
 interface DepInfo {
   name: string;
@@ -14,6 +16,7 @@ export function findDependents() {
 }
 
 function getDepsPaths(pkgPath: string): DepInfo[] {
+  const gitRoot = findGitRoot();
   const packageJsonFile = path.join(pkgPath, 'package.json');
 
   try {
@@ -37,7 +40,7 @@ function getDepsPaths(pkgPath: string): DepInfo[] {
 
         return { name: dep, path: path.dirname(fs.realpathSync(depPackageJson)) };
       })
-      .filter(p => p && p.path.indexOf('node_modules') === -1) as DepInfo[];
+      .filter(p => p && p.path.indexOf('node_modules') === -1 && isChildOf(p.path, gitRoot)) as DepInfo[];
   } catch (e) {
     logger.error(`Invalid package.json detected at ${packageJsonFile} `, e);
     return [];

--- a/packages/just-task/src/paths.ts
+++ b/packages/just-task/src/paths.ts
@@ -1,0 +1,6 @@
+const path = require('path');
+
+export function isChildOf(child: string, parent: string) {
+  const relativePath = path.relative(child, parent);
+  return /^[.\/\\]+$/.test(relativePath);
+}


### PR DESCRIPTION
In the case of build caching, if a dependency wasn't built with just, it wouldn't have the cache files created. So even if the source files didn't change, we will treat it as if we didn't have any cache for those cases. To take full advantage of caching with just-task, all the package builds need be run through `just-task`