### PR TITLE
use tar-fs instead of node-tar to make tarTask more robust

### DIFF
--- a/change/just-scripts-2020-04-07-10-29-33-tartask2.json
+++ b/change/just-scripts-2020-04-07-10-29-33-tartask2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "another take on tar task using tar-fs instead because it can actually handle large amounts of data",
+  "packageName": "just-scripts",
+  "email": "kchau@microsoft.com",
+  "commit": "b5c1b57062e97a6780c5c30d27f81e9c5298bedf",
+  "date": "2020-04-07T17:29:33.135Z"
+}

--- a/packages/just-scripts/src/tasks/tarTask.ts
+++ b/packages/just-scripts/src/tasks/tarTask.ts
@@ -1,111 +1,167 @@
 import { resolve, logger, TaskFunction } from 'just-task';
-import { Stats } from 'fs';
+import { createWriteStream, createReadStream } from 'fs';
+import { createGzip, createGunzip } from 'zlib';
+import { Stream } from 'stream';
 
-type ArchiveErrorCode =
-  | 'TAR_ENTRY_INFO'
-  | 'TAR_ENTRY_INVALID'
-  | 'TAR_ENTRY_ERROR'
-  | 'TAR_ENTRY_UNSUPPORTED'
-  | 'TAR_ABORT'
-  | 'TAR_BAD_ARCHIVE';
+export interface EntryHeader {
+  name: string;
+  size: number;
 
-export { ArchiveErrorCode };
+  /** entry mode. defaults to to 0755 for dirs and 0644 otherwise */
+  mode: number; //
+
+  /** last modified date for entry. defaults to now. */
+  mtime: Date;
+
+  /** type of entry. defaults to "file". */
+  type: 'file' | 'link' | 'symlink' | 'directory' | 'block-device' | 'character-device' | 'fifo' | 'contiguous-file';
+
+  /** linked file name */
+  linkname: string;
+
+  uid: number;
+  gid: number;
+  uname: string;
+  gname: string;
+  devmajor: number;
+  devminor: number;
+}
 
 export interface CreateOptions {
+  /** output file */
   file: string;
+
+  /** whether to gzip or not, either a boolean or uses the `zlib.Gzip` options like level, memLevel  */
   gzip?:
     | boolean
     | {
         level?: number;
         memLevel?: number;
       };
-  cwd?: string;
-  onwarn?: (code: ArchiveErrorCode, message: string, data: any) => void;
-  prefix?: string;
-  filter?: (path: string, stat: Stats) => boolean;
-  preservePaths?: boolean;
-  mode?: number;
-  noDirRecurse?: boolean;
-  follow?: boolean;
-  noMtime?: boolean;
-  mtime?: Date;
-}
 
-export interface CreateArchiveTaskOptions extends CreateOptions {
-  fileList?: string[];
-  glob?: string[] | string;
-  globOptions?: any;
+  /** the context path of the tar pack */
+  cwd?: string;
+
+  /** filter (ignore) entries */
+  filter?: (path: string, header: EntryHeader) => boolean;
+
+  /** change the header in the entry (e.g. to replace prefix) */
+  map?: (header: EntryHeader) => EntryHeader;
+
+  /** whether to dereference links */
+  dereference?: boolean;
+
+  /** specify a set of entries to be packed */
+  entries?: string[];
 }
 
 /**
  * Creates an tar (optionally gzipped) archive
  * @param options
  */
-export function createTarTask(options: CreateArchiveTaskOptions = { file: 'archive.tar.gz' }): TaskFunction {
-  const resolvedTar = resolve('tar');
-  const resolvedGlob = resolve('glob');
+export function createTarTask(options: CreateOptions = { file: 'archive.tar.gz' }): TaskFunction {
+  const resolvedTar = resolve('tar-fs');
 
+  // Inject default options
+  options = { cwd: process.cwd(), gzip: true, ...options };
+
+  // Validate whether tar-fs is installed
   if (!resolvedTar) {
-    logger.error('Please make sure to have "tar" as a dependency in your package.json');
-    throw new Error('Required dependency "tar" is not installed');
+    logger.error('Please make sure to have "tar-fs" as a dependency in your package.json');
+    throw new Error('Required dependency "tar-fs" is not installed!');
   }
 
   const tar = require(resolvedTar);
-  let { fileList = [], glob, globOptions = {}, ...restOptions } = options;
 
-  if (glob && resolvedGlob) {
-    const globModule = require(resolvedGlob);
-    glob = Array.isArray(glob) ? glob : [glob];
+  let { entries, file, cwd, ...restOptions } = options;
 
-    fileList = glob.reduce((collection, pattern) => {
-      return collection.concat(globModule.sync(pattern, { ...(restOptions.cwd ? { cwd: restOptions.cwd } : undefined), ...globOptions }));
-    }, []);
-  }
+  return function archive(done) {
+    let tarStream = tar.pack(cwd, {
+      entries,
+      finalize: true,
+      finish: () => {
+        done();
+      },
+      ...restOptions
+    });
 
-  return function archive() {
-    return tar.create(restOptions, fileList);
+    if (options.gzip) {
+      const gzip = typeof options.gzip === 'boolean' ? createGzip() : createGzip(options.gzip as any);
+      tarStream = tarStream.pipe(gzip);
+    }
+
+    tarStream.pipe(createWriteStream(options.file));
   };
 }
 
 export interface ExtractOptions {
+  /** output file */
   file: string;
-  gzip?:
-    | boolean
-    | {
-        level?: number;
-        memLevel?: number;
-      };
-  cwd?: string;
-  newer?: boolean;
-  strip?: number;
-  onwarn?: (code: ArchiveErrorCode, message: string, data: any) => void;
-  preserveOwner?: boolean;
-  filter?: (path: string, stat: Stats) => boolean;
-  preservePaths?: boolean;
-  unlink?: boolean;
-  noMtime?: boolean;
-}
 
-export interface ExtractArchiveTaskOptions extends ExtractOptions {
-  fileList?: string[];
+  /** whether to gzip or not, either a boolean or uses the `zlib.Gzip` options like level, memLevel  */
+  gzip?: boolean;
+
+  /** the context path of the tar pack */
+  cwd?: string;
+
+  /** filter (ignore) entries */
+  filter?: (path: string, header: EntryHeader) => boolean;
+
+  /** change the header in the entry (e.g. to replace prefix) */
+  map?: (header: EntryHeader) => EntryHeader;
+
+  /** mode for files (e.g. `parseInt(755, 8)`)*/
+  fmode?: number;
+
+  /** mode for directories (e.g. `parseInt(755, 8)`) */
+  dmode?: number;
+
+  /** set whether all files and dirs are readable */
+  readable?: boolean;
+
+  /** set whether all files and dirs are writable */
+  writable?: boolean;
+
+  /** whether to dereference links */
+  dereference?: boolean;
 }
 
 /**
  * Creates an tar (optionally gzipped) archive
  * @param options
  */
-export function extractTarTask(options: ExtractArchiveTaskOptions = { file: 'archive.tar.gz' }): TaskFunction {
-  const resolvedTar = resolve('tar');
+export function extractTarTask(options: ExtractOptions = { file: 'archive.tar.gz' }): TaskFunction {
+  const resolvedTar = resolve('tar-fs');
 
+  // Inject default options
+  options = { cwd: process.cwd(), gzip: true, ...options };
+
+  // Validate whether tar-fs is installed
   if (!resolvedTar) {
-    logger.error('Please make sure to have "tar" as a dependency in your package.json');
-    throw new Error('Required dependency "tar" is not installed');
+    logger.error('Please make sure to have "tar-fs" as a dependency in your package.json');
+    throw new Error('Required dependency "tar-fs" is not installed!');
   }
 
   const tar = require(resolvedTar);
-  const { fileList, ...restOptions } = options;
 
-  return function archive() {
-    return tar.extract(restOptions, fileList);
+  const { cwd, file, ...restOptions } = options;
+
+  return function extract(done) {
+    let tarStream: Stream = createReadStream(file);
+
+    if (options.gzip) {
+      const gunzip = createGunzip();
+      tarStream = tarStream.pipe(gunzip);
+    }
+
+    tarStream = tarStream.pipe(
+      tar.extract(cwd, {
+        finalize: true,
+        finish: () => {
+          done();
+        },
+        ...restOptions
+      })
+    );
   };
 }


### PR DESCRIPTION
node-tar fails miserably above a moderate number of files (at least on Windows). We need to swap over to tar-fs which operates exclusively on streams to make a faster tar task and more robust one.