### PR TITLE
Fix args passed to webpack.config.js function to match webpack spec

### DIFF
--- a/change/just-scripts-2020-04-24-12-57-12-webpack-function-config-args.json
+++ b/change/just-scripts-2020-04-24-12-57-12-webpack-function-config-args.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Fix args passed to webpack.config.js function to match webpack spec",
+  "packageName": "just-scripts",
+  "email": "email not defined",
+  "commit": "a0538ce665958ce61d23e7bc5d6d64d1b1c06a92",
+  "date": "2020-04-24T19:57:12.024Z"
+}

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -52,7 +52,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
       // If the loaded webpack config is a function
       // call it with the original process.argv arguments from build.js.
       if (typeof configLoader == 'function') {
-        webpackConfigs = configLoader(argv());
+        webpackConfigs = configLoader(argv().env, argv());
       } else {
         webpackConfigs = configLoader;
       }


### PR DESCRIPTION
## Overview
Webpack's config files can export a function which generates the config, as described here: https://webpack.js.org/configuration/configuration-types/

Our webpackTask currently calls this function with arguments `(argv)`, but the spec is `(env, argv)`. Updating to match spec.

## Test Notes
Tested manually in external repo, and compared args received by the config file against webpack-cli