### PR TITLE
Setting Timing value to environment variable.

### DIFF
--- a/change/just-scripts-2020-07-14-16-35-05-vipati-eslint-timing-fix.json
+++ b/change/just-scripts-2020-07-14-16-35-05-vipati-eslint-timing-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Setting Timing value to environment variable.",
+  "packageName": "just-scripts",
+  "email": "vipati@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-14T23:35:05.852Z"
+}

--- a/change/just-scripts-2020-07-14-16-35-05-vipati-eslint-timing-fix.json
+++ b/change/just-scripts-2020-07-14-16-35-05-vipati-eslint-timing-fix.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Setting Timing value to environment variable.",
+  "comment": "ESLint task: Setting Timing value to environment variable.",
   "packageName": "just-scripts",
   "email": "vipati@microsoft.com",
   "dependentChangeType": "patch",

--- a/packages/just-scripts/src/tasks/eslintTask.ts
+++ b/packages/just-scripts/src/tasks/eslintTask.ts
@@ -62,7 +62,7 @@ export function eslintTask(options: EsLintTaskOptions = {}): TaskFunction {
       ];
 
       logger.info(encodeArgs(eslintArgs).join(' '));
-        return spawn(process.execPath, eslintArgs, { stdio: 'inherit', ...(timing && { env: { TIMING: '1' } }) });
+      return spawn(process.execPath, eslintArgs, { stdio: 'inherit', ...(timing && { env: { TIMING: '1' } }) });
     } else {
       return Promise.resolve();
     }

--- a/packages/just-scripts/src/tasks/eslintTask.ts
+++ b/packages/just-scripts/src/tasks/eslintTask.ts
@@ -62,7 +62,7 @@ export function eslintTask(options: EsLintTaskOptions = {}): TaskFunction {
       ];
 
       logger.info(encodeArgs(eslintArgs).join(' '));
-      return spawn(process.execPath, eslintArgs, { stdio: 'inherit', ...(timing && { TIMING: '1' }) });
+        return spawn(process.execPath, eslintArgs, { stdio: 'inherit', ...(timing && { env: { TIMING: '1' } }) });
     } else {
       return Promise.resolve();
     }


### PR DESCRIPTION
## Overview 
ESLint task does not set "TIMING" option in environment variable.


## Testing
Tested changes by linking the newly output just-scripts to repo. Now we can see the rule grid in output 
![image](https://user-images.githubusercontent.com/62967100/87488998-ab9c5f00-c5f6-11ea-8240-6ee2046bdcde.png)
