### PR TITLE
Fix responsive img (sample.png) on landing page

### DIFF
--- a/packages/documentation/website/pages/en/index.js
+++ b/packages/documentation/website/pages/en/index.js
@@ -61,10 +61,12 @@ class HomeSplash extends React.Component {
         <div className="inner">
           <ProjectTitle />
           <PromoSection>
-            <img
-              src={`${siteConfig.baseUrl}img/sample.png`}
-              srcSet={`${siteConfig.baseUrl}img/sample.png, ${siteConfig.baseUrl}img/sample-2x.png 2x`}
-            />
+            <div>
+              <img
+                src={`${siteConfig.baseUrl}img/sample.png`}
+                srcSet={`${siteConfig.baseUrl}img/sample.png, ${siteConfig.baseUrl}img/sample-2x.png 2x`}
+              />
+            </div>
           </PromoSection>
           <PromoSection>
             <Button href={docUrl('doc-start.html', language)}>Let's Get Started!</Button>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->

**PR type bugfix**

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**
no

**If relevant, did you update the documentation?**
no

**Summary**
Fix bug #193, adding a div wrapper around the image so the resize works correctly on safari.

<!-- If possible, mention the issue with which it is related to -->

**Does this PR introduce a breaking change?**
no

**Other information**

### Before 
<img width="714" alt="Screen Shot 2019-09-22 at 9 55 05 PM" src="https://user-images.githubusercontent.com/22054505/65398470-610ad700-dd85-11e9-8320-7a27291052d9.png">

### After
<img width="709" alt="Screen Shot 2019-09-22 at 9 55 14 PM" src="https://user-images.githubusercontent.com/22054505/65398481-6831e500-dd85-11e9-87a6-0d94203e3af1.png">

