### PR TITLE
Fix autoprefixer warning

### DIFF
--- a/change/just-scripts-2020-06-01-14-49-53-fix-autoprefixer-warning.json
+++ b/change/just-scripts-2020-06-01-14-49-53-fix-autoprefixer-warning.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Use updated options to autoprefixer",
+  "packageName": "just-scripts",
+  "email": "jdh@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-01T21:49:53.733Z"
+}

--- a/packages/just-scripts/src/tasks/sassTask.ts
+++ b/packages/just-scripts/src/tasks/sassTask.ts
@@ -39,7 +39,7 @@ export function sassTask(
       return;
     }
 
-    const autoprefixerFn = autoprefixer({ browsers: ['> 1%', 'last 2 versions', 'ie >= 11'] });
+    const autoprefixerFn = autoprefixer({ overrideBrowserslist: ['> 1%', 'last 2 versions', 'ie >= 11'] });
     const files = glob.sync(path.resolve(process.cwd(), 'src/**/*.scss'));
 
     if (files.length) {


### PR DESCRIPTION
## Overview

`browsers` is a deprecated option, and is causing build warnings in consuming repos. Updating to recommended backup options.

Reference: https://github.com/microsoft/fluentui/issues/13362