### PR TITLE
Pretty print webpack stats on error instead of printing JSON

### DIFF
--- a/change/just-scripts-2020-04-24-10-52-38-webpack-pretty-errors.json
+++ b/change/just-scripts-2020-04-24-10-52-38-webpack-pretty-errors.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Pretty print webpack stats on error instead of printing JSON",
+  "packageName": "just-scripts",
+  "email": "email not defined",
+  "commit": "7187551b0606494f14a8ee2b9a9bb05498a91803",
+  "date": "2020-04-24T17:52:38.140Z"
+}

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -79,11 +79,8 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
           }
 
           if (err || stats.hasErrors()) {
-            const errorStats = stats.toJson('errors-only');
-            errorStats.errors.forEach((error: any) => {
-              logger.error(error);
-            });
-            reject(`Webpack failed with ${errorStats.errors.length} error(s).`);
+            logger.error(stats.toString({ colors: true }));
+            reject(`Webpack failed with ${stats.toJson('errors-only').errors.length} error(s).`);
           } else {
             resolve();
           }

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -79,7 +79,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
           }
 
           if (err || stats.hasErrors()) {
-            logger.error(stats.toString({ colors: true }));
+            logger.error(stats.toString({ children: webpackConfigs.map(c => c.stats) }));
             reject(`Webpack failed with ${stats.toJson('errors-only').errors.length} error(s).`);
           } else {
             resolve();


### PR DESCRIPTION
## Overview
When a webpackTask build fails we currently log error stats as JSON. This isn't very readable, and isn't a familiar format for people who use webpack-cli.

Instead, log the full formatted stats how webpack-cli would. Note `options,outputStats` still writes JSON to file if requested.

This currently prints the default stats on error, which includes some timing, caching, asset, etc. information as well. I think this info can be useful for investigating failures, but I'd be OK with trimming this down to just errors if we feel it needs to match the current output.

## Test Notes
It appears there's no tests for these. Tested manually in external repo.