### PR TITLE
fixing up the args so it's relevant at the right task for webpack

### DIFF
--- a/packages/just-scripts/src/tasks/webpackDevServerTask.ts
+++ b/packages/just-scripts/src/tasks/webpackDevServerTask.ts
@@ -8,6 +8,12 @@ import { WebpackCliTaskOptions } from './webpackCliTask';
 export interface WebpackDevServerTaskOptions extends WebpackCliTaskOptions, Configuration {
   config?: string;
 
+  /**
+   * Arguments to be passed into a spawn call for webpack dev server. This can be used to do things
+   * like increase the heap space for the JS engine to address out of memory issues.
+   */
+  nodeArgs?: string[];
+
   mode?: 'production' | 'development';
 
   /**


### PR DESCRIPTION
1. add an oncompile option for webpackTask
2. make some args type change to put the "nodeArgs" at the right place.
