### PR TITLE
Add more general findRepoRoot helper

### DIFF
--- a/change/just-repo-utils-2020-03-06-10-43-00-repo-root.json
+++ b/change/just-repo-utils-2020-03-06-10-43-00-repo-root.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add more general findRepoRoot utility",
+  "packageName": "just-repo-utils",
+  "email": "jasonmo@microsoft.com",
+  "commit": "0bde961ce85a7ce1a2b1c6cbb0109451fd6685a1",
+  "date": "2020-03-06T18:43:00.414Z"
+}

--- a/packages/just-repo-utils/src/interfaces/configTypes.ts
+++ b/packages/just-repo-utils/src/interfaces/configTypes.ts
@@ -55,6 +55,9 @@ export interface PackageJson {
   peerDependencies?: Dependencies;
   keywords?: string;
   just?: {
+    /** Indicator that this package should be treated as the root */
+    root?: boolean;
+
     /** Stack that the package is tracking */
     stack?: string;
   };

--- a/packages/just-repo-utils/src/interfaces/repoInfoTypes.ts
+++ b/packages/just-repo-utils/src/interfaces/repoInfoTypes.ts
@@ -1,6 +1,12 @@
 import { PackageJsonLoader, RushJsonLoader, LernaJsonLoader } from './configTypes';
 
 /**
+ * callback function for walking to the root.  Returning true will cancel the walk at
+ * that point, a false or no return result will keep walking.
+ */
+export type FindRootCallback = (cwd: string) => boolean | void;
+
+/**
  * types of supported monorepos
  */
 export type MonorepoType = 'lerna' | 'rush';


### PR DESCRIPTION
## Overview
There is some code in just (see [findMonoRepoRootPath.ts](https://github.com/microsoft/just/blob/master/packages/just-scripts-utils/src/findMonoRepoRootPath.ts)) which will actually check things such as rush.json and the just stack to determine the repo root.  While findGitRoot is fine if you know your repo is a git repo, for more general cases this may be insufficient.  Cases I can think of include:

- different non-git based repo
- the root of the repo not being at the root of the git enlistment
- a desire to have disconnected repos in subfolders, maybe for testing

### findRepoRoot

This adds a new `findRepoRoot` function which has the same usage as `findGitRoot` but does some additional checks along the way.  This will consider the root to be:

- the git root
- a folder that has rush.json or lerna.json
- a folder with package.json that includes just: { stack: 'just-stack-monorepo' }
- a folder with package.json that includes just: { root: true }

The just: { root: true } is a general escape that this change adds.  That way the just utilities will work, even if they are not actually using the monorepo stack directly.

### getRepoInfo consumes findRepoRoot instead of findGitRoot

This makes the general utility (with module based caching) use the more flexible implementation.  Internal tools in just should use getRepoInfo or findRepoRoot to make sure everything works in all types of repos.  External customers who want a (slightly) faster routine can call findGitRoot instead.

## Test Notes

Tests still run and use both functions and validate that the results match.  Note that unless we start creating representative test repos within the just project it is hard to test all sorts of different scenarnios.  That is something to consider for later.