### PR TITLE
Do not crash on errors in webpack 5

### DIFF
--- a/change/just-scripts-2020-10-22-07-40-17-chrisgo-do-not-crash-wp5.json
+++ b/change/just-scripts-2020-10-22-07-40-17-chrisgo-do-not-crash-wp5.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Do not crash reporting errors in Webpack 5",
+  "packageName": "just-scripts",
+  "email": "1581488+christiango@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-22T14:40:17.118Z"
+}

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -89,12 +89,18 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
 
           if (options && options.outputStats) {
             const statsFile = options.outputStats === true ? 'stats.json' : options.outputStats;
-            fs.writeFileSync(statsFile, JSON.stringify(stats.toJson(), null, 2));
+            fs.writeFileSync(statsFile, JSON.stringify(stats!.toJson(), null, 2));
           }
 
           if (err || stats.hasErrors()) {
-            logger.error(stats.toString({ children: webpackConfigs.map((c) => c.stats) }));
-            reject(`Webpack failed with ${stats.toJson('errors-only').errors.length} error(s).`);
+            // Stats may be undefined the the case of an error in Webpack 5
+            if (stats) {
+              logger.error(stats.toString({ children: webpackConfigs.map((c) => c.stats) }));
+              reject(`Webpack failed with ${stats.toJson('errors-only').errors.length} error(s).`);
+            } else {
+              logger.error(err.toString());
+              reject(`Webpack failed with error(s).`);
+            }
           } else {
             resolve();
           }


### PR DESCRIPTION
Resolves #477 

In webpack 5, config errors manifest as errors with no stats object, causing webpack task to crash. This PR does not change the current behavior in WP4, but does avoid crashing in WP5
