### PR TITLE
nodeExecTask: Use just-script-utils spawn

### DIFF
--- a/change/just-scripts-2020-11-09-14-17-26-jagore-node-exec-utils-sync.json
+++ b/change/just-scripts-2020-11-09-14-17-26-jagore-node-exec-utils-sync.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use just-script-utils version of spawn in order to properly forward OOMs.",
+  "packageName": "just-scripts",
+  "email": "jagore@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-09T22:17:26.896Z"
+}

--- a/packages/just-scripts/src/tasks/nodeExecTask.ts
+++ b/packages/just-scripts/src/tasks/nodeExecTask.ts
@@ -1,4 +1,5 @@
-import { spawn, SpawnOptions } from 'child_process';
+import { SpawnOptions } from 'child_process';
+import { spawn } from 'just-scripts-utils';
 import { logger } from 'just-task';
 import { resolveCwd, _tryResolve } from 'just-task/lib/resolve';
 import { getTsNodeEnv } from '../typescript/getTsNodeEnv';


### PR DESCRIPTION

## Overview

Use just-script-utils version of spawn in order to properly forward OOMs.

