### PR TITLE
Jest forceExit

### DIFF
--- a/change/just-scripts-2019-08-23-14-22-57-jest-force.json
+++ b/change/just-scripts-2019-08-23-14-22-57-jest-force.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adds a forceexit flag to make sure timeouts don't hang the runner",
+  "packageName": "just-scripts",
+  "email": "kchau@microsoft.com",
+  "commit": "1eaa0fd3bacc82c58d85dd02c53f3af5aa70eb79",
+  "date": "2019-08-23T21:22:57.600Z"
+}

--- a/packages/just-scripts/src/tasks/jestTask.ts
+++ b/packages/just-scripts/src/tasks/jestTask.ts
@@ -35,6 +35,8 @@ export function jestTask(options: JestTaskOptions = {}): TaskFunction {
         configFile,
         '--passWithNoTests',
         '--colors',
+        // This generates a warning from jest CLI, but it can be safely ignored
+        '--forceExit',
         ...(options.runInBand ? ['--runInBand'] : []),
         ...(options.coverage ? ['--coverage'] : []),
         ...(options.watch ? ['--watch'] : []),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->

**PR type ?**

feature

**Did you add tests for your changes?**

no

**If relevant, did you update the documentation?**

no

**Summary**

Getting jest to exit when there's a run away long process is tricky. The only way is through this "forceExit" flag.

**Does this PR introduce a breaking change?**

**Other information**
