### PR TITLE
Add support for default config override

### DIFF
--- a/change/just-task-38b01f84-5ab8-420d-b7a9-9276f1de3081.json
+++ b/change/just-task-38b01f84-5ab8-420d-b7a9-9276f1de3081.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for default config override",
+  "packageName": "just-task",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-task/src/cli.ts
+++ b/packages/just-task/src/cli.ts
@@ -34,6 +34,7 @@ function showHelp() {
 
 // Define a built-in option of "config" so users can specify which path to choose for configurations
 option('config', { describe: 'path to a just configuration file (includes the file name, e.g. /path/to/just.config.ts)' });
+option('defaultConfig', { describe: 'path to a default just configuration file that will be used when the current project does not have a just configuration file. (includes the file name, e.g. /path/to/just.config.ts)' });
 
 readConfig();
 

--- a/packages/just-task/src/config.ts
+++ b/packages/just-task/src/config.ts
@@ -5,16 +5,23 @@ import { argv } from './option';
 import { resolve } from './resolve';
 import { mark, logger } from 'just-task-logger';
 import { enableTypeScript } from './enableTypeScript';
+import yargsParser = require('yargs-parser');
+
+export function resolveConfigFile(args: yargsParser.Arguments): string | null {
+
+  for (const entry of [args.config, './just.config.js', './just-task.js', './just.config.ts', args.defaultConfig]) {
+    const configFile = resolve(entry);
+    if (configFile) {
+      return configFile;
+    }
+  }
+
+  return null;
+}
 
 export function readConfig(): void {
   // uses a separate instance of yargs to first parse the config (without the --help in the way) so we can parse the configFile first regardless
-  let configFile: string | null = null;
-  for (const entry of [argv().config, './just.config.js', './just-task.js', './just.config.ts']) {
-    configFile = resolve(entry);
-    if (configFile) {
-      break;
-    }
-  }
+  const configFile = resolveConfigFile(argv());
 
   mark('registry:configModule');
 


### PR DESCRIPTION
## Overview
This change adds another top level option to `just-scripts`. It already had a `--config` option to explicitly specify a config file. That setting overrides the config file to use and if not specified, each project must specify a config file next to package.json. This changes adds a new config option `--default-config` that allows a config file to be specified as last fallback. i.e. if a project has a local just config file, that one will be picked up. If not, it will fall back to the one specified in  `--default-config`. 

This is very useful for large monorepo's where projects are very homogeneous and all just.config.ts files look alike, yet still allows for extension and customization should a project need it.

## Example
This allows teams to add a package with a bin-script file in the shared repo i.e. `my-scripts.js` that can be used as `my-scripts build` instead of `just-scripts build`. The contents of my-scripts.js could be something like:
```
import * as path from 'path';
process.argv.push("--default-config", path.resolve(__dirname, "my.default.config.js"));
require("just-scripts/bin/just-scripts.js");
```
and have `my.default.config.js` as the default settings for the repo.

And projects that want to slightly customize can import the `my.default.config.js` and then override a few tasks, or fully specify the tasks they want.

## Test Notes
Factored the logic that determines which config file should be picked up and added unittest for those.
