### PR TITLE
Webpack devserver cli args

### DIFF
--- a/change/just-scripts-2020-04-24-15-20-36-webpack-devserver-cli-args.json
+++ b/change/just-scripts-2020-04-24-15-20-36-webpack-devserver-cli-args.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "webpackDevServerTask passes through webpackCliArgs to webpack-dev-server",
+  "packageName": "just-scripts",
+  "email": "iancra@microsoft.com",
+  "commit": "43716961d199545aeb4315a6ac360beed46297b1",
+  "date": "2020-04-24T22:20:36.460Z"
+}

--- a/packages/just-scripts/src/tasks/index.ts
+++ b/packages/just-scripts/src/tasks/index.ts
@@ -14,4 +14,5 @@ export * from './prettierTask';
 export * from './eslintTask';
 export * from './webpackCliInitTask';
 export * from './webpackCliTask';
+export * from './webpackDevServerTask';
 export * from './tarTask';

--- a/packages/just-scripts/src/tasks/webpackDevServerTask.ts
+++ b/packages/just-scripts/src/tasks/webpackDevServerTask.ts
@@ -1,0 +1,43 @@
+// // WARNING: Careful about add more imports - only import types from webpack
+import { Configuration } from 'webpack';
+import { encodeArgs, spawn } from 'just-scripts-utils';
+import { logger, resolve, resolveCwd } from 'just-task';
+import fs from 'fs';
+import { WebpackCliTaskOptions } from './webpackCliTask';
+
+export interface WebpackDevServerTaskOptions extends WebpackCliTaskOptions, Configuration {
+  config?: string;
+
+  mode?: 'production' | 'development';
+
+  /**
+   * If set to true, webpack will open browser page automatically when running the dev server
+   */
+  open?: boolean;
+}
+
+export function webpackDevServerTask(options: WebpackDevServerTaskOptions = {}) {
+  const configPath = resolveCwd((options && options.config) || 'webpack.serve.config.js');
+  const devServerCmd = resolve('webpack-dev-server/bin/webpack-dev-server.js');
+
+  return function webpackDevServer() {
+    if (devServerCmd && configPath && fs.existsSync(configPath)) {
+      let args = [...(options.nodeArgs || []), devServerCmd, '--config', configPath];
+      if (options.open) {
+        args.push('--open');
+      }
+      if (options.mode) {
+        args = [...args, '--mode', options.mode];
+      }
+      if (options.webpackCliArgs) {
+        args = [...args, ...options.webpackCliArgs];
+      }
+
+      logger.info(process.execPath, encodeArgs(args).join(' '));
+      return spawn(process.execPath, args, { stdio: 'inherit', env: options.env });
+    } else {
+      logger.warn('no webpack.serve.config.js configuration found, skipping');
+      return Promise.resolve();
+    }
+  };
+}

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -1,7 +1,6 @@
 // // WARNING: Careful about add more imports - only import types from webpack
 import { Configuration } from 'webpack';
-import { encodeArgs, spawn } from 'just-scripts-utils';
-import { logger, argv, resolve, resolveCwd, TaskFunction } from 'just-task';
+import { logger, argv, resolveCwd, TaskFunction } from 'just-task';
 import { tryRequire } from '../tryRequire';
 import fs from 'fs';
 import webpackMerge from 'webpack-merge';
@@ -11,8 +10,6 @@ export interface WebpackTaskOptions extends Configuration {
 
   /** true to output to stats.json; a string to output to a file */
   outputStats?: boolean | string;
-
-  mode?: 'production' | 'development';
 
   /**
    * Arguments to be passed into a spawn call for webpack dev server. This can be used to do things
@@ -24,11 +21,6 @@ export interface WebpackTaskOptions extends Configuration {
    * Environment variables to be passed to the webpack-dev-server
    */
   env?: NodeJS.ProcessEnv;
-
-  /**
-   * If set to true, webpack will open browser page automatically when running the dev server
-   */
-  open?: boolean;
 }
 
 export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
@@ -91,24 +83,5 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
     }
 
     return;
-  };
-}
-
-export function webpackDevServerTask(options: WebpackTaskOptions = {}) {
-  const configPath = resolveCwd((options && options.config) || 'webpack.serve.config.js');
-  const devServerCmd = resolve('webpack-dev-server/bin/webpack-dev-server.js');
-
-  return function webpackDevServer() {
-    if (devServerCmd && configPath && fs.existsSync(configPath)) {
-      const mode = options.mode || 'development';
-      const open = options.open ? '--open' : '';
-      const args = [...(options.nodeArgs || []), devServerCmd, '--config', configPath, open, '--mode', mode];
-
-      logger.info(devServerCmd, encodeArgs(args).join(' '));
-      return spawn(process.execPath, args, { stdio: 'inherit', env: options.env });
-    } else {
-      logger.warn('no webpack.serve.config.js configuration found, skipping');
-      return Promise.resolve();
-    }
   };
 }


### PR DESCRIPTION
## Overview
There is currently no way to pass command line arguments for webpack to webpack-dev-server through the webpackDevServerTask.
e.g. I might want to add an arg `--env.foo=bar` or `--port 8081`

We already have a way to do this with webpackCliTask, and webpackDevServerTask acts a lot more like webpackCliTask than webpackTask anyway, so I'm reusing that option and switching to extending from `WebpackCliTaskOptions`.

Keeping existing `config`, `mode` and `open` options to be backward compatible.

## Test Notes
Tested manually in external repo.