### PR TITLE
Write custom .npmrc when using create-just against a custom registry

### DIFF
--- a/change/create-just-2019-10-17-15-03-09-forceauth.json
+++ b/change/create-just-2019-10-17-15-03-09-forceauth.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "If a custom registry is specified, add an .npmrc file, that forces auth",
+  "packageName": "create-just",
+  "email": "acoates@microsoft.com",
+  "commit": "4b8f1a2d21bebb08281ff530329e0708cf4a5cca",
+  "date": "2019-10-17T22:03:08.947Z"
+}

--- a/packages/create-just/src/commands/initCommand.ts
+++ b/packages/create-just/src/commands/initCommand.ts
@@ -78,6 +78,7 @@ export async function initCommand(argv: yargs.Arguments) {
   const stackPath = await getStackPath(argv.stack, argv.registry);
 
   logger.info(`Installing stack dependencies in ${stackPath}`);
+  pkg.ensureNpmrcIfRequired(argv.registry, stackPath!);
   pkg.install(argv.registry, stackPath!);
 
   const stackName = getStackName(stackPath!);

--- a/packages/create-just/src/packageManager.ts
+++ b/packages/create-just/src/packageManager.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from 'child_process';
 import { getEnvInfo } from './getEnvInfo';
+import { existsSync, writeFileSync } from 'fs';
+import path from 'path';
 
 export function getYarn() {
   const yarnInfo = getEnvInfo().Binaries.Yarn;
@@ -9,6 +11,18 @@ export function getYarn() {
 function getNpm() {
   const npmInfo = getEnvInfo().Binaries.npm;
   return npmInfo && npmInfo.path;
+}
+
+export function ensureNpmrcIfRequired(registry: string, cwd: string) {
+  const npmrcPath = path.join(cwd, '.npmrc');
+  // If a custom registry is specified, add an .npmrc file, that forces auth
+  if (registry && !existsSync(npmrcPath)) {
+    writeFileSync(
+      npmrcPath,
+      `registry=${registry}
+${registry}:always-auth=true`
+    );
+  }
 }
 
 export function install(registry: string, cwd: string) {


### PR DESCRIPTION
If a custom registry is specified, generate a .npmrc file that ensures that auth will be used during the install command.  This is required when using yarn against a private registry which requires auth for install.