### PR TITLE
Add silent option to jest task to match Jest CLI --silent

### DIFF
--- a/change/just-scripts-045992a7-5103-4313-a490-671a7f9df917.json
+++ b/change/just-scripts-045992a7-5103-4313-a490-671a7f9df917.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add silent option to jest task to match Jest CLI --silent",
+  "packageName": "just-scripts",
+  "email": "iancra@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-scripts/src/tasks/jestTask.ts
+++ b/packages/just-scripts/src/tasks/jestTask.ts
@@ -12,6 +12,7 @@ export interface JestTaskOptions {
   colors?: boolean;
   passWithNoTests?: boolean;
   clearCache?: boolean;
+  silent?: boolean;
   testPathPattern?: string;
   testNamePattern?: string;
   u?: boolean;
@@ -52,6 +53,7 @@ export function jestTask(options: JestTaskOptions = {}): TaskFunction {
         ...(options.runInBand ? ['--runInBand'] : []),
         ...(options.coverage ? ['--coverage'] : []),
         ...(options.watch ? ['--watch'] : []),
+        ...(options.silent ? ['--silent'] : []),
         ...(options.testPathPattern ? ['--testPathPattern', options.testPathPattern] : []),
         ...(options.testNamePattern ? ['--testNamePattern', options.testNamePattern] : []),
         ...(options.u || options.updateSnapshot ? ['--updateSnapshot'] : ['']),


### PR DESCRIPTION
## Overview

Jest has a `--silent` CLI flag which disables console.log output. This can be helpful to prevent noise, especially in large test suites.

https://jestjs.io/docs/en/cli#--silent

This PR just adds an option to set this flag through the Jest task.

