### PR TITLE
change target in enableTypeScript

### DIFF
--- a/change/just-task-2020-04-14-16-04-33-master.json
+++ b/change/just-task-2020-04-14-16-04-33-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "change target in enableTypeScript",
+  "packageName": "just-task",
+  "email": "imjuni@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-14T07:04:33.625Z"
+}

--- a/packages/just-task/src/enableTypeScript.ts
+++ b/packages/just-task/src/enableTypeScript.ts
@@ -9,7 +9,7 @@ export function enableTypeScript({ transpileOnly = true }) {
       transpileOnly,
       skipProject: true,
       compilerOptions: {
-        target: 'esnext',
+        target: 'es2017',
         module: 'commonjs',
         strict: false,
         skipLibCheck: true,


### PR DESCRIPTION
## Overview
Node.js don't support nullish coalescing operator not yet. So nullish coalescing operator in just.config.ts cause error **Unexpected Token '?'**.
Simple change **esnext** -> **es2017** is prevent this error. 

## Test Notes
execute test script below
```js
import { logger, task } from 'just-scripts';

task('script', async () => {
  logger.info('hello ', process.env.GREETING ?? 'world');
});
```
