### PR TITLE
Fix API Extractor types

### DIFF
--- a/change/just-scripts-2020-04-24-12-57-09-master.json
+++ b/change/just-scripts-2020-04-24-12-57-09-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix API Extractor types",
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T19:57:09.429Z"
+}

--- a/packages/just-scripts/src/tasks/apiExtractorTask.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTask.ts
@@ -2,7 +2,7 @@ import { logger, TaskFunction } from 'just-task';
 import fs from 'fs-extra';
 import path from 'path';
 import { tryRequire } from '../tryRequire';
-import * as ApiExtractorTypes from './api-extractor.d';
+import * as ApiExtractorTypes from './apiExtractorTypes';
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 

--- a/packages/just-scripts/src/tasks/apiExtractorTypes.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTypes.ts
@@ -1047,5 +1047,3 @@ export declare interface IExtractorMessagesConfig {
    */
   tsdocMessageReporting?: IConfigMessageReportingTable;
 }
-
-export {};


### PR DESCRIPTION
Fixes #372 (missing types) by changing the types file to .ts so it automatically gets "built" and copied to lib.