### PR TITLE
API extractor task: create destination directory if it doesn't exist

### DIFF
--- a/change/just-scripts-2020-09-15-17-11-34-ecraig-api-report-first-run.json
+++ b/change/just-scripts-2020-09-15-17-11-34-ecraig-api-report-first-run.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "API extractor task: create destination directory if it doesn't exist",
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-16T00:11:34.711Z"
+}

--- a/packages/just-scripts/src/tasks/apiExtractorTask.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTask.ts
@@ -112,6 +112,7 @@ export function apiExtractorUpdateTask(
       if (apiExtractorResult) {
         if (!apiExtractorResult.succeeded) {
           logger.warn(`- Update API: API file is out of date, updating...`);
+          fs.mkdirpSync(path.dirname(context.config.reportFilePath)); // ensure destination exists
           fs.copyFileSync(context.config.reportTempFilePath, context.config.reportFilePath);
 
           logger.info(`- Update API: successfully updated API file, verifying the updates...`);


### PR DESCRIPTION
## Overview

The API Extractor update task should create the destination folder for the API report file if it doesn't exist, which would likely be the case the first time it's run. Prevents errors like this:
```
[5:04:01 PM] ■ started 'api-extractor:default:update'
[5:04:01 PM] ■ Extracting Public API surface from '<root>/fabric-react/packages/dom-utilities/lib/index.d.ts'
Warning: The API report file is missing. Please copy the file "temp/dom-utilities.api.md" to "etc/dom-utilities.api.md", or perform a local build (which does this automatically). See the Git repo documentation for more info.
[5:04:03 PM] ▲ - Update API: API file is out of date, updating...
[5:04:03 PM] x Error detected while running 'api-extractor:default:update'
[5:04:03 PM] x ------------------------------------
[5:04:03 PM] x Error: ENOENT: no such file or directory, copyfile '<root>/fabric-react/packages/dom-utilities/temp/dom-utilities.api.md' -> '<root>/fabric-react/packages/dom-utilities/etc/dom-utilities.api.md'
    at Object.copyFileSync (fs.js:1728:3)
    at apiExtractorUpdate (<root>/fabric-react/node_modules/just-scripts/src/tasks/apiExtractorTask.ts:115:14)
```