### PR TITLE
Add option to fix API report file newlines

### DIFF
--- a/change/just-scripts-2019-09-26-19-10-16-ecraig-api-newlines.json
+++ b/change/just-scripts-2019-09-26-19-10-16-ecraig-api-newlines.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add option to fix API report file newlines",
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com",
+  "commit": "e79daebd09eb7f8f39622cade3d2bd38b0b593f0",
+  "date": "2019-09-27T02:10:16.862Z"
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! -->

**PR type ?** minor feature

**Did you add tests for your changes?** no

**If relevant, did you update the documentation?** n/a?

**Summary**

API Extractor uses CRLF newlines by default and adds trailing spaces after empty comment lines, both of which can add excessive noise to diffs. Add an option to automatically fix those newlines as part of the API Extractor tasks. (The space after empty comment thing could potentially be fixed in API Extractor itself, but they refuse to add an option to use OS-appropriate newlines in output files.)

**Does this PR introduce a breaking change?** no