### PR TITLE
Failures on install should be fatal

### DIFF
--- a/change/create-just-2020-01-13-14-26-04-installfail.json
+++ b/change/create-just-2020-01-13-14-26-04-installfail.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Failures on install should be fatal",
+  "packageName": "create-just",
+  "email": "acoates@microsoft.com",
+  "commit": "8f5f8a2e9ad1e709c1eebc13c378677c49df545e",
+  "date": "2020-01-13T22:26:04.295Z"
+}

--- a/packages/create-just/src/packageManager.ts
+++ b/packages/create-just/src/packageManager.ts
@@ -28,9 +28,11 @@ ${registry}:always-auth=true`
 export function install(registry: string, cwd: string) {
   const registryArgs = registry ? ['--registry', registry] : [];
 
-  if (getYarn()) {
-    return spawnSync(getYarn(), ['install', ...registryArgs], { stdio: 'inherit', cwd });
-  } else {
-    return spawnSync(getNpm(), ['install', ...registryArgs], { stdio: 'inherit', cwd });
+  const result = spawnSync(getYarn() || getNpm(), ['install', ...registryArgs], { stdio: 'inherit', cwd });
+
+  if (result.error) {
+    throw result.error;
   }
+
+  return result;
 }


### PR DESCRIPTION
## Overview

During `yarn create just`, if the packager fails to install the top level yarn create command would continue and report success.  This change makes it bubble up the packager failure.