### PR TITLE
Several improvements with exit code for unknown command as well as webpack task dealing with configs

### DIFF
--- a/change/just-scripts-638f69ac-43a8-47e5-95c0-cd9140ccf30f.json
+++ b/change/just-scripts-638f69ac-43a8-47e5-95c0-cd9140ccf30f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "making webpackDevServerTask work with newer webpack-cli versions",
+  "packageName": "just-scripts",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/just-scripts-638f69ac-43a8-47e5-95c0-cd9140ccf30f.json
+++ b/change/just-scripts-638f69ac-43a8-47e5-95c0-cd9140ccf30f.json
@@ -1,6 +1,6 @@
 {
-  "type": "patch",
-  "comment": "making webpackDevServerTask work with newer webpack-cli versions",
+  "type": "minor",
+  "comment": "making webpackDevServerTask work with newer webpack-cli versions; webpack config are picked up more naturally like webpack-cli",
   "packageName": "just-scripts",
   "email": "kchau@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/just-task-ea62d607-66a7-463b-bc94-1a93bc5888c0.json
+++ b/change/just-task-ea62d607-66a7-463b-bc94-1a93bc5888c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "exit code 1 for unknown just command",
+  "packageName": "just-task",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-scripts/src/tasks/webpackCliTask.ts
+++ b/packages/just-scripts/src/tasks/webpackCliTask.ts
@@ -52,6 +52,10 @@ export function webpackCliTask(options: WebpackCliTaskOptions = {}): TaskFunctio
 
     let configPath = findWebpackConfig('webpack.config.js');
 
+    if (configPath) {
+      options.env = { ...options.env, ...(configPath.endsWith('.ts') && getTsNodeEnv(options.tsconfig, options.transpileOnly)) };
+    }
+
     if (options.webpackCliArgs) {
       const configIndex = options.webpackCliArgs.indexOf('--config');
       const configPathAvailable = configIndex > -1 && options.webpackCliArgs.length > configIndex + 2;
@@ -61,8 +65,6 @@ export function webpackCliTask(options: WebpackCliTaskOptions = {}): TaskFunctio
     }
 
     logger.info(`webpack-cli arguments: ${process.execPath} ${args.join(' ')}`);
-
-    options.env = { ...options.env, ...(configPath.endsWith('.ts') && getTsNodeEnv(options.tsconfig, options.transpileOnly)) };
 
     return spawn(process.execPath, args, { stdio: 'inherit', env: options.env });
   };

--- a/packages/just-scripts/src/webpack/findWebpackConfig.ts
+++ b/packages/just-scripts/src/webpack/findWebpackConfig.ts
@@ -1,16 +1,15 @@
 import { resolveCwd } from 'just-task';
 import * as path from 'path';
 
-export function findWebpackConfig(target: string): string {
-  let configPath: string = target;
-
-  const haystackConfigPaths = [target, target.replace(/\.js$/, '.ts')];
-  for (const needle of haystackConfigPaths) {
-    if (needle && resolveCwd(path.join('.', needle))) {
-      configPath = needle;
-      break;
+export function findWebpackConfig(...targets: string[]): string | null {
+  for (const target of targets) {
+    const haystackConfigPaths = [target, target.replace(/\.js$/, '.ts')];
+    for (const needle of haystackConfigPaths) {
+      if (needle && resolveCwd(path.join('.', needle))) {
+        return needle;
+      }
     }
   }
 
-  return configPath;
+  return null;
 }

--- a/packages/just-task/src/cli.ts
+++ b/packages/just-task/src/cli.ts
@@ -46,6 +46,7 @@ if (command) {
     undertaker.series(registry.get(command))(() => undefined);
   } else {
     logger.error(`Command not defined: ${command}`);
+    process.exitCode = 1;
   }
 } else {
   showHelp();


### PR DESCRIPTION
## Overview
1. webpack serve task now can use the correct CLI call to boot the webpack-cli >4
2. webpack.config can be used for dev server
3. zero config can still work for webpack
4. exitCode = 1 now if just command is unknown

