### PR TITLE
Remove void from task() return type

### DIFF
--- a/change/just-task-2019-09-16-12-09-31-ecraig-cached.json
+++ b/change/just-task-2019-09-16-12-09-31-ecraig-cached.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove void from task() return type",
+  "packageName": "just-task",
+  "email": "elcraig@microsoft.com",
+  "commit": "1cf24fd5e464d5045688b4d542cc2027e0e176cc",
+  "date": "2019-09-16T19:09:31.852Z"
+}

--- a/packages/just-task/src/task.ts
+++ b/packages/just-task/src/task.ts
@@ -5,11 +5,7 @@ import { TaskFunction } from './interfaces';
 import { logger } from 'just-task-logger';
 import { registerCachedTask, isCached, saveCache } from './cache';
 
-export function task(
-  firstParam: string | TaskFunction,
-  secondParam?: string | TaskFunction,
-  thirdParam?: TaskFunction
-): TaskFunction | void {
+export function task(firstParam: string | TaskFunction, secondParam?: string | TaskFunction, thirdParam?: TaskFunction): TaskFunction {
   const argCount = arguments.length;
 
   if (argCount === 1 && typeof firstParam === 'string') {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->

**PR type ?** bug fix

**Summary**

`task()`'s return type is listed as `TaskFunction | void`, which causes an error to show whenever you call `.cached()` on a task:
![image](https://user-images.githubusercontent.com/5864305/64986166-4c0ce000-d87b-11e9-8110-7e54882b7e5f.png)

I removed the `void` from the return type because the function never returns void; it either returns `TaskFunction` or throws an exception.