### PR TITLE
 eslint task: fix config resolution and add options

### DIFF
--- a/change/just-scripts-2020-06-02-12-50-18-ecraig-eslint.json
+++ b/change/just-scripts-2020-06-02-12-50-18-ecraig-eslint.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "eslint task: fix config resolution and add options",
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-02T19:49:55.437Z"
+}

--- a/change/just-task-2020-06-02-12-50-18-ecraig-eslint.json
+++ b/change/just-task-2020-06-02-12-50-18-ecraig-eslint.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "resolve: add extensions option",
+  "packageName": "just-task",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-02T19:50:18.057Z"
+}

--- a/packages/just-task/src/__tests__/resolve.spec.ts
+++ b/packages/just-task/src/__tests__/resolve.spec.ts
@@ -35,7 +35,7 @@ describe('_tryResolve', () => {
   });
 
   it('does not throw', () => {
-    expect(_tryResolve('foo', 'bar')).toBeNull();
+    expect(_tryResolve('foo', { cwd: 'bar' })).toBeNull();
     expect(_tryResolve(undefined as any, undefined as any)).toBeNull();
   });
 
@@ -43,7 +43,7 @@ describe('_tryResolve', () => {
     mockfs({
       a: { 'b.txt': '' }
     });
-    expect(_tryResolve('b.txt', process.cwd())).toBeNull();
+    expect(_tryResolve('b.txt', { cwd: process.cwd() })).toBeNull();
   });
 
   it('resolves filename relative to basedir', () => {
@@ -51,7 +51,7 @@ describe('_tryResolve', () => {
       a: { 'b.txt': '' }, // right
       'b.txt': '' // wrong
     });
-    expect(_tryResolve('b.txt', 'a')).toContain(path.join('a', 'b.txt'));
+    expect(_tryResolve('b.txt', { cwd: 'a' })).toContain(path.join('a', 'b.txt'));
   });
 
   it('resolves non-filename relative to node_modules in basedir', () => {
@@ -64,7 +64,7 @@ describe('_tryResolve', () => {
       // eslint-disable-next-line @typescript-eslint/camelcase
       node_modules: { 'b.js': '' } // wrong
     });
-    expect(_tryResolve('b', 'a')).toContain(path.join('a', 'node_modules', 'b.js'));
+    expect(_tryResolve('b', { cwd: 'a' })).toContain(path.join('a', 'node_modules', 'b.js'));
   });
 
   it('resolves path with /', () => {
@@ -72,7 +72,7 @@ describe('_tryResolve', () => {
       // eslint-disable-next-line @typescript-eslint/camelcase
       a: { node_modules: { b: { 'c.js': '' } } }
     });
-    expect(_tryResolve('b/c', 'a')).toContain(path.join('a', 'node_modules', 'b', 'c.js'));
+    expect(_tryResolve('b/c', { cwd: 'a' })).toContain(path.join('a', 'node_modules', 'b', 'c.js'));
   });
 });
 

--- a/packages/just-task/src/resolve.ts
+++ b/packages/just-task/src/resolve.ts
@@ -2,6 +2,13 @@ import { sync as resolveSync } from 'resolve';
 import path from 'path';
 import { argv } from './option';
 
+export interface ResolveOptions {
+  /** Directory to start resolution from. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Array of file extensions to search in order */
+  extensions?: string[];
+}
+
 let customResolvePaths: string[] = [];
 
 /**
@@ -31,13 +38,11 @@ export function _isFileNameLike(name: string): boolean {
  * Exported for testing only.
  * @private
  */
-export function _tryResolve(moduleName: string, basedir: string): string | null {
+export function _tryResolve(moduleName: string, options: ResolveOptions): string | null {
   try {
-    if (_isFileNameLike(moduleName)) {
-      return resolveSync(`./${moduleName}`, { basedir, preserveSymlinks: true });
-    } else {
-      return resolveSync(moduleName, { basedir, preserveSymlinks: true });
-    }
+    const { cwd, ...rest } = options;
+    const nameToResolve = _isFileNameLike(moduleName) ? `./${moduleName}` : moduleName;
+    return resolveSync(nameToResolve, { basedir: cwd, ...rest, preserveSymlinks: true });
   } catch (e) {
     return null;
   }
@@ -64,15 +69,34 @@ export function _getResolvePaths(cwd?: string): string[] {
  * @param moduleName Module name to resolve. Anything which appears to be a file name (contains .
  * and doesn't contain slashes) will be resolved relative to the working directory.
  * Other names will be resolved within node_modules.
+ * @param options Resolution options, including custom cwd (defaults to `process.cwd()`)
+ * @returns The module path, or null if the module can't be resolved.
+ */
+export function resolve(moduleName: string, options?: ResolveOptions): string | null;
+/**
+ * Resolve a module. Resolution will be tried starting from `cwd`, the location of a config file
+ * passed using the `--config` command line arg, and any paths added using `addResolvePath`.
+ * @deprecated Use object params signature instead.
+ * @param moduleName Module name to resolve. Anything which appears to be a file name (contains .
+ * and doesn't contain slashes) will be resolved relative to the working directory.
+ * Other names will be resolved within node_modules.
  * @param cwd Working directory in which to start resolution. Defaults to `process.cwd()`.
  * @returns The module path, or null if the module can't be resolved.
  */
-export function resolve(moduleName: string, cwd?: string): string | null {
-  const allResolvePaths = _getResolvePaths(cwd);
+export function resolve(moduleName: string, cwd?: string): string | null;
+export function resolve(moduleName: string, cwdOrOptions?: string | ResolveOptions): string | null {
+  let options: ResolveOptions = {};
+  if (typeof cwdOrOptions === 'string') {
+    options = { cwd: cwdOrOptions };
+  } else if (cwdOrOptions) {
+    options = cwdOrOptions;
+  }
+
+  const allResolvePaths = _getResolvePaths(options.cwd);
   let resolved: string | null = null;
 
   for (const tryPath of allResolvePaths) {
-    resolved = _tryResolve(moduleName, tryPath);
+    resolved = _tryResolve(moduleName, { ...options, cwd: tryPath });
     if (resolved) {
       return resolved;
     }
@@ -87,12 +111,30 @@ export function resolve(moduleName: string, cwd?: string): string | null {
  * @param moduleName Module name to resolve. Anything which appears to be a file name (contains .
  * and doesn't contain slashes) will be resolved relative to the working directory.
  * Other names will be resolved within node_modules.
+ * @param options Resolution options, including custom cwd (defaults to `process.cwd()`)
+ * @returns The module path, or null if the module can't be resolved.
+ */
+export function resolveCwd(moduleName: string, options?: ResolveOptions): string | null;
+/**
+ * Resolve a module. Resolution will *only* be tried starting from `cwd` (does not respect
+ * `--config` arg or `addResolvePath`).
+ * @deprecated Use object params signature instead.
+ * @param moduleName Module name to resolve. Anything which appears to be a file name (contains .
+ * and doesn't contain slashes) will be resolved relative to the working directory.
+ * Other names will be resolved within node_modules.
  * @param cwd Working directory in which to start resolution. Defaults to `process.cwd()`.
  * @returns The module path, or null if the module can't be resolved.
  */
-export function resolveCwd(moduleName: string, cwd?: string): string | null {
-  if (!cwd) {
-    cwd = process.cwd();
+export function resolveCwd(moduleName: string, cwd?: string): string | null;
+export function resolveCwd(moduleName: string, cwdOrOptions?: string | ResolveOptions): string | null {
+  let options: ResolveOptions = {};
+  if (typeof cwdOrOptions === 'string') {
+    options = { cwd: cwdOrOptions };
+  } else if (cwdOrOptions) {
+    options = cwdOrOptions;
   }
-  return _tryResolve(moduleName, cwd);
+  if (!options.cwd) {
+    options.cwd = process.cwd();
+  }
+  return _tryResolve(moduleName, options);
 }


### PR DESCRIPTION
The eslint task was only resolving `.eslintrc` or `.eslintrc.js`, when per the [eslint docs](https://eslint.org/docs/user-guide/configuring#configuration-file-formats) there are several other extensions which should be resolved. Add logic to resolve those extensions, including new options in the resolve utility to facilitate that.

Also add options for `--cache`, `--cache-location`, and [measuring rule performance](https://eslint.org/docs/developer-guide/working-with-rules-deprecated#per-rule-performance).