### PR TITLE
Styleoverlay fix to allow localIdentName to be used

### DIFF
--- a/change/just-scripts-2019-09-16-16-28-48-styleoverlay.json
+++ b/change/just-scripts-2019-09-16-16-28-48-styleoverlay.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixes styleoverlay",
+  "packageName": "just-scripts",
+  "email": "kchau@microsoft.com",
+  "commit": "9b93e3942e2aff9ae8693b8964d8319fcc2ae335",
+  "date": "2019-09-16T23:28:48.524Z"
+}

--- a/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
@@ -35,6 +35,17 @@ function createStyleLoaderRule(cssOptions: CssLoaderOptions, preprocessor: 'sass
     ...(preprocessor ? [preprocessor] : [])
   ];
 
+  const moduleOptions = cssOptions.localIdentName
+    ? {
+        modules: {
+          mode: 'local',
+          localIdentName: cssOptions.localIdentName
+        }
+      }
+    : {
+        modules: cssOptions.modules
+      };
+
   return [
     {
       loader: styleLoader // creates style nodes from JS strings
@@ -42,7 +53,7 @@ function createStyleLoaderRule(cssOptions: CssLoaderOptions, preprocessor: 'sass
     {
       loader: 'css-loader', // translates CSS into CommonJS
       options: {
-        ...cssOptions,
+        ...moduleOptions,
         importLoaders: preloaders.length
       }
     },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->

**PR type ?**

bugfix

**Did you add tests for your changes?**
no

**If relevant, did you update the documentation?**
no

**Summary**
Fixes #236