### PR TITLE
Selective task: only register tasks for config as module that export actual functions

### DIFF
--- a/change/just-task-cad8e002-ab15-40f4-9c07-bf8fe3ad59a2.json
+++ b/change/just-task-cad8e002-ab15-40f4-9c07-bf8fe3ad59a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "adding a check to make sure the tasks are registered only for task functions",
+  "packageName": "just-task",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-task/src/cli.ts
+++ b/packages/just-task/src/cli.ts
@@ -1,4 +1,4 @@
-import { undertaker } from './undertaker';
+import { series, undertaker } from './undertaker';
 import { option, parseCommand } from './option';
 import { logger } from 'just-task-logger';
 import { TaskFunction } from './interfaces';
@@ -47,7 +47,9 @@ const configModule = readConfig();
 // Support named task function as exports of a config module
 if (configModule && typeof configModule === 'object') {
   for (const taskName of Object.keys(configModule)) {
-    task(taskName, configModule[taskName]);
+    if (typeof configModule[taskName] == 'function') {
+      task(taskName, configModule[taskName]);
+    }
   }
 }
 

--- a/packages/just-task/src/cli.ts
+++ b/packages/just-task/src/cli.ts
@@ -1,4 +1,4 @@
-import { series, undertaker } from './undertaker';
+import { undertaker } from './undertaker';
 import { option, parseCommand } from './option';
 import { logger } from 'just-task-logger';
 import { TaskFunction } from './interfaces';


### PR DESCRIPTION
Previously, anything that is exported from the config module is registered as tasks. This led to some problems with some existing & odd exports of config module like primitives for port numbers, etc. This PR will filter those out.