### PR TITLE
Add cwd support for repo utils

### DIFF
--- a/change/just-repo-utils-2020-05-20-14-44-17-repo-util-update.json
+++ b/change/just-repo-utils-2020-05-20-14-44-17-repo-util-update.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add ability to query packages or roots from a different working directory",
+  "packageName": "just-repo-utils",
+  "email": "jasonmo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-20T21:44:17.284Z"
+}

--- a/packages/just-repo-utils/src/interfaces/packageInfoTypes.ts
+++ b/packages/just-repo-utils/src/interfaces/packageInfoTypes.ts
@@ -1,4 +1,5 @@
 import { PackageJsonLoader } from './configTypes';
+import { RepoInfoOptions } from './repoInfoTypes';
 
 export interface PackageEntry {
   path: string;
@@ -21,7 +22,7 @@ export type CacheStrategy = 'normal' | 'no-cache' | 'update';
 /**
  * optional options for package info routines
  */
-export interface PackageInfoOptions {
+export interface PackageInfoOptions extends RepoInfoOptions {
   /**
    * caching strategy to use for package info queries, defaults to 'normal'
    */

--- a/packages/just-repo-utils/src/interfaces/repoInfoTypes.ts
+++ b/packages/just-repo-utils/src/interfaces/repoInfoTypes.ts
@@ -30,3 +30,11 @@ export interface RepoInfo {
   /** loader function to get the parsed lerna json */
   getLernaJson?: LernaJsonLoader;
 }
+
+/**
+ * Options for querying repository info
+ */
+export interface RepoInfoOptions {
+  /** current working directory to start from */
+  cwd?: string;
+}

--- a/packages/just-repo-utils/src/packageInfo.ts
+++ b/packages/just-repo-utils/src/packageInfo.ts
@@ -1,17 +1,28 @@
 import { PackageInfoOptions, PackageInfo } from './interfaces/packageInfoTypes';
 import { getRepoInfo } from './repoInfo';
 
+function validateOptions(options?: PackageInfoOptions): PackageInfoOptions {
+  options = options || {};
+  // if a current working directory is being specified the primary use case is querying dependencies or packages of a different
+  // repository.  In this case, any information retrieved shouldn't be stored in our cache as it may or may not be relevant
+  if (options.cwd) {
+    options.strategy = 'no-cache';
+  }
+  return options;
+}
+
 /**
  * retrieves information about the packages in the repository
  * @param strategy - cache strategy to use for loading, defaults to normal
  */
 export function getPackageInfo(options?: PackageInfoOptions): PackageInfo {
+  options = validateOptions(options);
   const { retrievePackageInfo, cachePackageInfo } = require('./internal/packageInfoCache');
   const { infoFromEntries, buildPackageInfoFromGlobs, buildPackageInfoFromRushProjects } = require('./internal/packageInfoHelpers');
-  const { strategy = 'normal' } = options || {};
+  const { strategy = 'normal' } = options;
   let repoPackageInfo = strategy === 'normal' && retrievePackageInfo();
   if (!repoPackageInfo) {
-    const repo = getRepoInfo();
+    const repo = getRepoInfo(options);
     if (repo.getLernaJson) {
       repoPackageInfo = buildPackageInfoFromGlobs(repo.rootPath, repo.getLernaJson().packages);
     } else if (repo.getRushJson) {

--- a/packages/just-repo-utils/src/repoInfo.ts
+++ b/packages/just-repo-utils/src/repoInfo.ts
@@ -72,7 +72,7 @@ export function findRepoRoot(cb?: FindRootCallback, options?: RepoInfoOptions): 
  * Note that this uses in-module caching to avoid traversing unnecessarily.
  */
 export function getRepoInfo(options?: RepoInfoOptions): RepoInfo {
-  if (_repoInfo) {
+  if (_repoInfo && (!options || !options.cwd)) {
     return _repoInfo;
   }
 


### PR DESCRIPTION
## Overview
This adds support for specifying a different current working directory when querying the repo root or dependencies.

### Use case
In the fluentui-react-native repo I'm creating several test repositories, I need the ability to walk the packages for those repositories programmatically, particularly as I plan to make many of those repositories dynamically generated.

These repositories are not part of the yarn workspaces and have their own install roots but do not have their own git roots.  I used the just: { root: true } marker I added previously to disambiguate these.

### Additional notes

I had to fix the caching layers to be ignored when cwd is specified.  

## Test Notes

I tested this in the fluentui-react-native repository.  It's a little tough to test the use cases in the just repo in a way that is actually interesting.  (At least not without setting up a lot of additional infrastructure)

This is non-breaking, though I do want to make a separate breaking change to merge the cb and options in the various findRepo/findGit root routines.