### PR TITLE
tscTask supports string array values for `build` option

### DIFF
--- a/change/just-scripts-2019-07-18-20-42-00-tsc-build-arrays.json
+++ b/change/just-scripts-2019-07-18-20-42-00-tsc-build-arrays.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Support string array options.",
+  "type": "minor",
+  "packageName": "just-scripts",
+  "email": "ScottHysom@users.noreply.github.com",
+  "commit": "4632a549f0141c4574565aa546b793bc6a4faa3e",
+  "date": "2019-07-19T03:41:59.910Z"
+}

--- a/packages/just-scripts/src/tasks/__tests__/__snapshots__/tscTask.spec.ts.snap
+++ b/packages/just-scripts/src/tasks/__tests__/__snapshots__/tscTask.spec.ts.snap
@@ -9,6 +9,17 @@ Array [
 ]
 `;
 
+exports[`tscTask using 'tscTask' function with 'build' option where 'build' is multiple paths and they all exist execs expected command 1`] = `
+Array [
+  "\${nodeExePath}",
+  "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--build",
+  "project/a/tsconfig.json",
+  "project/b/tsconfig.json",
+  "project/c/tsconfig.json",
+]
+`;
+
 exports[`tscTask using 'tscTask' function with 'project' option where 'project' is custom path and tsconfig.json exists execs expected command 1`] = `
 Array [
   "\${nodeExePath}",
@@ -18,7 +29,16 @@ Array [
 ]
 `;
 
-exports[`tscTask using 'tscTask' function with a boolean switch execs expected command 1`] = `
+exports[`tscTask using 'tscTask' function with a boolean 'false' switch execs expected command 1`] = `
+Array [
+  "\${nodeExePath}",
+  "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--project",
+  "\${packageRoot}/tsconfig.json",
+]
+`;
+
+exports[`tscTask using 'tscTask' function with a boolean 'true' switch execs expected command 1`] = `
 Array [
   "\${nodeExePath}",
   "\${repoRoot}/node_modules/typescript/lib/tsc.js",
@@ -40,10 +60,43 @@ Array [
 ]
 `;
 
-exports[`tscTask using 'tscTask' function with empty options and tsconfig.json exists at package root execs expected command 1`] = `
+exports[`tscTask using 'tscTask' function with empty options execs expected command 1`] = `
 Array [
   "\${nodeExePath}",
   "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--project",
+  "\${packageRoot}/tsconfig.json",
+]
+`;
+
+exports[`tscTask using 'tscTask' function with no arguments execs expected command 1`] = `
+Array [
+  "\${nodeExePath}",
+  "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--project",
+  "\${packageRoot}/tsconfig.json",
+]
+`;
+
+exports[`tscTask using 'tscTask' function with string array option execs expected command 1`] = `
+Array [
+  "\${nodeExePath}",
+  "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--lib",
+  "es6",
+  "dom",
+  "esnext.intl",
+  "--project",
+  "\${packageRoot}/tsconfig.json",
+]
+`;
+
+exports[`tscTask using 'tscTask' function with string value option execs expected command 1`] = `
+Array [
+  "\${nodeExePath}",
+  "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--module",
+  "ESNext",
   "--project",
   "\${packageRoot}/tsconfig.json",
 ]
@@ -58,6 +111,17 @@ Array [
 ]
 `;
 
+exports[`tscTask using 'tscWatchTask' function with 'build' option where 'build' is multiple paths and they all exist execs expected command 1`] = `
+Array [
+  "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--build",
+  "project/a/tsconfig.json",
+  "project/b/tsconfig.json",
+  "project/c/tsconfig.json",
+  "--watch",
+]
+`;
+
 exports[`tscTask using 'tscWatchTask' function with 'project' option where 'project' is custom path and tsconfig.json exists execs expected command 1`] = `
 Array [
   "\${repoRoot}/node_modules/typescript/lib/tsc.js",
@@ -67,7 +131,16 @@ Array [
 ]
 `;
 
-exports[`tscTask using 'tscWatchTask' function with a boolean switch execs expected command 1`] = `
+exports[`tscTask using 'tscWatchTask' function with a boolean 'false' switch execs expected command 1`] = `
+Array [
+  "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--project",
+  "\${packageRoot}/tsconfig.json",
+  "--watch",
+]
+`;
+
+exports[`tscTask using 'tscWatchTask' function with a boolean 'true' switch execs expected command 1`] = `
 Array [
   "\${repoRoot}/node_modules/typescript/lib/tsc.js",
   "--allowJs",
@@ -89,9 +162,42 @@ Array [
 ]
 `;
 
-exports[`tscTask using 'tscWatchTask' function with empty options and tsconfig.json exists at package root execs expected command 1`] = `
+exports[`tscTask using 'tscWatchTask' function with empty options execs expected command 1`] = `
 Array [
   "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--project",
+  "\${packageRoot}/tsconfig.json",
+  "--watch",
+]
+`;
+
+exports[`tscTask using 'tscWatchTask' function with no arguments execs expected command 1`] = `
+Array [
+  "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--project",
+  "\${packageRoot}/tsconfig.json",
+  "--watch",
+]
+`;
+
+exports[`tscTask using 'tscWatchTask' function with string array option execs expected command 1`] = `
+Array [
+  "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--lib",
+  "es6",
+  "dom",
+  "esnext.intl",
+  "--project",
+  "\${packageRoot}/tsconfig.json",
+  "--watch",
+]
+`;
+
+exports[`tscTask using 'tscWatchTask' function with string value option execs expected command 1`] = `
+Array [
+  "\${repoRoot}/node_modules/typescript/lib/tsc.js",
+  "--module",
+  "ESNext",
   "--project",
   "\${packageRoot}/tsconfig.json",
   "--watch",

--- a/packages/just-scripts/src/tasks/tscTask.ts
+++ b/packages/just-scripts/src/tasks/tscTask.ts
@@ -3,8 +3,11 @@ import { resolve, logger, resolveCwd, TaskFunction } from 'just-task';
 import { exec, encodeArgs, spawn } from 'just-scripts-utils';
 import fs from 'fs';
 
-export type TscTaskOptions = { [key in keyof ts.CompilerOptions]?: string | boolean };
+export type TscTaskOptions = { [key in keyof ts.CompilerOptions]?: string | boolean | string[] };
 
+/**
+ * Returns a task that runs the TSC CLI.
+ */
 export function tscTask(options: TscTaskOptions = {}): TaskFunction {
   const tscCmd = resolve('typescript/lib/tsc.js');
 
@@ -19,19 +22,7 @@ export function tscTask(options: TscTaskOptions = {}): TaskFunction {
     if (isValidProject(options)) {
       logger.info(`Running ${tscCmd} with ${options.project || options.build}`);
 
-      const args = Object.keys(options).reduce(
-        (args, option) => {
-          if (typeof options[option] === 'string') {
-            return args.concat(['--' + option, options[option] as string]);
-          } else if (typeof options[option] === 'boolean') {
-            return args.concat(['--' + option]);
-          }
-
-          return args;
-        },
-        [tscCmd]
-      );
-
+      const args = argsFromOptions(tscCmd, options);
       const cmd = encodeArgs([process.execPath, ...args]).join(' ');
       logger.info(`Executing: ${cmd}`);
       return exec(cmd);
@@ -40,6 +31,9 @@ export function tscTask(options: TscTaskOptions = {}): TaskFunction {
   };
 }
 
+/**
+ * Returns a task that runs the TSC CLI in watch mode.
+ */
 export function tscWatchTask(options: TscTaskOptions = {}): TaskFunction {
   const tscCmd = resolve('typescript/lib/tsc.js');
 
@@ -47,25 +41,13 @@ export function tscWatchTask(options: TscTaskOptions = {}): TaskFunction {
     throw new Error('cannot find tsc');
   }
 
-  options = { ...options, ...getProjectOrBuildOptions(options) };
-
   return function tscWatch() {
+    options = { ...options, ...getProjectOrBuildOptions(options) };
+
     if (isValidProject(options)) {
       logger.info(`Running ${tscCmd} with ${options.project || options.build} in watch mode`);
 
-      const args = Object.keys(options).reduce(
-        (args, option) => {
-          if (typeof options[option] === 'string') {
-            return args.concat(['--' + option, options[option] as string]);
-          } else if (typeof options[option] === 'boolean') {
-            return args.concat(['--' + option]);
-          }
-
-          return args;
-        },
-        [tscCmd]
-      );
-
+      const args = argsFromOptions(tscCmd, options);
       const cmd = [...args, '--watch'];
       logger.info(encodeArgs(cmd).join(' '));
       return spawn(process.execPath, cmd, { stdio: 'inherit' });
@@ -74,21 +56,54 @@ export function tscWatchTask(options: TscTaskOptions = {}): TaskFunction {
   };
 }
 
+/**
+ * Determine `project` or `build` options. `build` option takes precedence.
+ */
 function getProjectOrBuildOptions(options: TscTaskOptions) {
   const tsConfigFile = resolveCwd('./tsconfig.json') || 'tsconfig.json';
-  const result: { [option: string]: string | boolean } = {};
+  const result: { [option: string]: string | boolean | string[] } = {};
 
-  if (options.project) {
-    result.project = options && typeof options.project === 'string' ? options.project : tsConfigFile;
-  } else if (options.build) {
-    result.build = options && typeof options.build === 'string' ? options.build : tsConfigFile;
-  } else if (tsConfigFile) {
-    result.project = tsConfigFile;
+  if (options.build) {
+    result.build = typeof options.build === 'string' || Array.isArray(options.build) ? options.build : tsConfigFile;
+  } else {
+    result.project = typeof options.project === 'string' ? options.project : tsConfigFile;
   }
-
   return result;
 }
 
+/**
+ * Returns true if the `project` or `build` setting refers to an existing `tsconfig.json` file.
+ */
 function isValidProject(options: TscTaskOptions) {
-  return (options.project && fs.existsSync(options.project as string)) || (options.build && fs.existsSync(options.build as string));
+  return (
+    (typeof options.project === 'string' && fs.existsSync(options.project)) ||
+    (typeof options.build === 'string' && fs.existsSync(options.build)) ||
+    (Array.isArray(options.build) &&
+      options.build.reduce(
+        (currentIsValid, buildPath) => {
+          return currentIsValid && typeof buildPath === 'string' && fs.existsSync(buildPath);
+        },
+        true as boolean
+      ))
+  );
+}
+
+/**
+ * Returns an array of CLI arguments for TSC given the `options`.
+ */
+function argsFromOptions(tscCmd: string, options: TscTaskOptions): string[] {
+  return Object.keys(options).reduce(
+    (currentArgs, option) => {
+      const optionValue = options[option];
+      if (typeof optionValue === 'string') {
+        return currentArgs.concat(['--' + option, optionValue]);
+      } else if (typeof optionValue === 'boolean' && optionValue) {
+        return currentArgs.concat(['--' + option]);
+      } else if (Array.isArray(optionValue)) {
+        return currentArgs.concat(['--' + option, ...optionValue]);
+      }
+      return currentArgs;
+    },
+    [tscCmd]
+  );
 }


### PR DESCRIPTION
**PR type**
Feature

**Did you add tests for your changes?**
Yes

**If relevant, did you update the documentation?**
n/a

**Summary**
`tscTask` supports options that specify string arrays. In particular, the `build` option can take either a single string value or an array of strings. This allows packages to pass in multiple paths to the `build` option. 

The support for string arrays extends to other options, such as the `lib` option.

An ancillary bug was fixed as well, where a boolean flag is specified with a falsey value.

More unit tests were added.

**Does this PR introduce a breaking change?**
No.

