### PR TITLE
Replace cssnano with postcss-clean

### DIFF
--- a/change/just-scripts-2020-06-04-14-58-15-dzearing-replace-cssnano.json
+++ b/change/just-scripts-2020-06-04-14-58-15-dzearing-replace-cssnano.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Replacing cssnano with postcss-clean, which is more reliable.",
+  "packageName": "just-scripts",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-04T21:58:15.984Z"
+}

--- a/packages/just-scripts/src/tasks/sassTask.ts
+++ b/packages/just-scripts/src/tasks/sassTask.ts
@@ -31,7 +31,7 @@ export function sassTask(
     const postcss = tryRequire('postcss');
     const autoprefixer = tryRequire('autoprefixer');
     const postcssRtl = tryRequire('postcss-rtl');
-    const cssnano = tryRequire('cssnano');
+    const clean = tryRequire('postcss-clean');
 
     if (!nodeSass || !postcss || !autoprefixer) {
       logger.warn('One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect');
@@ -67,9 +67,9 @@ export function sassTask(
                     plugins.splice(plugins.indexOf(autoprefixerFn) + 1, 0, postcssRtl({}));
                   }
 
-                  // If css nano exists, add it to the end of the chain.
-                  if (cssnano) {
-                    plugins.push(cssnano());
+                  // If postcss-clean exists, add it to the end of the chain.
+                  if (clean) {
+                    plugins.push(clean());
                   }
 
                   postcss(plugins)


### PR DESCRIPTION
We noticed that cssnano is stripping load-themed-styles tokens from css files. There doesn't seem to be a config option to fix this.

Changing out to postcss-clean which is what we've used elsewhere; should have started with this. Tested locally, tokens are preserved.

This is blocking ODSP consumption of the experiment package.