### PR TITLE
Export spawn utility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true
-  }
+  },
+  "typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/change/just-scripts-2020-07-06-11-36-48-jagore-export-spawn.json
+++ b/change/just-scripts-2020-07-06-11-36-48-jagore-export-spawn.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Export spawn util.",
+  "packageName": "just-scripts",
+  "email": "jagore@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-06T18:36:48.012Z"
+}

--- a/packages/just-scripts/src/index.ts
+++ b/packages/just-scripts/src/index.ts
@@ -40,3 +40,5 @@ export { CopyInstruction, CopyConfig } from './copy/CopyInstruction';
 export { copyInstructions };
 
 export * from 'just-task';
+
+export { spawn } from 'just-scripts-utils';


### PR DESCRIPTION
## Overview

The `spawn` util is a convenient promise wrapper with internal just linkages that are useful to use directly rather than replicate in external repos. As a result, export it from `just-scripts`.