### PR TITLE
Fix problem with loading css/scsss

### DIFF
--- a/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
@@ -34,7 +34,7 @@ function createStyleLoaderRule(cssOptions: CssLoaderOptions, preprocessor: 'sass
     ...(preprocessor ? [preprocessor] : []),
   ];
 
-  const moduleOptions = cssOptions.localIdentName
+  const moduleOptions = cssOptions.modules !== false && cssOptions.localIdentName
     ? {
         modules: {
           mode: 'local',


### PR DESCRIPTION
As long as the `localIdentName` was set in the parameter the modules parameter was ignored. This resulted in the use of modules even when modules was set to false explicitly

## Overview
Fixes #343 

The problem was introduced in #243. It fixed a problem with invalid options, but always set the module option for the css-loader.
This prevented the styles to get applied since the name of the style was changed in the css but not in the DOM.

## Test Notes
