### PR TITLE
Npm init uifabric fix (when there is no yarn)

### DIFF
--- a/change/create-just-2019-08-06-10-17-40-npm.json
+++ b/change/create-just-2019-08-06-10-17-40-npm.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixes npm init uifabric",
+  "packageName": "create-just",
+  "email": "kchau@microsoft.com",
+  "commit": "985a5b733c4407e84c35dfd8756ec4b43e2cae81",
+  "date": "2019-08-06T17:17:40.258Z"
+}

--- a/change/create-uifabric-2019-08-06-10-18-11-npm.json
+++ b/change/create-uifabric-2019-08-06-10-18-11-npm.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Change files",
+  "comment": "bump create-just, fixes npm install",
   "packageName": "create-uifabric",
   "email": "kchau@microsoft.com",
   "commit": "4a89b06321fcf9223fa2c4a00b4cd96ad4ea81de",

--- a/change/create-uifabric-2019-08-06-10-18-11-npm.json
+++ b/change/create-uifabric-2019-08-06-10-18-11-npm.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Change files",
+  "packageName": "create-uifabric",
+  "email": "kchau@microsoft.com",
+  "commit": "4a89b06321fcf9223fa2c4a00b4cd96ad4ea81de",
+  "date": "2019-08-06T17:18:11.576Z"
+}

--- a/packages/create-just/src/commands/initCommand.ts
+++ b/packages/create-just/src/commands/initCommand.ts
@@ -1,11 +1,11 @@
-import { paths, logger, prettyPrintMarkdown, downloadPackage } from 'just-scripts-utils';
-import path from 'path';
-import { readdirSync, readFileSync, existsSync } from 'fs';
-import prompts from 'prompts';
 import { execSync } from 'child_process';
-import yargs from 'yargs';
 import { getPlopGenerator, runGenerator } from '../plop';
+import { paths, logger, prettyPrintMarkdown, downloadPackage } from 'just-scripts-utils';
+import { readdirSync, readFileSync, existsSync } from 'fs';
 import * as pkg from '../packageManager';
+import path from 'path';
+import prompts from 'prompts';
+import yargs from 'yargs';
 
 const initCwd = process.cwd();
 
@@ -50,7 +50,7 @@ export async function initCommand(argv: yargs.Arguments) {
         { title: 'React App', value: 'just-stack-react' },
         { title: 'UI Fabric (React)', value: 'just-stack-uifabric' },
         { title: 'Basic TypeScript', value: 'just-stack-single-lib' },
-        { title: 'Monorepo', value: 'just-stack-monorepo' }
+        ...(pkg.getYarn() ? [{ title: 'Monorepo', value: 'just-stack-monorepo' }] : [])
       ]
     });
     argv.stack = stack;

--- a/packages/create-just/src/getEnvInfo.ts
+++ b/packages/create-just/src/getEnvInfo.ts
@@ -1,5 +1,6 @@
 import envinfo from 'envinfo';
 import os from 'os';
+import path from 'path';
 
 let envInfoCache: { Binaries: { Yarn: any; npm: any } };
 
@@ -13,20 +14,25 @@ export const initialize = async () => {
       {
         Binaries: ['Yarn', 'npm']
       },
-      { json: true, showNotFound: true }
+      { json: true, showNotFound: false }
     )
   );
 
-  envInfoCache.Binaries.Yarn.path = envInfoCache.Binaries.Yarn && expandHome(envInfoCache.Binaries.Yarn.path);
-  envInfoCache.Binaries.npm.path = envInfoCache.Binaries.npm && expandHome(envInfoCache.Binaries.npm.path);
+  if (envInfoCache.Binaries.Yarn) {
+    envInfoCache.Binaries.Yarn.path = expandHome(envInfoCache.Binaries.Yarn.path);
+  }
+
+  if (envInfoCache.Binaries.npm) {
+    envInfoCache.Binaries.npm.path = expandHome(envInfoCache.Binaries.npm.path);
+  }
 
   return envInfoCache;
 };
 
-function expandHome(path: string) {
-  if (path.startsWith('~/')) {
-    return path.replace('~/', os.homedir() + '/');
+function expandHome(pathString: string) {
+  if (pathString.startsWith('~' + path.sep)) {
+    return pathString.replace('~', os.homedir());
   }
 
-  return path;
+  return pathString;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->

**PR type ?**
bugfix

**Did you add tests for your changes?**
No

**If relevant, did you update the documentation?**
No

**Summary**
envinfo was return a string for "not found" and we need to disable the monorepo stack choice if yarn isn't detected.

