### PR TITLE
add just-repo-utils package

### DIFF
--- a/change/just-repo-utils-2020-03-04-22-05-25-monorepo-utils.json
+++ b/change/just-repo-utils-2020-03-04-22-05-25-monorepo-utils.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add repo utils project",
+  "packageName": "just-repo-utils",
+  "email": "jasonmo@microsoft.com",
+  "commit": "245d9ba06f989ae569fbe2e5fe531c7cad5cfb20",
+  "date": "2020-03-05T06:05:25.888Z"
+}

--- a/packages/just-repo-utils/.npmignore
+++ b/packages/just-repo-utils/.npmignore
@@ -1,0 +1,3 @@
+src
+CHANGELOG.*
+__tests__

--- a/packages/just-repo-utils/jest.config.js
+++ b/packages/just-repo-utils/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../scripts/jest.config');

--- a/packages/just-repo-utils/package.json
+++ b/packages/just-repo-utils/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "just-repo-utils",
+  "version": "0.1.1",
+  "description": "Utilities for gathering info about the current repository",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/just"
+  },
+  "main": "./lib/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "tsc -w --preserveWatchOutput",
+    "test": "jest",
+    "start-test": "jest --watch"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "fs-extra": "^7.0.1",
+    "glob": "^7.1.3",
+    "jju": "^1.4.0",
+    "just-task-logger": ">=0.3.0 <1.0.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^5.0.4",
+    "@types/glob": "^7.1.1",
+    "@types/jest": "^23.3.13",
+    "@types/jju": "^1.4.0",
+    "@types/mock-fs": "^3.6.30",
+    "@types/node": "^10.12.18",
+    "jest": "^24.0.0",
+    "mock-fs": "^4.8.0",
+    "ts-jest": "^24.0.1",
+    "typescript": "~3.4.4"
+  }
+}

--- a/packages/just-repo-utils/src/__tests__/__snapshots__/packageInfo.spec.ts.snap
+++ b/packages/just-repo-utils/src/__tests__/__snapshots__/packageInfo.spec.ts.snap
@@ -1,5 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`packageInfo dependency graph 1`] = `
+Object {
+  "just-scripts-utils": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-task-logger": Object {},
+      },
+    },
+    "path": "/packages/just-scripts-utils",
+  },
+  "just-task": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-task-logger": Object {},
+      },
+    },
+    "path": "/packages/just-task",
+  },
+  "just-task-logger": Object {
+    "dependencies": Object {},
+    "path": "/packages/just-task-logger",
+  },
+}
+`;
+
+exports[`packageInfo dependency graph with devDependency filter 1`] = `Object {}`;
+
+exports[`packageInfo dependency graph with filters 1`] = `
+Object {
+  "just-scripts-utils": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-task-logger": Object {},
+      },
+    },
+    "path": "/packages/just-scripts-utils",
+  },
+  "just-task": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-task-logger": Object {},
+      },
+    },
+    "path": "/packages/just-task",
+  },
+  "just-task-logger": Object {
+    "dependencies": Object {},
+    "path": "/packages/just-task-logger",
+  },
+}
+`;
+
 exports[`packageInfo info matches snapshot 1`] = `
 Object {
   "create-just": Object {

--- a/packages/just-repo-utils/src/__tests__/__snapshots__/packageInfo.spec.ts.snap
+++ b/packages/just-repo-utils/src/__tests__/__snapshots__/packageInfo.spec.ts.snap
@@ -1,0 +1,155 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`packageInfo info matches snapshot 1`] = `
+Object {
+  "create-just": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-plop-helpers": Object {},
+      },
+      "1": Object {
+        "just-scripts-utils": Object {},
+      },
+    },
+    "path": "/packages/create-just",
+  },
+  "create-uifabric": Object {
+    "dependencies": Object {
+      "0": Object {
+        "create-just": Object {},
+      },
+    },
+    "path": "/packages/create-uifabric",
+  },
+  "example-lib": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-scripts": Object {},
+      },
+    },
+    "path": "/packages/example-lib",
+  },
+  "just-plop-helpers": Object {
+    "dependencies": Object {},
+    "path": "/packages/just-plop-helpers",
+  },
+  "just-repo-utils": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-task-logger": Object {},
+      },
+    },
+    "path": "/packages/just-repo-utils",
+  },
+  "just-scripts": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-scripts-utils": Object {},
+      },
+      "1": Object {
+        "just-task": Object {},
+      },
+    },
+    "path": "/packages/just-scripts",
+  },
+  "just-scripts-utils": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-task-logger": Object {},
+      },
+    },
+    "path": "/packages/just-scripts-utils",
+  },
+  "just-stack-monorepo": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-plop-helpers": Object {},
+      },
+    },
+    "path": "/packages/just-stack-monorepo",
+  },
+  "just-stack-react": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-plop-helpers": Object {},
+      },
+    },
+    "path": "/packages/just-stack-react",
+  },
+  "just-stack-single-lib": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-plop-helpers": Object {},
+      },
+      "1": Object {
+        "just-scripts": Object {},
+      },
+    },
+    "path": "/packages/just-stack-single-lib",
+  },
+  "just-stack-uifabric": Object {
+    "dependencies": Object {},
+    "path": "/packages/just-stack-uifabric",
+  },
+  "just-task": Object {
+    "dependencies": Object {
+      "0": Object {
+        "just-task-logger": Object {},
+      },
+    },
+    "path": "/packages/just-task",
+  },
+  "just-task-docs": Object {
+    "dependencies": Object {},
+    "path": "/packages/documentation/website",
+  },
+  "just-task-logger": Object {
+    "dependencies": Object {},
+    "path": "/packages/just-task-logger",
+  },
+  "just-task-scripts": Object {
+    "dependencies": Object {},
+    "path": "/scripts",
+  },
+}
+`;
+
+exports[`packageInfo names 1`] = `
+Array [
+  "create-just",
+  "create-uifabric",
+  "example-lib",
+  "just-plop-helpers",
+  "just-repo-utils",
+  "just-scripts-utils",
+  "just-scripts",
+  "just-stack-monorepo",
+  "just-stack-react",
+  "just-stack-single-lib",
+  "just-stack-uifabric",
+  "just-task-logger",
+  "just-task",
+  "just-task-docs",
+  "just-task-scripts",
+]
+`;
+
+exports[`packageInfo paths 1`] = `
+Array [
+  "/packages/create-just",
+  "/packages/create-uifabric",
+  "/packages/example-lib",
+  "/packages/just-plop-helpers",
+  "/packages/just-repo-utils",
+  "/packages/just-scripts-utils",
+  "/packages/just-scripts",
+  "/packages/just-stack-monorepo",
+  "/packages/just-stack-react",
+  "/packages/just-stack-single-lib",
+  "/packages/just-stack-uifabric",
+  "/packages/just-task-logger",
+  "/packages/just-task",
+  "/packages/documentation/website",
+  "/scripts",
+]
+`;

--- a/packages/just-repo-utils/src/__tests__/packageInfo.spec.ts
+++ b/packages/just-repo-utils/src/__tests__/packageInfo.spec.ts
@@ -2,9 +2,9 @@ import { PackageEntries } from '../interfaces/packageInfoTypes';
 import { getPackageInfo } from '../packageInfo';
 import { getRepoPackagesFromSerializableForm, getSerializableRepoPackages } from '../internal/packageInfoCache';
 import { findGitRoot } from '../repoInfo';
-import { normalizePath } from '../normalizePath';
+import { normalizeToUnixPath } from '../normalizeToUnixPath';
 
-const _rootPath = normalizePath(findGitRoot());
+const _rootPath = normalizeToUnixPath(findGitRoot());
 
 function trimPath(rootPath: string, fullPath: string): string {
   const index = fullPath.indexOf(rootPath);

--- a/packages/just-repo-utils/src/__tests__/packageInfo.spec.ts
+++ b/packages/just-repo-utils/src/__tests__/packageInfo.spec.ts
@@ -85,4 +85,19 @@ describe('packageInfo', () => {
     const info = getPackageInfo();
     expect(comparableEntries(info.entries)).toMatchSnapshot();
   });
+
+  test('dependency graph', () => {
+    const info = getPackageInfo().dependencies({ target: 'just-scripts' });
+    expect(comparableEntries(info.entries)).toMatchSnapshot();
+  });
+
+  test('dependency graph with filters', () => {
+    const info = getPackageInfo().dependencies({ target: 'just-scripts', dependencyType: 'dependencies' });
+    expect(comparableEntries(info.entries)).toMatchSnapshot();
+  });
+
+  test('dependency graph with devDependency filter', () => {
+    const info = getPackageInfo().dependencies({ target: 'just-scripts', dependencyType: 'devDependencies' });
+    expect(comparableEntries(info.entries)).toMatchSnapshot();
+  });
 });

--- a/packages/just-repo-utils/src/__tests__/packageInfo.spec.ts
+++ b/packages/just-repo-utils/src/__tests__/packageInfo.spec.ts
@@ -1,0 +1,88 @@
+import { PackageEntries } from '../interfaces/packageInfoTypes';
+import { getPackageInfo } from '../packageInfo';
+import { getRepoPackagesFromSerializableForm, getSerializableRepoPackages } from '../internal/packageInfoCache';
+import { findGitRoot } from '../repoInfo';
+import { normalizePath } from '../normalizePath';
+
+const _rootPath = normalizePath(findGitRoot());
+
+function trimPath(rootPath: string, fullPath: string): string {
+  const index = fullPath.indexOf(rootPath);
+  return index >= 0 ? fullPath.substr(index + rootPath.length) : fullPath;
+}
+
+/**
+ * create a version of PackageEntries that does not have config loaders so that they can be compared cleanly
+ * @param entries - entries to create a comparable copy of
+ */
+function comparableEntries(entries: PackageEntries): PackageEntries {
+  return Object.assign(
+    {},
+    ...Object.keys(entries)
+      .sort()
+      .map(name => {
+        const entry = entries[name];
+        return {
+          [name]: {
+            path: trimPath(_rootPath, entry.path),
+            dependencies: Object.assign(
+              {},
+              Object.keys(entry.dependencies).map(name => ({ [name]: {} }))
+            )
+          }
+        };
+      })
+  );
+}
+
+describe('packageInfo', () => {
+  test('load with no-cache', () => {
+    const info = getPackageInfo({ strategy: 'no-cache' });
+    Object.keys(info.entries).forEach(name => {
+      const entry = info.entries[name];
+      const config = entry.getConfig();
+      expect(config.name).toEqual(name);
+    });
+  });
+
+  test('load with cache', () => {
+    const info = getPackageInfo({ strategy: 'normal' });
+    Object.keys(info.entries).forEach(name => {
+      const entry = info.entries[name];
+      const config = entry.getConfig();
+      expect(config.name).toEqual(name);
+    });
+  });
+
+  test('serialize and back are equivalent', () => {
+    const info = getPackageInfo();
+    const serializedForm = getSerializableRepoPackages(info.entries);
+    const unserializedEntries = getRepoPackagesFromSerializableForm(serializedForm);
+    const reserializedForm = getSerializableRepoPackages(unserializedEntries);
+    expect(serializedForm).toEqual(reserializedForm);
+    expect(comparableEntries(info.entries)).toEqual(comparableEntries(unserializedEntries));
+  });
+
+  test('cached and non-cached are equivalent', () => {
+    const infoCached = getPackageInfo();
+    const infoDirect = getPackageInfo({ strategy: 'no-cache' });
+    expect(comparableEntries(infoCached.entries)).toEqual(comparableEntries(infoDirect.entries));
+  });
+
+  test('paths', () => {
+    const paths = getPackageInfo()
+      .paths()
+      .map(path => trimPath(_rootPath, path));
+    expect(paths).toMatchSnapshot();
+  });
+
+  test('names', () => {
+    const names = getPackageInfo().names();
+    expect(names).toMatchSnapshot();
+  });
+
+  test('info matches snapshot', () => {
+    const info = getPackageInfo();
+    expect(comparableEntries(info.entries)).toMatchSnapshot();
+  });
+});

--- a/packages/just-repo-utils/src/__tests__/repoInfo.spec.ts
+++ b/packages/just-repo-utils/src/__tests__/repoInfo.spec.ts
@@ -1,4 +1,4 @@
-import { findGitRoot, repoInfo } from '../repoInfo';
+import { findGitRoot, getRepoInfo } from '../repoInfo';
 
 describe('findGitRoot', () => {
   test('find git root exists', () => {
@@ -36,11 +36,11 @@ describe('findGitRoot', () => {
 describe('repoInfo', () => {
   test('repoInfo includes the correct root', () => {
     const root = findGitRoot();
-    expect(repoInfo().rootPath).toEqual(root);
+    expect(getRepoInfo().rootPath).toEqual(root);
   });
 
   test('repo info finds monorepo info', () => {
-    const info = repoInfo();
+    const info = getRepoInfo();
     expect(info.monorepo).toEqual('lerna');
     expect(info.getLernaJson).toBeDefined();
     expect(info.getRushJson).toBeUndefined();
@@ -48,10 +48,10 @@ describe('repoInfo', () => {
   });
 
   test('repoInfo can load lerna config', () => {
-    expect(repoInfo().getLernaJson!().packages).toBeDefined();
+    expect(getRepoInfo().getLernaJson!().packages).toBeDefined();
   });
 
   test('repoInfo can load root package json', () => {
-    expect(repoInfo().getPackageJson().name).toEqual('just-repo');
+    expect(getRepoInfo().getPackageJson().name).toEqual('just-repo');
   });
 });

--- a/packages/just-repo-utils/src/__tests__/repoInfo.spec.ts
+++ b/packages/just-repo-utils/src/__tests__/repoInfo.spec.ts
@@ -1,0 +1,57 @@
+import { findGitRoot, repoInfo } from '../repoInfo';
+
+describe('findGitRoot', () => {
+  test('find git root exists', () => {
+    expect(findGitRoot()).toBeTruthy();
+  });
+
+  test('findGitRoot callback basic', () => {
+    let count = 0;
+    const paths: string[] = [];
+    const root = findGitRoot(cur => {
+      count++;
+      paths.push(cur);
+    });
+    expect(count).toBeGreaterThan(0);
+    expect(paths.length).toEqual(count);
+    expect(root).toEqual(paths[paths.length - 1]);
+  });
+
+  test('findGitRoot callback cancels correctly', () => {
+    const paths: string[] = [];
+    findGitRoot(cur => {
+      paths.push(cur);
+    });
+    for (let i = 0; i < paths.length; i++) {
+      let count = 0;
+      const stopPt = findGitRoot(_cur => {
+        return count++ === i;
+      });
+      expect(stopPt).toEqual(paths[i]);
+      expect(count).toEqual(i + 1);
+    }
+  });
+});
+
+describe('repoInfo', () => {
+  test('repoInfo includes the correct root', () => {
+    const root = findGitRoot();
+    expect(repoInfo().rootPath).toEqual(root);
+  });
+
+  test('repo info finds monorepo info', () => {
+    const info = repoInfo();
+    expect(info.monorepo).toEqual('lerna');
+    expect(info.getLernaJson).toBeDefined();
+    expect(info.getRushJson).toBeUndefined();
+    expect(info.getPackageJson).toBeDefined();
+  });
+
+  test('repoInfo can load lerna config', () => {
+    expect(repoInfo().getLernaJson!().packages).toBeDefined();
+  });
+
+  test('repoInfo can load root package json', () => {
+    expect(repoInfo().getPackageJson().name).toEqual('just-repo');
+  });
+});

--- a/packages/just-repo-utils/src/cacheUtils.ts
+++ b/packages/just-repo-utils/src/cacheUtils.ts
@@ -1,23 +1,60 @@
 import { gitListFiles, gitHashObject } from './gitUtils';
 import { repoInfo } from './repoInfo';
 import path from 'path';
+import fs from 'fs-extra';
 
-export const lockFiles = ['shrinkwrap.yml', 'package-lock.json', 'yarn.lock', 'pnpmfile.js'];
-export const projectFiles = ['rush.json', 'lerna.json'];
-
+/**
+ * Processes the list of files (or globs), returns a set, then returns hash keys for those files
+ * @param rootPath - root path to base the git query
+ * @param files - file scopings for matching
+ */
 export function getFileHashes(rootPath: string, files: string[]): { [file: string]: string } {
   const foundFiles = gitListFiles(rootPath, files);
   const hashes = gitHashObject(rootPath, foundFiles);
-  return Object.assign({}, ...foundFiles.map((fileName: string, index: number) => ({
-    [fileName]: hashes[index]
-  })));
+  return Object.assign(
+    {},
+    ...foundFiles.map((fileName: string, index: number) => ({
+      [fileName]: hashes[index]
+    }))
+  );
 }
 
+/**
+ * Given a list of files, this:
+ *  - filters the list for existence
+ *  - then returns an array of modified timestamps as strings
+ *
+ * Note that in rough profiling on Windows this routine took ~0.5ms vs ~100ms for getFileHashes
+ * for the same set of files.
+ *
+ * @param rootPath - root path to search for files in
+ * @param files - list of files to query, note that this does not accept globs
+ */
+export function queryTimestamps(rootPath: string, files: string[]): string[] {
+  return files
+    .map(file => path.join(rootPath, file))
+    .filter(filePath => fs.existsSync(filePath))
+    .map(existingFile => String(fs.statSync(existingFile).mtimeMs));
+}
+
+/**
+ * Get a cheap hash key for the repository structure.  Note that this is mainly for information
+ * that only changes when things like the lock file, lerna.json, rush.json are modified
+ *
+ * @param rootPath - root of the repo
+ */
 export function getRepoHashKey(rootPath: string): string {
-  const hashes = gitHashObject(rootPath, gitListFiles(rootPath, [...lockFiles, ...projectFiles]));
-  return hashes.join('-');
+  return queryTimestamps(rootPath, ['shrinkwrap.yml', 'package-lock.json', 'yarn.lock', 'pnpmfile.js', 'rush.json', 'lerna.json']).join(
+    '-'
+  );
 }
 
+/**
+ * Get a standard path for just cache files
+ *
+ * @param fileName - file name for the cache file
+ * @param useRoot - if true will find the repo root, if false or omitted will work from the current working directory
+ */
 export function getCachePath(fileName: string, useRoot?: boolean): string {
   const basePath = useRoot ? repoInfo().rootPath : process.cwd();
   return path.join(basePath, 'node_modules/.just', fileName);

--- a/packages/just-repo-utils/src/cacheUtils.ts
+++ b/packages/just-repo-utils/src/cacheUtils.ts
@@ -1,0 +1,24 @@
+import { gitListFiles, gitHashObject } from './gitUtils';
+import { repoInfo } from './repoInfo';
+import path from 'path';
+
+export const lockFiles = ['shrinkwrap.yml', 'package-lock.json', 'yarn.lock', 'pnpmfile.js'];
+export const projectFiles = ['rush.json', 'lerna.json'];
+
+export function getFileHashes(rootPath: string, files: string[]): { [file: string]: string } {
+  const foundFiles = gitListFiles(rootPath, files);
+  const hashes = gitHashObject(rootPath, foundFiles);
+  return Object.assign({}, ...foundFiles.map((fileName: string, index: number) => ({
+    [fileName]: hashes[index]
+  })));
+}
+
+export function getRepoHashKey(rootPath: string): string {
+  const hashes = gitHashObject(rootPath, gitListFiles(rootPath, [...lockFiles, ...projectFiles]));
+  return hashes.join('-');
+}
+
+export function getCachePath(fileName: string, useRoot?: boolean): string {
+  const basePath = useRoot ? repoInfo().rootPath : process.cwd();
+  return path.join(basePath, 'node_modules/.just', fileName);
+}

--- a/packages/just-repo-utils/src/cacheUtils.ts
+++ b/packages/just-repo-utils/src/cacheUtils.ts
@@ -1,5 +1,5 @@
 import { gitListFiles, gitHashObject } from './gitUtils';
-import { repoInfo } from './repoInfo';
+import { getRepoInfo } from './repoInfo';
 import path from 'path';
 import fs from 'fs-extra';
 
@@ -56,6 +56,6 @@ export function getRepoHashKey(rootPath: string): string {
  * @param useRoot - if true will find the repo root, if false or omitted will work from the current working directory
  */
 export function getCachePath(fileName: string, useRoot?: boolean): string {
-  const basePath = useRoot ? repoInfo().rootPath : process.cwd();
+  const basePath = useRoot ? getRepoInfo().rootPath : process.cwd();
   return path.join(basePath, 'node_modules/.just', fileName);
 }

--- a/packages/just-repo-utils/src/gitUtils.ts
+++ b/packages/just-repo-utils/src/gitUtils.ts
@@ -5,7 +5,8 @@ function cleanGitStdout(stdout: Buffer): string[] {
   return stdout
     .toString()
     .split(/\n/)
-    .map(l => l.trim());
+    .map(l => l.trim())
+    .filter(v => v);
 }
 
 export function findGitRoot(): string {

--- a/packages/just-repo-utils/src/gitUtils.ts
+++ b/packages/just-repo-utils/src/gitUtils.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process';
-import { repoInfo } from './repoInfo';
+import { findGitRoot } from './repoInfo';
 
 function cleanGitStdout(stdout: Buffer): string[] {
   return stdout
@@ -7,10 +7,6 @@ function cleanGitStdout(stdout: Buffer): string[] {
     .split(/\n/)
     .map(l => l.trim())
     .filter(v => v);
-}
-
-export function findGitRoot(): string {
-  return repoInfo().rootPath;
 }
 
 export function gitListFiles(root: string | undefined, scope: string[]): string[] {

--- a/packages/just-repo-utils/src/gitUtils.ts
+++ b/packages/just-repo-utils/src/gitUtils.ts
@@ -1,0 +1,26 @@
+import { spawnSync } from 'child_process';
+import { repoInfo } from './repoInfo';
+
+function cleanGitStdout(stdout: Buffer): string[] {
+  return stdout
+    .toString()
+    .split(/\n/)
+    .map(l => l.trim());
+}
+
+export function findGitRoot(): string {
+  return repoInfo().rootPath;
+}
+
+export function gitListFiles(root: string | undefined, scope: string[]): string[] {
+  root = root || findGitRoot();
+  scope = scope || [];
+  const lsResults = spawnSync('git', ['ls-files', ...scope], { cwd: root });
+  return lsResults.status !== 0 ? [] : cleanGitStdout(lsResults.stdout);
+}
+
+export function gitHashObject(root: string | undefined, files: string[]): string[] {
+  root = root || findGitRoot();
+  const hashResults = spawnSync('git', ['hash-object', ...files], { cwd: root });
+  return hashResults.status !== 0 ? [] : cleanGitStdout(hashResults.stdout);
+}

--- a/packages/just-repo-utils/src/index.ts
+++ b/packages/just-repo-utils/src/index.ts
@@ -1,7 +1,7 @@
 export { PackageJson, RushJson, LernaJson } from './interfaces/configTypes';
 export * from './cacheUtils';
 export * from './gitUtils';
-export * from './normalizePath';
+export * from './normalizeToUnixPath';
 export * from './packageInfo';
 export * from './readConfigs';
 export * from './repoInfo';

--- a/packages/just-repo-utils/src/index.ts
+++ b/packages/just-repo-utils/src/index.ts
@@ -1,0 +1,7 @@
+export { PackageJson, RushJson, LernaJson } from './interfaces/configTypes';
+export * from './cacheUtils';
+export * from './gitUtils';
+export * from './normalizePath';
+export * from './packageInfo';
+export * from './readConfigs';
+export * from './repoInfo';

--- a/packages/just-repo-utils/src/interfaces/configTypes.ts
+++ b/packages/just-repo-utils/src/interfaces/configTypes.ts
@@ -1,0 +1,67 @@
+/**
+ * defers the actual parsing and loading of a JSON file behind a loader function.  Generally the
+ * existence check will already be completed such that a successful return can be guaranteed
+ */
+export type ConfigLoader<T> = () => T;
+
+/**
+ * Rush project info, corresponds to each project within the larger rush repo
+ */
+export interface RushProject {
+  packageName: string;
+  projectFolder: string;
+  shouldPublish?: boolean;
+  versionPolicyName?: string;
+}
+
+/**
+ * Root of the parsed rush json
+ */
+export interface RushJson {
+  projects: RushProject[];
+  rushVersion: string;
+  // more properties can be added as needed
+}
+
+/**
+ * Loader type for deferred loading of rush JSON
+ */
+export type RushJsonLoader = ConfigLoader<RushJson>;
+
+/**
+ * Format for lerna json, packages reflect the globs denoting sub-packages
+ */
+export interface LernaJson {
+  packages: string[];
+  useWorkspaces?: boolean;
+  npmClient?: string;
+  version?: string;
+}
+
+/**
+ * Loader type for deferred loading of lerna json
+ */
+export type LernaJsonLoader = ConfigLoader<LernaJson>;
+
+interface Dependencies {
+  [key: string]: string;
+}
+
+export interface PackageJson {
+  name: string;
+  description?: string;
+  dependencies?: Dependencies;
+  devDependencies?: Dependencies;
+  peerDependencies?: Dependencies;
+  keywords?: string;
+  just?: {
+    /** Stack that the package is tracking */
+    stack?: string;
+  };
+  [key: string]: any;
+}
+
+/**
+ * loader type for deferred loading of package JSON
+ */
+export type PackageJsonLoader = ConfigLoader<PackageJson>;

--- a/packages/just-repo-utils/src/interfaces/packageInfoTypes.ts
+++ b/packages/just-repo-utils/src/interfaces/packageInfoTypes.ts
@@ -1,0 +1,35 @@
+import { PackageJsonLoader } from './configTypes';
+
+export interface PackageEntry {
+  path: string;
+  getConfig: PackageJsonLoader;
+  dependencies: { [key: string]: PackageEntry };
+}
+
+export interface PackageInfo {
+  [key: string]: PackageEntry;
+}
+
+/**
+ * cache strategy to use for package info.  Values are:
+ *  normal - try to load from the cache and save normally
+ *  update - don't load from the cache and save a new copy to the cache
+ *  no-cache - don't load or save to the cache
+ */
+export type CacheStrategy = 'normal' | 'no-cache' | 'update';
+
+/**
+ * optional options for package info routines
+ */
+export interface PackageInfoOptions {
+  /**
+   * caching strategy to use for package info queries, defaults to 'normal'
+   */
+  strategy?: CacheStrategy;
+
+  /**
+   * when querying dependencies this is the target package name to use for the query.  If
+   * omitted this is assumed to be the package in process.cwd()
+   */
+  target?: string;
+}

--- a/packages/just-repo-utils/src/interfaces/packageInfoTypes.ts
+++ b/packages/just-repo-utils/src/interfaces/packageInfoTypes.ts
@@ -6,7 +6,7 @@ export interface PackageEntry {
   dependencies: { [key: string]: PackageEntry };
 }
 
-export interface PackageInfo {
+export interface PackageEntries {
   [key: string]: PackageEntry;
 }
 
@@ -32,4 +32,28 @@ export interface PackageInfoOptions {
    * omitted this is assumed to be the package in process.cwd()
    */
   target?: string;
+}
+
+export interface PackageInfo {
+  /**
+   * Retrieve an array of paths for the entries
+   */
+  paths: () => string[];
+
+  /**
+   * Retrieve an array of names for the entries
+   */
+  names: () => string[];
+
+  /**
+   * Return a filtered PackageInfo for either targeting the name of a package or the
+   * package in the current working directory
+   */
+  dependencies: (target?: string) => PackageInfo;
+
+  /**
+   * Raw entry table for clients who want to do name to path mappings or have access to the package
+   * json files for the packages
+   */
+  entries: PackageEntries;
 }

--- a/packages/just-repo-utils/src/interfaces/packageInfoTypes.ts
+++ b/packages/just-repo-utils/src/interfaces/packageInfoTypes.ts
@@ -32,6 +32,15 @@ export interface PackageInfoOptions {
    * omitted this is assumed to be the package in process.cwd()
    */
   target?: string;
+
+  /**
+   * normally a package is a dependency if it is in dependencies or devDependencies as these
+   * two are effectively the same from a repository package install perspective.  (i.e. changing
+   * from one to the other won't change the yarn lockfile)
+   *
+   * Specifying one of these will narrow the returned results
+   */
+  dependencyType?: 'dependencies' | 'devDependencies';
 }
 
 export interface PackageInfo {
@@ -49,7 +58,7 @@ export interface PackageInfo {
    * Return a filtered PackageInfo for either targeting the name of a package or the
    * package in the current working directory
    */
-  dependencies: (target?: string) => PackageInfo;
+  dependencies: (options?: PackageInfoOptions) => PackageInfo;
 
   /**
    * Raw entry table for clients who want to do name to path mappings or have access to the package

--- a/packages/just-repo-utils/src/interfaces/repoInfoTypes.ts
+++ b/packages/just-repo-utils/src/interfaces/repoInfoTypes.ts
@@ -1,0 +1,26 @@
+import { PackageJsonLoader, RushJsonLoader, LernaJsonLoader } from './configTypes';
+
+/**
+ * types of supported monorepos
+ */
+export type MonorepoType = 'lerna' | 'rush';
+
+/**
+ * Info for the repository
+ */
+export interface RepoInfo {
+  /** root of the enlistment */
+  rootPath: string;
+
+  /** loader for package JSON */
+  getPackageJson: PackageJsonLoader;
+
+  /** if it is a monorepo denotes whether it is rush or lerna based */
+  monorepo?: MonorepoType;
+
+  /** loader function to get the parsed rush json */
+  getRushJson?: RushJsonLoader;
+
+  /** loader function to get the parsed lerna json */
+  getLernaJson?: LernaJsonLoader;
+}

--- a/packages/just-repo-utils/src/internal/packageInfoCache.ts
+++ b/packages/just-repo-utils/src/internal/packageInfoCache.ts
@@ -1,4 +1,4 @@
-import { repoInfo } from '../repoInfo';
+import { getRepoInfo } from '../repoInfo';
 import { getRepoHashKey, getCachePath } from '../cacheUtils';
 import { PackageEntries } from '../interfaces/packageInfoTypes';
 import { getConfigLoader, readJsonConfig } from '../readConfigs';
@@ -66,7 +66,7 @@ export function getRepoPackagesFromSerializableForm(info: ISerializableRepoPacka
  * @param pkgInfo - package info to save in a cache file
  */
 export function cachePackageInfo(pkgInfo: PackageEntries): void {
-  const repo = repoInfo();
+  const repo = getRepoInfo();
   const toJson: IPackageInfoCacheJson = {
     hash: getRepoHashKey(repo.rootPath),
     packages: getSerializableRepoPackages(pkgInfo)
@@ -84,7 +84,7 @@ export function cachePackageInfo(pkgInfo: PackageEntries): void {
  * this attempts to load package info from a JSON cache file
  */
 export function retrievePackageInfo(): PackageEntries | undefined {
-  const repo = repoInfo();
+  const repo = getRepoInfo();
   const jsonData = readJsonConfig<IPackageInfoCacheJson>(cachePath);
   if (jsonData && jsonData.hash == getRepoHashKey(repo.rootPath)) {
     return getRepoPackagesFromSerializableForm(jsonData.packages);

--- a/packages/just-repo-utils/src/internal/packageInfoCache.ts
+++ b/packages/just-repo-utils/src/internal/packageInfoCache.ts
@@ -1,8 +1,8 @@
-import { repoInfo } from './repoInfo';
-import { getRepoHashKey, getCachePath } from './cacheUtils';
-import { PackageInfo } from './interfaces/packageInfoTypes';
-import { getConfigLoader, readJsonConfig } from './readConfigs';
-import { PackageJson, PackageJsonLoader } from './interfaces/configTypes';
+import { repoInfo } from '../repoInfo';
+import { getRepoHashKey, getCachePath } from '../cacheUtils';
+import { PackageEntries } from '../interfaces/packageInfoTypes';
+import { getConfigLoader, readJsonConfig } from '../readConfigs';
+import { PackageJson, PackageJsonLoader } from '../interfaces/configTypes';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -23,19 +23,25 @@ interface IPackageInfoCacheJson {
 const cacheFileName = 'package-info.json';
 const cachePath = getCachePath(cacheFileName, true);
 
-function getSerializableRepoPackages(info: PackageInfo): ISerializableRepoPackages {
+/**
+ * @private only exposed for testing
+ */
+export function getSerializableRepoPackages(info: PackageEntries): ISerializableRepoPackages {
   const results: ISerializableRepoPackages = {};
   Object.keys(info).forEach(pkgName => {
     results[pkgName] = {
       path: info[pkgName].path,
       dependencies: Object.keys(info[pkgName].dependencies)
-    }
+    };
   });
   return results;
 }
 
-function getRepoPackagesFromSerializableForm(info: ISerializableRepoPackages): PackageInfo {
-  const results: PackageInfo = {};
+/**
+ * @private only exposed for testing
+ */
+export function getRepoPackagesFromSerializableForm(info: ISerializableRepoPackages): PackageEntries {
+  const results: PackageEntries = {};
   // build the initial set
   Object.keys(info).forEach(pkgName => {
     const entry = info[pkgName];
@@ -43,31 +49,28 @@ function getRepoPackagesFromSerializableForm(info: ISerializableRepoPackages): P
       path: entry.path,
       getConfig: getConfigLoader<PackageJson>(entry.path, 'package.json') as PackageJsonLoader,
       dependencies: {}
-    }
+    };
   });
   // now link dependencies
   Object.keys(info).forEach(pkgName => {
     const dependencies = results[pkgName].dependencies;
     info[pkgName].dependencies.forEach(pkg => {
       dependencies[pkg] = results[pkg];
-    })
+    });
   });
   return results;
 }
-
-// local storage value for calling this multiple times in the same session
-let _packageInfo: PackageInfo | undefined = undefined;
 
 /**
  * this saves the loaded package info into a JSON cache file
  * @param pkgInfo - package info to save in a cache file
  */
-export function cachePackageInfo(pkgInfo: PackageInfo): void {
+export function cachePackageInfo(pkgInfo: PackageEntries): void {
   const repo = repoInfo();
   const toJson: IPackageInfoCacheJson = {
     hash: getRepoHashKey(repo.rootPath),
     packages: getSerializableRepoPackages(pkgInfo)
-  }
+  };
   // ensure the directory is created
   const cacheDir = path.dirname(cachePath);
   if (!fs.pathExistsSync(cacheDir)) {
@@ -75,17 +78,12 @@ export function cachePackageInfo(pkgInfo: PackageInfo): void {
   }
   // now write out the cache file
   fs.writeFileSync(cachePath, JSON.stringify(toJson, null, 2));
-  _packageInfo = pkgInfo;
 }
 
 /**
  * this attempts to load package info from a JSON cache file
  */
-export function retrievePackageInfo(): PackageInfo | undefined {
-  if (_packageInfo) {
-    return _packageInfo;
-  }
-
+export function retrievePackageInfo(): PackageEntries | undefined {
   const repo = repoInfo();
   const jsonData = readJsonConfig<IPackageInfoCacheJson>(cachePath);
   if (jsonData && jsonData.hash == getRepoHashKey(repo.rootPath)) {

--- a/packages/just-repo-utils/src/internal/packageInfoHelpers.ts
+++ b/packages/just-repo-utils/src/internal/packageInfoHelpers.ts
@@ -1,7 +1,7 @@
 import { PackageJson, PackageJsonLoader, RushProject } from '../interfaces/configTypes';
 import { PackageEntries, PackageEntry, PackageInfo } from '../interfaces/packageInfoTypes';
 import { getConfigLoader, readPackageJson } from '../readConfigs';
-import { normalizePath } from '../normalizePath';
+import { normalizeToUnixPath } from '../normalizeToUnixPath';
 import path from 'path';
 import glob from 'glob';
 
@@ -10,7 +10,7 @@ function buildPackageInfo(root: string, pkgPath: string, pkgJsonName?: string): 
   const getConfig = getConfigLoader<PackageJson>(pkgJsonPath) as PackageJsonLoader;
   return {
     [getConfig().name]: {
-      path: normalizePath(path.dirname(pkgJsonPath)),
+      path: normalizeToUnixPath(path.dirname(pkgJsonPath)),
       getConfig,
       dependencies: {}
     }
@@ -70,7 +70,7 @@ function addRecursiveDependencies(collector: PackageEntries, entry: PackageEntry
 
 export function infoFromEntries(entries: PackageEntries): PackageInfo {
   return {
-    paths: () => Object.keys(entries).map(pkgName => normalizePath(entries[pkgName].path)),
+    paths: () => Object.keys(entries).map(pkgName => normalizeToUnixPath(entries[pkgName].path)),
     names: () => Object.keys(entries),
     dependencies: (target?: string) => {
       target = target || readPackageJson(process.cwd())!.name;

--- a/packages/just-repo-utils/src/internal/packageInfoHelpers.ts
+++ b/packages/just-repo-utils/src/internal/packageInfoHelpers.ts
@@ -1,0 +1,86 @@
+import { PackageJson, PackageJsonLoader, RushProject } from '../interfaces/configTypes';
+import { PackageEntries, PackageEntry, PackageInfo } from '../interfaces/packageInfoTypes';
+import { getConfigLoader, readPackageJson } from '../readConfigs';
+import { normalizePath } from '../normalizePath';
+import path from 'path';
+import glob from 'glob';
+
+function buildPackageInfo(root: string, pkgPath: string, pkgJsonName?: string): PackageEntries {
+  const pkgJsonPath = pkgJsonName ? path.join(root, pkgPath, pkgJsonName) : path.join(root, pkgPath);
+  const getConfig = getConfigLoader<PackageJson>(pkgJsonPath) as PackageJsonLoader;
+  return {
+    [getConfig().name]: {
+      path: normalizePath(path.dirname(pkgJsonPath)),
+      getConfig,
+      dependencies: {}
+    }
+  };
+}
+
+function buildPackageInfoForGlob(root: string, pkgGlob: string): PackageEntries {
+  const matchPattern = pkgGlob + '/package.json';
+  const globOptions = { cwd: root, ignore: '**/node_modules/**' };
+  return Object.assign({}, ...glob.sync(matchPattern, globOptions).map(subPath => buildPackageInfo(root, subPath)));
+}
+
+function addPackageDependencyBranch(repoInfo: PackageEntries, pkg: PackageEntry, key: string): void {
+  const config = pkg.getConfig();
+  const section = config[key];
+  const dependencies = pkg.dependencies;
+  if (section) {
+    Object.keys(section).forEach(dependency => {
+      if (repoInfo[dependency] && !dependencies[dependency]) {
+        dependencies[dependency] = repoInfo[dependency];
+      }
+    });
+  }
+}
+
+function addPackageDependencies(info: PackageEntries): void {
+  Object.keys(info).forEach(pkg => {
+    addPackageDependencyBranch(info, info[pkg], 'dependencies');
+    addPackageDependencyBranch(info, info[pkg], 'devDependencies');
+  });
+}
+
+export function buildPackageInfoFromGlobs(root: string, globs: string[]): PackageEntries {
+  const results: PackageEntries = Object.assign({}, ...globs.map(glob => buildPackageInfoForGlob(root, glob)));
+  addPackageDependencies(results);
+  return results;
+}
+
+export function buildPackageInfoFromRushProjects(root: string, projects: RushProject[]): PackageEntries {
+  const results: PackageEntries = Object.assign(
+    {},
+    ...projects.map(project => buildPackageInfo(root, project.projectFolder, 'package.json'))
+  );
+  addPackageDependencies(results);
+  return results;
+}
+
+function addRecursiveDependencies(collector: PackageEntries, entry: PackageEntry): void {
+  const dependencies = entry.dependencies;
+  Object.keys(dependencies).forEach(dep => {
+    if (!collector[dep]) {
+      collector[dep] = dependencies[dep];
+      addRecursiveDependencies(collector, dependencies[dep]);
+    }
+  });
+}
+
+export function infoFromEntries(entries: PackageEntries): PackageInfo {
+  return {
+    paths: () => Object.keys(entries).map(pkgName => normalizePath(entries[pkgName].path)),
+    names: () => Object.keys(entries),
+    dependencies: (target?: string) => {
+      target = target || readPackageJson(process.cwd())!.name;
+      const baseEntry = entries[target];
+      const collector: PackageEntries = {};
+      if (baseEntry) {
+        addRecursiveDependencies(collector, baseEntry);
+      }
+      return infoFromEntries(collector);
+    },
+    entries
+  };
+}

--- a/packages/just-repo-utils/src/normalizePath.ts
+++ b/packages/just-repo-utils/src/normalizePath.ts
@@ -1,0 +1,9 @@
+import path from 'path';
+
+/**
+ * take a path and make sure it uses forward slashes
+ * @param base - path to put into forward slashed form
+ */
+export function normalizePath(base: string): string {
+  return path.normalize(base).replace(/\\/g, '/');
+}

--- a/packages/just-repo-utils/src/normalizeToUnixPath.ts
+++ b/packages/just-repo-utils/src/normalizeToUnixPath.ts
@@ -1,9 +1,9 @@
 import path from 'path';
 
 /**
- * take a path and make sure it uses forward slashes
+ * take a path, call path.normalize, then make sure it uses forward slashes
  * @param base - path to put into forward slashed form
  */
-export function normalizePath(base: string): string {
+export function normalizeToUnixPath(base: string): string {
   return path.normalize(base).replace(/\\/g, '/');
 }

--- a/packages/just-repo-utils/src/packageInfo.ts
+++ b/packages/just-repo-utils/src/packageInfo.ts
@@ -1,67 +1,13 @@
-import { PackageInfo, PackageEntry, PackageInfoOptions } from './interfaces/packageInfoTypes';
+import { PackageInfoOptions, PackageInfo } from './interfaces/packageInfoTypes';
 import { repoInfo } from './repoInfo';
-import { PackageJson, PackageJsonLoader, RushProject } from './interfaces/configTypes';
-import { getConfigLoader, readPackageJson } from './readConfigs';
-import { normalizePath } from './normalizePath';
-import path from 'path';
-import glob from 'glob';
-import { retrievePackageInfo, cachePackageInfo } from './packageInfoCache';
-
-function buildPackageInfo(root: string, pkgPath: string, pkgJsonName?: string): PackageInfo {
-  const pkgJsonPath = pkgJsonName ? path.join(root, pkgPath, pkgJsonName) : path.join(root, pkgPath);
-  const getConfig = getConfigLoader<PackageJson>(pkgJsonPath) as PackageJsonLoader;
-  return {
-    [getConfig().name]: {
-      path: normalizePath(path.dirname(pkgJsonPath)),
-      getConfig,
-      dependencies: {}
-    }
-  };
-}
-
-function buildPackageInfoForGlob(root: string, pkgGlob: string): PackageInfo {
-  const matchPattern = pkgGlob + '/package.json';
-  const globOptions = { cwd: root, ignore: '**/node_modules/**' };
-  return Object.assign({}, ...glob.sync(matchPattern, globOptions).map(subPath => buildPackageInfo(root, subPath)));
-}
-
-function addPackageDependencyBranch(repoInfo: PackageInfo, pkg: PackageEntry, key: string): void {
-  const config = pkg.getConfig();
-  const section = config[key];
-  const dependencies = pkg.dependencies;
-  if (section) {
-    Object.keys(section).forEach(dependency => {
-      if (repoInfo[dependency] && !dependencies[dependency]) {
-        dependencies[dependency] = repoInfo[dependency];
-      }
-    });
-  }
-}
-
-function addPackageDependencies(info: PackageInfo): void {
-  Object.keys(info).forEach(pkg => {
-    addPackageDependencyBranch(info, info[pkg], 'dependencies');
-    addPackageDependencyBranch(info, info[pkg], 'devDependencies');
-  })
-}
-
-function buildPackageInfoFromGlobs(root: string, globs: string[]): PackageInfo {
-  const results: PackageInfo = Object.assign({}, ...globs.map(glob => buildPackageInfoForGlob(root, glob)));
-  addPackageDependencies(results);
-  return results;
-}
-
-function buidlPackageInfoFromRushProjects(root: string, projects: RushProject[]): PackageInfo {
-  const results: PackageInfo = Object.assign({}, ...projects.map(project => buildPackageInfo(root, project.projectFolder, 'package.json')));
-  addPackageDependencies(results);
-  return results;
-}
 
 /**
  * retrieves information about the packages in the repository
  * @param strategy - cache strategy to use for loading, defaults to normal
  */
 export function getPackageInfo(options?: PackageInfoOptions): PackageInfo {
+  const { retrievePackageInfo, cachePackageInfo } = require('./internal/packageInfoCache');
+  const { infoFromEntries, buildPackageInfoFromGlobs, buildPackageInfoFromRushProjects } = require('./internal/packageInfoHelpers');
   const { strategy = 'normal' } = options || {};
   let repoPackageInfo = strategy === 'normal' && retrievePackageInfo();
   if (!repoPackageInfo) {
@@ -69,67 +15,16 @@ export function getPackageInfo(options?: PackageInfoOptions): PackageInfo {
     if (repo.getLernaJson) {
       repoPackageInfo = buildPackageInfoFromGlobs(repo.rootPath, repo.getLernaJson().packages);
     } else if (repo.getRushJson) {
-      repoPackageInfo = buidlPackageInfoFromRushProjects(repo.rootPath, repo.getRushJson().projects);
+      repoPackageInfo = buildPackageInfoFromRushProjects(repo.rootPath, repo.getRushJson().projects);
     }
     if (strategy !== 'no-cache' && repoPackageInfo) {
       cachePackageInfo(repoPackageInfo);
     }
   }
-  return repoPackageInfo || {};
+  return infoFromEntries(repoPackageInfo || {});
 }
 
-function packageInfoToPaths(info: PackageInfo): string[] {
-  return Object.keys(info).map(pkgName => normalizePath(info[pkgName].path));
-}
-
-/**
- * Get the name of all packages that are part of this repo
- * @param options - standard package info options
- */
-export function getRepoPackageNames(options?: PackageInfoOptions): string[] {
-  return Object.keys(getPackageInfo(options));
-}
-
-/**
- * Get paths for all packages that are part of this repo
- * @param options - standard package info options
- */
-export function getRepoPackagePaths(options?: PackageInfoOptions): string[] {
-  return packageInfoToPaths(getPackageInfo(options));
-}
-
-function addRecursiveDependencies(collector: PackageInfo, entry: PackageEntry): void {
-  const dependencies = entry.dependencies;
-  Object.keys(dependencies).forEach(dep => {
-    if (!collector[dep]) {
-      collector[dep] = dependencies[dep];
-      addRecursiveDependencies(collector, dependencies[dep]);
-    }
-  });
-}
-
-function getDependentPackageEntries(options?: PackageInfoOptions): PackageInfo {
-  const target = options && options.target || readPackageJson(process.cwd())!.name;
-  const baseEntry = getPackageInfo(options)[target];
-  const collector: PackageInfo = {};
-  if (baseEntry) {
-    addRecursiveDependencies(collector, baseEntry);
-  }
-  return collector;
-}
-
-/**
- * return a list of dependent packages for the package in the current working directory
- * @param options - options for caching and targeting a package by name
- */
-export function getDependentPackageNames(options?: PackageInfoOptions): string[] {
-  return Object.keys(getDependentPackageEntries(options));
-}
-
-/**
- * return a list of dependent package paths for the package in the current working directory
- * @param options - options for caching and targeting a package by name
- */
-export function getDependentPackagePaths(options?: PackageInfoOptions): string[] {
-  return packageInfoToPaths(getDependentPackageEntries(options));
+export function getDependentPackageInfo(options?: PackageInfoOptions): PackageInfo {
+  options = options || {};
+  return getPackageInfo(options).dependencies(options.target);
 }

--- a/packages/just-repo-utils/src/packageInfo.ts
+++ b/packages/just-repo-utils/src/packageInfo.ts
@@ -1,5 +1,5 @@
 import { PackageInfoOptions, PackageInfo } from './interfaces/packageInfoTypes';
-import { repoInfo } from './repoInfo';
+import { getRepoInfo } from './repoInfo';
 
 /**
  * retrieves information about the packages in the repository
@@ -11,7 +11,7 @@ export function getPackageInfo(options?: PackageInfoOptions): PackageInfo {
   const { strategy = 'normal' } = options || {};
   let repoPackageInfo = strategy === 'normal' && retrievePackageInfo();
   if (!repoPackageInfo) {
-    const repo = repoInfo();
+    const repo = getRepoInfo();
     if (repo.getLernaJson) {
       repoPackageInfo = buildPackageInfoFromGlobs(repo.rootPath, repo.getLernaJson().packages);
     } else if (repo.getRushJson) {

--- a/packages/just-repo-utils/src/packageInfo.ts
+++ b/packages/just-repo-utils/src/packageInfo.ts
@@ -1,0 +1,135 @@
+import { PackageInfo, PackageEntry, PackageInfoOptions } from './interfaces/packageInfoTypes';
+import { repoInfo } from './repoInfo';
+import { PackageJson, PackageJsonLoader, RushProject } from './interfaces/configTypes';
+import { getConfigLoader, readPackageJson } from './readConfigs';
+import { normalizePath } from './normalizePath';
+import path from 'path';
+import glob from 'glob';
+import { retrievePackageInfo, cachePackageInfo } from './packageInfoCache';
+
+function buildPackageInfo(root: string, pkgPath: string, pkgJsonName?: string): PackageInfo {
+  const pkgJsonPath = pkgJsonName ? path.join(root, pkgPath, pkgJsonName) : path.join(root, pkgPath);
+  const getConfig = getConfigLoader<PackageJson>(pkgJsonPath) as PackageJsonLoader;
+  return {
+    [getConfig().name]: {
+      path: normalizePath(path.dirname(pkgJsonPath)),
+      getConfig,
+      dependencies: {}
+    }
+  };
+}
+
+function buildPackageInfoForGlob(root: string, pkgGlob: string): PackageInfo {
+  const matchPattern = pkgGlob + '/package.json';
+  const globOptions = { cwd: root, ignore: '**/node_modules/**' };
+  return Object.assign({}, ...glob.sync(matchPattern, globOptions).map(subPath => buildPackageInfo(root, subPath)));
+}
+
+function addPackageDependencyBranch(repoInfo: PackageInfo, pkg: PackageEntry, key: string): void {
+  const config = pkg.getConfig();
+  const section = config[key];
+  const dependencies = pkg.dependencies;
+  if (section) {
+    Object.keys(section).forEach(dependency => {
+      if (repoInfo[dependency] && !dependencies[dependency]) {
+        dependencies[dependency] = repoInfo[dependency];
+      }
+    });
+  }
+}
+
+function addPackageDependencies(info: PackageInfo): void {
+  Object.keys(info).forEach(pkg => {
+    addPackageDependencyBranch(info, info[pkg], 'dependencies');
+    addPackageDependencyBranch(info, info[pkg], 'devDependencies');
+  })
+}
+
+function buildPackageInfoFromGlobs(root: string, globs: string[]): PackageInfo {
+  const results: PackageInfo = Object.assign({}, ...globs.map(glob => buildPackageInfoForGlob(root, glob)));
+  addPackageDependencies(results);
+  return results;
+}
+
+function buidlPackageInfoFromRushProjects(root: string, projects: RushProject[]): PackageInfo {
+  const results: PackageInfo = Object.assign({}, ...projects.map(project => buildPackageInfo(root, project.projectFolder, 'package.json')));
+  addPackageDependencies(results);
+  return results;
+}
+
+/**
+ * retrieves information about the packages in the repository
+ * @param strategy - cache strategy to use for loading, defaults to normal
+ */
+export function getPackageInfo(options?: PackageInfoOptions): PackageInfo {
+  const { strategy = 'normal' } = options || {};
+  let repoPackageInfo = strategy === 'normal' && retrievePackageInfo();
+  if (!repoPackageInfo) {
+    const repo = repoInfo();
+    if (repo.getLernaJson) {
+      repoPackageInfo = buildPackageInfoFromGlobs(repo.rootPath, repo.getLernaJson().packages);
+    } else if (repo.getRushJson) {
+      repoPackageInfo = buidlPackageInfoFromRushProjects(repo.rootPath, repo.getRushJson().projects);
+    }
+    if (strategy !== 'no-cache' && repoPackageInfo) {
+      cachePackageInfo(repoPackageInfo);
+    }
+  }
+  return repoPackageInfo || {};
+}
+
+function packageInfoToPaths(info: PackageInfo): string[] {
+  return Object.keys(info).map(pkgName => normalizePath(info[pkgName].path));
+}
+
+/**
+ * Get the name of all packages that are part of this repo
+ * @param options - standard package info options
+ */
+export function getRepoPackageNames(options?: PackageInfoOptions): string[] {
+  return Object.keys(getPackageInfo(options));
+}
+
+/**
+ * Get paths for all packages that are part of this repo
+ * @param options - standard package info options
+ */
+export function getRepoPackagePaths(options?: PackageInfoOptions): string[] {
+  return packageInfoToPaths(getPackageInfo(options));
+}
+
+function addRecursiveDependencies(collector: PackageInfo, entry: PackageEntry): void {
+  const dependencies = entry.dependencies;
+  Object.keys(dependencies).forEach(dep => {
+    if (!collector[dep]) {
+      collector[dep] = dependencies[dep];
+      addRecursiveDependencies(collector, dependencies[dep]);
+    }
+  });
+}
+
+function getDependentPackageEntries(options?: PackageInfoOptions): PackageInfo {
+  const target = options && options.target || readPackageJson(process.cwd())!.name;
+  const baseEntry = getPackageInfo(options)[target];
+  const collector: PackageInfo = {};
+  if (baseEntry) {
+    addRecursiveDependencies(collector, baseEntry);
+  }
+  return collector;
+}
+
+/**
+ * return a list of dependent packages for the package in the current working directory
+ * @param options - options for caching and targeting a package by name
+ */
+export function getDependentPackageNames(options?: PackageInfoOptions): string[] {
+  return Object.keys(getDependentPackageEntries(options));
+}
+
+/**
+ * return a list of dependent package paths for the package in the current working directory
+ * @param options - options for caching and targeting a package by name
+ */
+export function getDependentPackagePaths(options?: PackageInfoOptions): string[] {
+  return packageInfoToPaths(getDependentPackageEntries(options));
+}

--- a/packages/just-repo-utils/src/packageInfo.ts
+++ b/packages/just-repo-utils/src/packageInfo.ts
@@ -26,5 +26,5 @@ export function getPackageInfo(options?: PackageInfoOptions): PackageInfo {
 
 export function getDependentPackageInfo(options?: PackageInfoOptions): PackageInfo {
   options = options || {};
-  return getPackageInfo(options).dependencies(options.target);
+  return getPackageInfo(options).dependencies(options);
 }

--- a/packages/just-repo-utils/src/packageInfoCache.ts
+++ b/packages/just-repo-utils/src/packageInfoCache.ts
@@ -4,6 +4,7 @@ import { PackageInfo } from './interfaces/packageInfoTypes';
 import { getConfigLoader, readJsonConfig } from './readConfigs';
 import { PackageJson, PackageJsonLoader } from './interfaces/configTypes';
 import fs from 'fs-extra';
+import path from 'path';
 
 interface ISerializablePackageEntry {
   path: string;
@@ -67,6 +68,12 @@ export function cachePackageInfo(pkgInfo: PackageInfo): void {
     hash: getRepoHashKey(repo.rootPath),
     packages: getSerializableRepoPackages(pkgInfo)
   }
+  // ensure the directory is created
+  const cacheDir = path.dirname(cachePath);
+  if (!fs.pathExistsSync(cacheDir)) {
+    fs.mkdirpSync(cacheDir);
+  }
+  // now write out the cache file
   fs.writeFileSync(cachePath, JSON.stringify(toJson, null, 2));
   _packageInfo = pkgInfo;
 }

--- a/packages/just-repo-utils/src/packageInfoCache.ts
+++ b/packages/just-repo-utils/src/packageInfoCache.ts
@@ -1,0 +1,88 @@
+import { repoInfo } from './repoInfo';
+import { getRepoHashKey, getCachePath } from './cacheUtils';
+import { PackageInfo } from './interfaces/packageInfoTypes';
+import { getConfigLoader, readJsonConfig } from './readConfigs';
+import { PackageJson, PackageJsonLoader } from './interfaces/configTypes';
+import fs from 'fs-extra';
+
+interface ISerializablePackageEntry {
+  path: string;
+  dependencies: string[];
+}
+
+interface ISerializableRepoPackages {
+  [key: string]: ISerializablePackageEntry;
+}
+
+interface IPackageInfoCacheJson {
+  hash: string;
+  packages: ISerializableRepoPackages;
+}
+
+const cacheFileName = 'package-info.json';
+const cachePath = getCachePath(cacheFileName, true);
+
+function getSerializableRepoPackages(info: PackageInfo): ISerializableRepoPackages {
+  const results: ISerializableRepoPackages = {};
+  Object.keys(info).forEach(pkgName => {
+    results[pkgName] = {
+      path: info[pkgName].path,
+      dependencies: Object.keys(info[pkgName].dependencies)
+    }
+  });
+  return results;
+}
+
+function getRepoPackagesFromSerializableForm(info: ISerializableRepoPackages): PackageInfo {
+  const results: PackageInfo = {};
+  // build the initial set
+  Object.keys(info).forEach(pkgName => {
+    const entry = info[pkgName];
+    results[pkgName] = {
+      path: entry.path,
+      getConfig: getConfigLoader<PackageJson>(entry.path, 'package.json') as PackageJsonLoader,
+      dependencies: {}
+    }
+  });
+  // now link dependencies
+  Object.keys(info).forEach(pkgName => {
+    const dependencies = results[pkgName].dependencies;
+    info[pkgName].dependencies.forEach(pkg => {
+      dependencies[pkg] = results[pkg];
+    })
+  });
+  return results;
+}
+
+// local storage value for calling this multiple times in the same session
+let _packageInfo: PackageInfo | undefined = undefined;
+
+/**
+ * this saves the loaded package info into a JSON cache file
+ * @param pkgInfo - package info to save in a cache file
+ */
+export function cachePackageInfo(pkgInfo: PackageInfo): void {
+  const repo = repoInfo();
+  const toJson: IPackageInfoCacheJson = {
+    hash: getRepoHashKey(repo.rootPath),
+    packages: getSerializableRepoPackages(pkgInfo)
+  }
+  fs.writeFileSync(cachePath, JSON.stringify(toJson, null, 2));
+  _packageInfo = pkgInfo;
+}
+
+/**
+ * this attempts to load package info from a JSON cache file
+ */
+export function retrievePackageInfo(): PackageInfo | undefined {
+  if (_packageInfo) {
+    return _packageInfo;
+  }
+
+  const repo = repoInfo();
+  const jsonData = readJsonConfig<IPackageInfoCacheJson>(cachePath);
+  if (jsonData && jsonData.hash == getRepoHashKey(repo.rootPath)) {
+    return getRepoPackagesFromSerializableForm(jsonData.packages);
+  }
+  return undefined;
+}

--- a/packages/just-repo-utils/src/readConfigs.ts
+++ b/packages/just-repo-utils/src/readConfigs.ts
@@ -13,7 +13,7 @@ export function loadJson<T = object>(pkgPath: string): T {
     // this emits a warning for the bad file, then returns null (though that is against the return
     // signature)  This allows a caller to handle null but will mimic { throws: false } behavior
     logger.warn(`Invalid ${pkgPath.split(path.sep).pop()} detected.`);
-    return undefined as unknown as T;
+    return (undefined as unknown) as T;
   }
 }
 
@@ -27,7 +27,7 @@ export function loadCJson<T = object>(pkgPath: string): T {
     // this emits a warning for the bad file, then returns null (though that is against the return
     // signature)  This allows a caller to handle null but will mimic { throws: false } behavior
     logger.warn(`Invalid ${pkgPath.split(path.sep).pop()} detected.`);
-    return undefined as unknown as T;
+    return (undefined as unknown) as T;
   }
 }
 
@@ -70,12 +70,12 @@ export function readJsonConfig<T = object>(folder: string, name?: string, onLoad
 export function getConfigLoader<T = object>(folder: string, name?: string, onLoad?: LoaderFn<T>): ConfigLoader<T> | undefined {
   onLoad = onLoad || loadJson;
   return ifConfig<ConfigLoader<T>>(folder, name, pkgPath => {
-    let _storage: T | undefined = undefined;
+    let _storage: { config?: T } = {};
     return () => {
-      if (!_storage) {
-        _storage = fse.readJsonSync(pkgPath, { throws: false });
+      if (!_storage.config) {
+        _storage.config = fse.readJsonSync(pkgPath, { throws: false });
       }
-      return _storage as T;
+      return _storage.config as T;
     };
   });
 }
@@ -87,4 +87,3 @@ export function getConfigLoader<T = object>(folder: string, name?: string, onLoa
 export function readPackageJson(folder: string): PackageJson | undefined {
   return readJsonConfig<PackageJson>(folder, 'package.json');
 }
-

--- a/packages/just-repo-utils/src/readConfigs.ts
+++ b/packages/just-repo-utils/src/readConfigs.ts
@@ -1,0 +1,90 @@
+import path from 'path';
+import fse from 'fs-extra';
+import { PackageJson, ConfigLoader } from './interfaces/configTypes';
+import { logger } from 'just-task-logger';
+
+type LoaderFn<T> = (pkgPath: string) => T;
+
+/** default JSON load implementation */
+export function loadJson<T = object>(pkgPath: string): T {
+  try {
+    return fse.readJsonSync(pkgPath);
+  } catch (e) {
+    // this emits a warning for the bad file, then returns null (though that is against the return
+    // signature)  This allows a caller to handle null but will mimic { throws: false } behavior
+    logger.warn(`Invalid ${pkgPath.split(path.sep).pop()} detected.`);
+    return undefined as unknown as T;
+  }
+}
+
+/** loader implementation for CJSON */
+export function loadCJson<T = object>(pkgPath: string): T {
+  const jju = require('jju');
+  try {
+    const fileAsString = fse.readFileSync(pkgPath, 'utf8').toString();
+    return jju.parse(fileAsString, { mode: 'cjson' });
+  } catch (e) {
+    // this emits a warning for the bad file, then returns null (though that is against the return
+    // signature)  This allows a caller to handle null but will mimic { throws: false } behavior
+    logger.warn(`Invalid ${pkgPath.split(path.sep).pop()} detected.`);
+    return undefined as unknown as T;
+  }
+}
+
+/**
+ * A wrapper around checking if a file exists and executing an action on it if it does.  Otherwise returning
+ * undefined.
+ *
+ * @param folder - folder path to use as the base of the config search
+ * @param name - package name, if undefined or falsy the package is assumed to be included in the folder
+ * @param cb - callback function to execute if the file exists
+ */
+function ifConfig<T>(folder: string, name: string | undefined, cb: LoaderFn<T>): T | undefined {
+  const pkgPath = name ? path.join(folder, name) : folder;
+  if (fse.existsSync(pkgPath)) {
+    return cb(pkgPath);
+  }
+  return undefined;
+}
+
+/**
+ * Reads and parses a configuration file from the given folder.  Will return undefined if not found.
+ * @param folder - The folder path to query for the config file
+ * @param name - name of the config file, if omitted the file is assumed to already be in folder
+ */
+export function readJsonConfig<T = object>(folder: string, name?: string, onLoad?: LoaderFn<T>): T | undefined {
+  onLoad = onLoad || loadJson;
+  return ifConfig<T>(folder, name, loadJson);
+}
+
+/**
+ * If a file exists, return a config loader function that can be used to load the file at a later
+ * time.  If the file doesn't exist will return undefined.  The closure includes storage
+ * such that if the file is loaded the results will be cached.  Subsequent calls will use cached results
+ *
+ * If the file is to be modified this will need to be recalculated via a different method
+ *
+ * @param folder - The folder path to query for the config file
+ * @param name - name of the config file, if omitted the file is assume to be included in folder
+ */
+export function getConfigLoader<T = object>(folder: string, name?: string, onLoad?: LoaderFn<T>): ConfigLoader<T> | undefined {
+  onLoad = onLoad || loadJson;
+  return ifConfig<ConfigLoader<T>>(folder, name, pkgPath => {
+    let _storage: T | undefined = undefined;
+    return () => {
+      if (!_storage) {
+        _storage = fse.readJsonSync(pkgPath, { throws: false });
+      }
+      return _storage as T;
+    };
+  });
+}
+
+/**
+ * Read a package json file
+ * @param folder - folder path for the package.json
+ */
+export function readPackageJson(folder: string): PackageJson | undefined {
+  return readJsonConfig<PackageJson>(folder, 'package.json');
+}
+

--- a/packages/just-repo-utils/src/repoInfo.ts
+++ b/packages/just-repo-utils/src/repoInfo.ts
@@ -7,8 +7,7 @@ import fse from 'fs-extra';
 let _repoInfo: RepoInfo | undefined = undefined;
 
 /**
- * Everyone seems to have one of these, so this is a common implementation that can
- * be leveraged by different utilities.
+ * Finds the root of the git repository, i.e. where .git resides
  *
  * @param cb - callback function to execute at each level.  A true result for the callback will
  * cancel the walk and return the current path at the time it was cancelled.
@@ -28,9 +27,11 @@ export function findGitRoot(cb?: (current: string) => boolean | void): string {
 
 /**
  * Retrieve info for the repository.  This will walk up from the current working directory
- * until it finds the git root and then prepare loaders for various monorepo config files
+ * until it finds the git root and then prepare loaders for various monorepo config files.
+ *
+ * Note that this uses in-module caching to avoid traversing unnecessarily.
  */
-export function repoInfo(): RepoInfo {
+export function getRepoInfo(): RepoInfo {
   if (_repoInfo) {
     return _repoInfo;
   }

--- a/packages/just-repo-utils/src/repoInfo.ts
+++ b/packages/just-repo-utils/src/repoInfo.ts
@@ -1,0 +1,38 @@
+import { getConfigLoader, loadCJson } from './readConfigs';
+import { LernaJson, RushJson, PackageJson } from './interfaces/configTypes';
+import { RepoInfo } from './interfaces/repoInfoTypes';
+import path from 'path';
+import fse from 'fs-extra';
+
+let _repoInfo: RepoInfo | undefined = undefined;
+
+/**
+ * Retrieve info for the repository.  This will walk up from the current working directory
+ * until it finds a lerna.json, rush.json, or the git root.
+ */
+export function repoInfo(): RepoInfo {
+  if (_repoInfo) {
+    return _repoInfo;
+  }
+
+  let cwd = process.cwd();
+  const root = path.parse(cwd).root;
+  while (cwd !== root) {
+    // walk up to the git root
+    if (fse.existsSync(path.join(cwd, '.git'))) {
+      const getRushJson = getConfigLoader<RushJson>(cwd, 'rush.json', loadCJson);
+      const getLernaJson = getConfigLoader<LernaJson>(cwd, 'lerna.json');
+      const isMonoRepo = getRushJson || getLernaJson;
+      _repoInfo = {
+        rootPath: cwd,
+        getRushJson,
+        getLernaJson,
+        getPackageJson: getConfigLoader<PackageJson>(cwd, 'package.json')!,
+        ...(isMonoRepo && { monorepo: getRushJson ? 'rush' : 'lerna' })
+      }
+      return _repoInfo;
+    }
+    cwd = path.dirname(cwd);
+  }
+  throw ('No repository root found!');
+}

--- a/packages/just-repo-utils/src/repoInfo.ts
+++ b/packages/just-repo-utils/src/repoInfo.ts
@@ -13,7 +13,7 @@ let _repoInfo: RepoInfo | undefined = undefined;
  * @param cb - callback function to execute at each level.  A true result for the callback will
  * cancel the walk and return the current path at the time it was cancelled.
  */
-export function findGitRoot(cb?: (current: string) => boolean | undefined): string {
+export function findGitRoot(cb?: (current: string) => boolean | void): string {
   let cwd = process.cwd();
   const root = path.parse(cwd).root;
 

--- a/packages/just-repo-utils/tsconfig.json
+++ b/packages/just-repo-utils/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Overview
This adds a just-repo-utils package which focuses on utilities for getting various bits of information about your repository.  Currently I see various implementations of getting the repo root, getting dependencies, loading config files, and getting packages floating around in different projects.  I ended up having to write a bunch of these for our react native controls project so I thought I would put them in just.

__UPDATE: added unit tests and did some validation__

There are several sets of utilities here:

### config / json loading
This has two patterns, loading a json file if it exists, or creating a loader for a json file if it exists.  It is written to be able to handle CJSON loads (like for rush) using the alternate load function.  Generally these can replace the various implementations of getting/loading json files scattered around just-tasks and just-scripts-utils.

### repoInfo
Probably want to rename this to getRepoInfo but this loads the root path as well as creating loaders for package json, lerna json and rush json, as well as determining the type of monorepo based on lerna/rush existence.

### packageInfo
These get information about the packages in the repo as well as the dependencies between them.  Note the dependencies are only tracked for in-repo deps, out of repo dependencies are a much broader set.  This is written to work for both lerna and rush.

It also caches the information because in the RN cases we need to do things like package lists and dependency trees in jest or metro configs to set up the watch paths correctly, so a single build pass may call this repeatedly.  ~~Caching is based on lock file + lerna/rush hashes.~~  __In testing this is really slow, it looks like spawnSync has an ~50ms startup cost which makes the two git actions take ~100ms to execute.  Switched to timestamp based and that made the cost ~0.5ms__

### cacheUtils
Some generalization of the utilities in just-tasks/cache.ts

### gitUtils
Some generalization of various git utilities elsewhere

## Test Notes
I added unit tests for the packageInfo functionality as well as the repoInfo.  Note that it tests against the structure of the just repo so it primarily validates the lerna codepaths.  It has snapshots for repo state so they will need to be updated if a new package or intra-repo dependency is added.

I did a bunch of validation in the fluentui-react-native repo on dependencies, repo stats, and perf testing.  Some random observations:

- spawnSync works great for big tasks but has a high startup cost.  Particularly for cache file validation it takes a big chunk of time.  It's interesting because git operations are super fast, particularly at scale.  When I played with switching the lerna glob parsing from using glob to git ls-files git was way faster, for a large set of files.  It unfortunately doesn't work for untracked changes.  On a small set of files it is slow.
- glob.sync is kind of slow.  I seem to recall glob having a match function and if so doing a file/dir crawl using the fs module, calling glob as a matcher might be substantially faster.  Internally it might be calling spawnSync (or an equivalent) so it might be partially startup cost.
- I changed a few things to use inline requires.  If I'm understanding things right, running as a build script things are loaded using eval and things like global variables in files go in and out of scope.  For instance I had a global variable to store the packageInfo if it had just been retrieved but it never actually was set.  Every time the function was called it hit the cache.