### PR TITLE
Resolve from custom resolve paths before __dirname

### DIFF
--- a/change/just-task-2020-04-24-10-38-25-custom-resolve-path-order.json
+++ b/change/just-task-2020-04-24-10-38-25-custom-resolve-path-order.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Resolve from custom resolve paths before Just location",
+  "packageName": "just-task",
+  "email": "email not defined",
+  "commit": "490035421b6af3c5af6149d07863080b75ea612d",
+  "date": "2020-04-24T17:38:25.709Z"
+}

--- a/packages/just-task/src/__tests__/resolve.spec.ts
+++ b/packages/just-task/src/__tests__/resolve.spec.ts
@@ -1,6 +1,6 @@
 import mockfs from 'mock-fs';
 import path from 'path';
-import { _isFileNameLike, _tryResolve, resetResolvePaths, resolveCwd, addResolvePath, resolve } from '../resolve';
+import { _isFileNameLike, _tryResolve, resetResolvePaths, resolveCwd, addResolvePath, resolve, _getResolvePaths } from '../resolve';
 
 import * as option from '../option';
 
@@ -73,6 +73,22 @@ describe('_tryResolve', () => {
       a: { node_modules: { b: { 'c.js': '' } } }
     });
     expect(_tryResolve('b/c', 'a')).toContain(path.join('a', 'node_modules', 'b', 'c.js'));
+  });
+});
+
+describe('_getResolvePaths', () => {
+  afterEach(() => {
+    resetResolvePaths();
+  });
+
+  it('uses resolvePaths for before __dirname', () => {
+    jest.spyOn(option, 'argv').mockImplementation(() => ({ config: 'config/just-task.js' } as any));
+    addResolvePath('custom1');
+    addResolvePath('custom2');
+
+    const paths = _getResolvePaths('cwd');
+
+    expect(paths.map(p => path.basename(p))).toEqual(['cwd', 'config', 'custom1', 'custom2', 'src']);
   });
 });
 

--- a/packages/just-task/src/resolve.ts
+++ b/packages/just-task/src/resolve.ts
@@ -44,6 +44,21 @@ export function _tryResolve(moduleName: string, basedir: string): string | null 
 }
 
 /**
+ * Exported for testing only.
+ * @private
+ */
+export function _getResolvePaths(cwd?: string): string[] {
+  if (!cwd) {
+    cwd = process.cwd();
+  }
+
+  const configArg = argv().config;
+  const configFilePath = configArg ? path.resolve(path.dirname(configArg)) : undefined;
+
+  return [cwd, ...(configFilePath ? [configFilePath] : []), ...customResolvePaths, __dirname];
+}
+
+/**
  * Resolve a module. Resolution will be tried starting from `cwd`, the location of a config file
  * passed using the `--config` command line arg, and any paths added using `addResolvePath`.
  * @param moduleName Module name to resolve. Anything which appears to be a file name (contains .
@@ -53,14 +68,7 @@ export function _tryResolve(moduleName: string, basedir: string): string | null 
  * @returns The module path, or null if the module can't be resolved.
  */
 export function resolve(moduleName: string, cwd?: string): string | null {
-  if (!cwd) {
-    cwd = process.cwd();
-  }
-
-  const configArg = argv().config;
-  const configFilePath = configArg ? path.resolve(path.dirname(configArg)) : undefined;
-
-  const allResolvePaths = [cwd, ...(configFilePath ? [configFilePath] : []), ...customResolvePaths, __dirname];
+  const allResolvePaths = _getResolvePaths(cwd);
   let resolved: string | null = null;
 
   for (const tryPath of allResolvePaths) {

--- a/packages/just-task/src/resolve.ts
+++ b/packages/just-task/src/resolve.ts
@@ -2,21 +2,21 @@ import { sync as resolveSync } from 'resolve';
 import path from 'path';
 import { argv } from './option';
 
-let resolvePaths: string[] = [__dirname];
+let customResolvePaths: string[] = [];
 
 /**
  * Add a path to the list used by `resolve()`.
  * @param pathName Path to add
  */
 export function addResolvePath(pathName: string): void {
-  resolvePaths.push(pathName);
+  customResolvePaths.push(pathName);
 }
 
 /**
  * Reset the list of paths used by `resolve()`.
  */
 export function resetResolvePaths(): void {
-  resolvePaths = [__dirname];
+  customResolvePaths = [];
 }
 
 /**
@@ -60,7 +60,7 @@ export function resolve(moduleName: string, cwd?: string): string | null {
   const configArg = argv().config;
   const configFilePath = configArg ? path.resolve(path.dirname(configArg)) : undefined;
 
-  const allResolvePaths = [cwd, ...(configFilePath ? [configFilePath] : []), ...resolvePaths];
+  const allResolvePaths = [cwd, ...(configFilePath ? [configFilePath] : []), ...customResolvePaths, __dirname];
   let resolved: string | null = null;
 
   for (const tryPath of allResolvePaths) {


### PR DESCRIPTION
## Overview
When a config has used `addResolvePath(pathName)` to add custom resolve paths, `resolve(moduleName)` should check these paths before reverting to `__dirname`

## Test Notes
Ran unit tests, tested in external repo. Let me know if you can think of other tests.
