### PR TITLE
When webpack config is specified, don't search for others, include path in warnings

### DIFF
--- a/change/just-scripts-2020-10-20-14-15-03-webpack-config-option-strict.json
+++ b/change/just-scripts-2020-10-20-14-15-03-webpack-config-option-strict.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Error if explicit webpack config path does not exist",
+  "packageName": "just-scripts",
+  "email": "iancra@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-20T21:15:03.019Z"
+}

--- a/packages/just-scripts/src/tasks/webpackDevServerTask.ts
+++ b/packages/just-scripts/src/tasks/webpackDevServerTask.ts
@@ -1,8 +1,9 @@
 // // WARNING: Careful about add more imports - only import types from webpack
 import { Configuration } from 'webpack';
 import { encodeArgs, spawn } from 'just-scripts-utils';
-import { logger, resolve } from 'just-task';
+import { logger, resolve, resolveCwd } from 'just-task';
 import * as fs from 'fs';
+import * as path from 'path';
 import { WebpackCliTaskOptions } from './webpackCliTask';
 import { getTsNodeEnv } from '../typescript/getTsNodeEnv';
 import { findWebpackConfig } from '../webpack/findWebpackConfig';
@@ -46,7 +47,7 @@ export interface WebpackDevServerTaskOptions extends WebpackCliTaskOptions, Conf
 }
 
 export function webpackDevServerTask(options: WebpackDevServerTaskOptions = {}) {
-  let configPath = findWebpackConfig('webpack.serve.config.js', options && options.config);
+  let configPath = options && options.config ? resolveCwd(path.join('.', options.config)) : findWebpackConfig('webpack.serve.config.js');
 
   const devServerCmd = resolve('webpack-dev-server/bin/webpack-dev-server.js');
 
@@ -68,7 +69,7 @@ export function webpackDevServerTask(options: WebpackDevServerTaskOptions = {}) 
       logger.info(process.execPath, encodeArgs(args).join(' '));
       return spawn(process.execPath, args, { stdio: 'inherit', env: options.env });
     } else {
-      logger.warn('no webpack.serve.config.js (or .ts) configuration found, skipping');
+      logger.warn(`${options?.config || 'webpack.serve.config.js'} not found, skipping`);
       return Promise.resolve();
     }
   };

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -1,6 +1,6 @@
 // // WARNING: Careful about add more imports - only import types from webpack
 import { Configuration } from 'webpack';
-import { logger, argv, TaskFunction } from 'just-task';
+import { logger, argv, TaskFunction, resolveCwd } from 'just-task';
 import { tryRequire } from '../tryRequire';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -41,7 +41,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
 
     logger.info(`Running Webpack`);
 
-    let webpackConfigPath = findWebpackConfig('webpack.config.js', options && options.config);
+    let webpackConfigPath = options && options.config ? resolveCwd(path.join('.', options.config)) : findWebpackConfig('webpack.config.js');
 
     logger.info(`Webpack Config Path: ${webpackConfigPath}`);
 
@@ -68,14 +68,14 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
       }
 
       // Convert everything to promises first to make sure we resolve all promises
-      const webpackConfigPromises = await Promise.all(webpackConfigs.map((webpackConfig) => Promise.resolve(webpackConfig)));
+      const webpackConfigPromises = await Promise.all(webpackConfigs.map(webpackConfig => Promise.resolve(webpackConfig)));
 
       // We support passing in arbitrary webpack config options that we need to merge with any read configs.
       // To do this, we need to filter out the properties that aren't valid config options and then run webpack merge.
       // A better long term solution here would be to have an option called webpackConfigOverrides instead of extending the configuration object.
       const { config, outputStats, ...restConfig } = options || ({} as WebpackTaskOptions);
 
-      webpackConfigs = webpackConfigPromises.map((webpackConfig) => webpackMerge(webpackConfig, restConfig));
+      webpackConfigs = webpackConfigPromises.map(webpackConfig => webpackMerge(webpackConfig, restConfig));
 
       return new Promise((resolve, reject) => {
         wp(webpackConfigs, async (err: Error, stats: any) => {
@@ -93,7 +93,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
           }
 
           if (err || stats.hasErrors()) {
-            logger.error(stats.toString({ children: webpackConfigs.map((c) => c.stats) }));
+            logger.error(stats.toString({ children: webpackConfigs.map(c => c.stats) }));
             reject(`Webpack failed with ${stats.toJson('errors-only').errors.length} error(s).`);
           } else {
             resolve();
@@ -101,7 +101,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
         });
       });
     } else {
-      logger.info('webpack.config.js not found, skipping webpack');
+      logger.info(`${options?.config || 'webpack.config.js'} not found, skipping webpack`);
     }
 
     return;

--- a/packages/just-scripts/src/webpack/findWebpackConfig.ts
+++ b/packages/just-scripts/src/webpack/findWebpackConfig.ts
@@ -1,10 +1,10 @@
 import { resolveCwd } from 'just-task';
 import * as path from 'path';
 
-export function findWebpackConfig(target: string, config?: string) {
+export function findWebpackConfig(target: string) {
   let configPath: string = target;
 
-  const haystackConfigPaths = [config, target, target.replace(/\.js$/, '.ts')];
+  const haystackConfigPaths = [target, target.replace(/\.js$/, '.ts')];
   for (const needle of haystackConfigPaths) {
     if (needle && resolveCwd(path.join('.', needle))) {
       configPath = needle;


### PR DESCRIPTION
#  Overview
If a user specifies the `config` option in webpack or webpackDevServer tasks, they Just should not try to run Webpack with a different config file silently if it fails to find the one they asked for.

Updating the config resolution to respect this, and also improve the warning when not found

## Test Notes
- UTs
- Tested against a real repo where config path was wrong so the requested config was not found