### PR TITLE
Verbose logs the location of a task definition.

### DIFF
--- a/change/just-task-2020-03-31-10-56-33-debug-improvements.json
+++ b/change/just-task-2020-03-31-10-56-33-debug-improvements.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Verbose logs the location of a task definition.",
+  "packageName": "just-task",
+  "email": "jdh@microsoft.com",
+  "commit": "c9fad5e956827b7e14ca4df0f8e7530e6eb1559b",
+  "date": "2020-03-31T17:56:33.323Z"
+}

--- a/change/just-task-logger-2020-03-31-10-56-33-debug-improvements.json
+++ b/change/just-task-logger-2020-03-31-10-56-33-debug-improvements.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Verbose logs the location of a task definition.",
+  "packageName": "just-task-logger",
+  "email": "jdh@microsoft.com",
+  "commit": "c9fad5e956827b7e14ca4df0f8e7530e6eb1559b",
+  "date": "2020-03-31T17:56:29.109Z"
+}

--- a/packages/just-task-logger/src/logger.ts
+++ b/packages/just-task-logger/src/logger.ts
@@ -29,7 +29,7 @@ const square = '\u25a0';
 const triangle = '\u25b2';
 
 export const logger: Logger = {
-  enableVerbose: !!yargs.argv.verbose,
+  enableVerbose: !!yargs.argv.verbose || !!process.env.JUST_VERBOSE,
 
   verbose(...args: any[]) {
     if (logger.enableVerbose) {

--- a/packages/just-task/src/TaskDefinitionRecord.ts
+++ b/packages/just-task/src/TaskDefinitionRecord.ts
@@ -1,0 +1,3 @@
+export class TaskDefinitionRecord {
+  constructor(public name: string, public trace: string) {}
+}


### PR DESCRIPTION
## Overview

In large monorepos with many levels of indirection between a task being defined and being invoked, it can be difficult to trace back to where a problem exists.

This change adds functionality that will emit a truncated stack trace when just is run with `--verbose`.

Also causes the logger to run in verbose mode when `JUST_VERBOSE` is defined as an environment variable, as just is often run behind levels of indirection making command line arguments more difficult to pass.
