### PR TITLE
Add watch() API

### DIFF
--- a/change/just-task-f42c6511-b76e-43ff-9b5b-c3afb3bd61a6.json
+++ b/change/just-task-f42c6511-b76e-43ff-9b5b-c3afb3bd61a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adds a watch() API that will generate taskfunction that watches",
+  "packageName": "just-task",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/example-lib/just.config.ts
+++ b/packages/example-lib/just.config.ts
@@ -10,11 +10,20 @@ task('watch', parallel('typescript:watch'));
 
 task('start', () => {
   return parallel(
-    watch(['./src/**/*.js'], () => {
-      console.log('dude js');
-    }),
-    watch(['./src/**/*.ts'], () => {
-      console.log('dude ts');
-    }),
+    () =>
+      watch(['./src/**/*.js'], () => {
+        console.log('dude js');
+      }),
+    () =>
+      watch(['./src/**/*.ts'], () => {
+        console.log('dude ts');
+      }),
   );
+});
+
+task('w', () => {
+  const watcher = watch(['./src/**/*.js']);
+  watcher.on('change', (evt, file) => {
+    console.log(file, 'is changed', evt);
+  });
 });

--- a/packages/example-lib/just.config.ts
+++ b/packages/example-lib/just.config.ts
@@ -1,4 +1,4 @@
-import { nodeExecTask, tscTask, task, parallel } from 'just-scripts';
+import { nodeExecTask, tscTask, task, parallel, watch } from 'just-scripts';
 
 task('typescript', tscTask({}));
 task('typescript:watch', tscTask({ watch: true }));
@@ -7,3 +7,14 @@ task('customNodeTask', nodeExecTask({ enableTypeScript: true, args: ['./tasks/cu
 
 task('build', parallel('customNodeTask', 'typescript'));
 task('watch', parallel('typescript:watch'));
+
+task('start', () => {
+  return parallel(
+    watch(['./src/**/*.js'], () => {
+      console.log('dude js');
+    }),
+    watch(['./src/**/*.ts'], () => {
+      console.log('dude ts');
+    }),
+  );
+});

--- a/packages/example-lib/src/hello.js
+++ b/packages/example-lib/src/hello.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/just-task/package.json
+++ b/packages/just-task/package.json
@@ -28,10 +28,13 @@
     "resolve": "^1.19.0",
     "undertaker": "^1.3.0",
     "undertaker-registry": "^1.0.1",
-    "yargs-parser": "^20.2.3"
+    "yargs-parser": "^20.2.3",
+    "glob-watcher": "^5.0.5"
   },
   "devDependencies": {
+    "@types/chokidar": "^2.1.3",
     "@types/fs-extra": "^8.0.0",
+    "@types/glob-watcher": "^5.0.0",
     "@types/jest": "^26.0.20",
     "@types/mock-fs": "^4.13.0",
     "@types/node": "^10.12.18",

--- a/packages/just-task/src/__tests__/watch.spec.ts
+++ b/packages/just-task/src/__tests__/watch.spec.ts
@@ -13,7 +13,7 @@ describe('watch', () => {
 
     const cleanup = () => {
       watcher.close();
-      fs.rmSync(tmpDir, { recursive: true });
+      fs.rmdirSync(tmpDir, { recursive: true });
     };
 
     const callback = () => {

--- a/packages/just-task/src/__tests__/watch.spec.ts
+++ b/packages/just-task/src/__tests__/watch.spec.ts
@@ -13,7 +13,8 @@ describe('watch', () => {
 
     const cleanup = () => {
       watcher.close();
-      fs.rmdirSync(tmpDir, { recursive: true });
+      fs.unlinkSync(changeFile);
+      fs.rmdirSync(tmpDir);
     };
 
     const callback = () => {

--- a/packages/just-task/src/__tests__/watch.spec.ts
+++ b/packages/just-task/src/__tests__/watch.spec.ts
@@ -1,0 +1,30 @@
+import { watch } from '../watch';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+describe('watch', () => {
+  it('can take a synchronous taskFunction', done => {
+    const tmpDir = path.join(os.tmpdir(), fs.mkdtempSync('watch-sync'));
+    const changeFile = path.join(tmpDir, 'change.txt');
+
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(changeFile, 'to be changed');
+
+    const callback = () => {
+      try {
+        expect(true).toBeTruthy();
+        watcher.close();
+        done();
+      } catch (error) {
+        watcher.close();
+        done(error);
+      }
+    };
+    const watcher = watch([path.join(changeFile)], callback);
+
+    watcher.on('ready', () => {
+      fs.writeFileSync(changeFile, 'new content');
+    });
+  });
+});

--- a/packages/just-task/src/__tests__/watch.spec.ts
+++ b/packages/just-task/src/__tests__/watch.spec.ts
@@ -11,13 +11,18 @@ describe('watch', () => {
     fs.mkdirSync(tmpDir, { recursive: true });
     fs.writeFileSync(changeFile, 'to be changed');
 
+    const cleanup = () => {
+      watcher.close();
+      fs.rmSync(tmpDir, { recursive: true });
+    };
+
     const callback = () => {
       try {
         expect(true).toBeTruthy();
-        watcher.close();
+        cleanup();
         done();
       } catch (error) {
-        watcher.close();
+        cleanup();
         done(error);
       }
     };

--- a/packages/just-task/src/index.ts
+++ b/packages/just-task/src/index.ts
@@ -7,3 +7,4 @@ export { option, argv } from './option';
 export { clearCache } from './cache';
 export * from './logger';
 export * from './chain';
+export * from './watch';

--- a/packages/just-task/src/watch.ts
+++ b/packages/just-task/src/watch.ts
@@ -1,14 +1,13 @@
 import * as globWatch from 'glob-watcher';
-import * as fs from 'fs';
 import { wrapTask } from './wrapTask';
 import { TaskFunction } from './interfaces';
-import type { WatchOptions } from 'chokidar';
+import type { WatchOptions, FSWatcher } from 'chokidar';
 
 export function watch(
   globs: string | string[],
   optionsOrTaskFunction?: TaskFunction | WatchOptions | undefined,
   taskFunction?: TaskFunction | undefined,
-): () => Promise<fs.FSWatcher> {
+): FSWatcher {
   let options: WatchOptions = {};
   if (typeof optionsOrTaskFunction === 'function') {
     taskFunction = optionsOrTaskFunction;
@@ -17,17 +16,7 @@ export function watch(
     options = optionsOrTaskFunction as WatchOptions;
   }
 
-  // Return a taskFunction, so this API can be parallelized
-  return () =>
-    new Promise((resolve, reject) => {
-      // Wrapping this function teaches the glob-watcher about how to deal with sync taskFunction
-      const wrappedFunction = wrapTask(taskFunction);
-      const watcher = globWatch(globs, options, wrappedFunction);
-      watcher.on('close', () => {
-        resolve(watcher);
-      });
-      watcher.on('error', () => {
-        reject();
-      });
-    });
+  // Wrapping this function teaches the glob-watcher about how to deal with sync taskFunction
+  const wrappedFunction = wrapTask(taskFunction);
+  return globWatch(globs, options, wrappedFunction) as FSWatcher;
 }

--- a/packages/just-task/src/watch.ts
+++ b/packages/just-task/src/watch.ts
@@ -1,0 +1,33 @@
+import * as globWatch from 'glob-watcher';
+import * as fs from 'fs';
+import { wrapTask } from './wrapTask';
+import { TaskFunction } from './interfaces';
+import type { WatchOptions } from 'chokidar';
+
+export function watch(
+  globs: string | string[],
+  optionsOrTaskFunction?: TaskFunction | WatchOptions | undefined,
+  taskFunction?: TaskFunction | undefined,
+): () => Promise<fs.FSWatcher> {
+  let options: WatchOptions = {};
+  if (typeof optionsOrTaskFunction === 'function') {
+    taskFunction = optionsOrTaskFunction;
+    options = {};
+  } else {
+    options = optionsOrTaskFunction as WatchOptions;
+  }
+
+  // Return a taskFunction, so this API can be parallelized
+  return () =>
+    new Promise((resolve, reject) => {
+      // Wrapping this function teaches the glob-watcher about how to deal with sync taskFunction
+      const wrappedFunction = wrapTask(taskFunction);
+      const watcher = globWatch(globs, options, wrappedFunction);
+      watcher.on('close', () => {
+        resolve(watcher);
+      });
+      watcher.on('error', () => {
+        reject();
+      });
+    });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1391,6 +1391,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/chokidar@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@types/chokidar/-/chokidar-2.1.3.tgz#123ab795dba6d89be04bf076e6aecaf8620db674"
+  integrity sha512-6qK3xoLLAhQVTucQGHTySwOVA1crHRXnJeLwqK6KIFkkKa2aoMFXh+WEi8PotxDtvN6MQJLyYN9ag9P6NLV81w==
+  dependencies:
+    chokidar "*"
+
 "@types/diff-match-patch@1.0.32":
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/@types/diff-match-patch/-/diff-match-patch-1.0.32.tgz#d9c3b8c914aa8229485351db4865328337a3d09f"
@@ -1400,6 +1407,13 @@
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.1.tgz#1e49f22d09aa46e19b51c0b013cb63d0d923a068"
   integrity sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==
+  dependencies:
+    "@types/node" "*"
+
+"@types/glob-watcher@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/glob-watcher/-/glob-watcher-5.0.0.tgz#cfd63a8547c8e5c2d81fdac9552fd83f32c6f819"
+  integrity sha512-UZRHIRfTpcymeWQM6knz7SIHkYNNFZGn+3ybomdEyuEO0RpUHjRm5ro7ALL7MjYWI+W5Xn3VgVEl7atzlavVpw==
   dependencies:
     "@types/node" "*"
 
@@ -2566,7 +2580,7 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-async-done@^1.2.2, async-done@^1.3.2, async-done@~1.3.2:
+async-done@^1.2.0, async-done@^1.2.2, async-done@^1.3.2, async-done@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/async-done/-/async-done-1.3.2.tgz#5e15aa729962a4b07414f528a88cdf18e0b290a2"
   integrity sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==
@@ -3368,6 +3382,21 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
+chokidar@*:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
+
 chokidar@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -3384,7 +3413,7 @@ chokidar@^1.6.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^2.0.3, chokidar@^2.1.8:
+chokidar@^2.0.0, chokidar@^2.0.3, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -5938,6 +5967,19 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
+glob-watcher@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/glob-watcher/-/glob-watcher-5.0.5.tgz#aa6bce648332924d9a8489be41e3e5c52d4186dc"
+  integrity sha512-zOZgGGEHPklZNjZQaZ9f41i7F2YwE+tS5ZHrDhbBCk3stwahn5vQxnFmBJZHoYdusR6R1bLSXeGUy/BhctwKzw==
+  dependencies:
+    anymatch "^2.0.0"
+    async-done "^1.2.0"
+    chokidar "^2.0.0"
+    is-negated-glob "^1.0.0"
+    just-debounce "^1.0.0"
+    normalize-path "^3.0.0"
+    object.defaults "^1.1.0"
+
 glob2base@^0.0.12:
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56"
@@ -6842,6 +6884,11 @@ is-installed-globally@^0.3.1:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
 
+is-negated-glob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz#6910bca5da8c95e784b5751b976cf5a10fee36d2"
+  integrity sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=
+
 is-negative-zero@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
@@ -7624,6 +7671,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+just-debounce@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/just-debounce/-/just-debounce-1.1.0.tgz#2f81a3ad4121a76bc7cb45dbf704c0d76a8e5ddf"
+  integrity sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -8679,7 +8731,7 @@ object.assign@^4.1.0, object.assign@^4.1.1:
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
 
-object.defaults@^1.0.0:
+object.defaults@^1.0.0, object.defaults@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/object.defaults/-/object.defaults-1.1.0.tgz#3a7f868334b407dea06da16d88d5cd29e435fecf"
   integrity sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=


### PR DESCRIPTION
## Overview

Adding `glob-watcher` (another gem from the gulp ecosystem) to allow watched task functions. Whenever a file changed in the glob, it'll trigger the task function.

1. `just-task`'s `watch()` a watcher, they can participate in parallel / series composition with `() => watch`
2. watch will take on sync taskfunction's like other `just-task` functions