### PR TITLE
Upgraded marked and marked-terminal packages due to a security vulnerability

### DIFF
--- a/change/just-scripts-utils-2019-08-13-11-03-40-altinokd-update-marked-packages.json
+++ b/change/just-scripts-utils-2019-08-13-11-03-40-altinokd-update-marked-packages.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Upgraded marked to 0.7.0 and marked-terminal to 3.3.0",
+  "type": "patch",
+  "packageName": "just-scripts-utils",
+  "email": "altinokd@microsoft.com",
+  "commit": "003c41cf6d3d3ac5bce48c6966475fcb6ceb7406",
+  "date": "2019-08-13T18:03:40.563Z"
+}

--- a/packages/just-scripts-utils/package.json
+++ b/packages/just-scripts-utils/package.json
@@ -22,8 +22,8 @@
     "handlebars": "^4.0.12",
     "jju": "^1.4.0",
     "just-task-logger": ">=0.3.0 <1.0.0",
-    "marked": "^0.6.0",
-    "marked-terminal": "^3.2.0",
+    "marked": "^0.7.0",
+    "marked-terminal": "^3.3.0",
     "semver": "^5.6.0",
     "tar": "^4.4.8",
     "yargs": "^12.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8980,10 +8980,10 @@ markdown-toc@^1.2.0:
     repeat-string "^1.6.1"
     strip-color "^0.1.0"
 
-marked-terminal@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-3.2.0.tgz#3fc91d54569332bcf096292af178d82219000474"
-  integrity sha512-Yr1yVS0BbDG55vx7be1D0mdv+jGs9AW563o/Tt/7FTsId2J0yqhrTeXAqq/Q0DyyXltIn6CSxzesQuFqXgafjQ==
+marked-terminal@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-3.3.0.tgz#25ce0c0299285998c7636beaefc87055341ba1bd"
+  integrity sha512-+IUQJ5VlZoAFsM5MHNT7g3RHSkA3eETqhRCdXv4niUMAKHQ7lb1yvAcuGPmm4soxhmtX13u4Li6ZToXtvSEH+A==
   dependencies:
     ansi-escapes "^3.1.0"
     cardinal "^2.1.1"
@@ -8992,10 +8992,10 @@ marked-terminal@^3.2.0:
     node-emoji "^1.4.1"
     supports-hyperlinks "^1.0.1"
 
-marked@^0.6.0:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.2.tgz#c574be8b545a8b48641456ca1dbe0e37b6dccc1a"
-  integrity sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 math-random@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
**PR type ?**
Package Update
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
marked 0.6.3 has security vulnerability.
Description: Affected versions of marked are vulnerable to Regular Expression Denial of Service (ReDoS). The _label subrule may significantly degrade parsing performance of malformed input.
Recommendation: Upgrade to version 0.7.0 or later.
https://www.npmjs.com/advisories/1076

**Does this PR introduce a breaking change?**
No