### PR TITLE
Only pass valid webpack config options to webpack

### DIFF
--- a/change/just-scripts-2019-07-10-14-25-37-chrisgo-spread-bug-3.json
+++ b/change/just-scripts-2019-07-10-14-25-37-chrisgo-spread-bug-3.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Only pass valid webpack options to webpack",
+  "type": "patch",
+  "packageName": "just-scripts",
+  "email": "1581488+christiango@users.noreply.github.com",
+  "commit": "97f699d46f96b051d9ffa66e9c72f11f11a20825",
+  "date": "2019-07-10T18:25:37.102Z"
+}

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -54,7 +54,10 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
       // Convert everything to promises first to make sure we resolve all promises
       const webpackConfigPromises = await Promise.all(webpackConfigs.map(webpackConfig => Promise.resolve(webpackConfig)));
 
-      const { ...restConfig } = options || {};
+      // We support passing in arbitrary webpack config options that we need to merge with any read configs.
+      // To do this, we need to filter out the properties that aren't valid config options and then run webpack merge.
+      // A better long term solution here would be to have an option called webpackConfigOverrides instead of extending the configuration object.
+      const { config, outputStats, nodeArgs, ...restConfig } = options || ({} as WebpackTaskOptions);
 
       webpackConfigs = webpackConfigPromises.map(webpackConfig => webpackMerge(webpackConfig, restConfig));
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->

**PR type: bugfix**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**

**Summary**
We are passing all webpack task options to webpack, which is causing issues since some of the task options (like nodeArgs and config) are not webpack options. This PR is a short term fix that filters out the known invalid webpack options. The right long term fix would be to put config overrides in their own property.

**Does this PR introduce a breaking change?**
No
**Other information**