### PR TITLE
spawn() should reject if process is terminated

### DIFF
--- a/change/just-scripts-utils-a045a857-3f8f-448a-a2dd-2b0c251004d0.json
+++ b/change/just-scripts-utils-a045a857-3f8f-448a-a2dd-2b0c251004d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Error when parallel process is terminated",
+  "packageName": "just-scripts-utils",
+  "email": "iancra@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-scripts-utils/src/exec.ts
+++ b/packages/just-scripts-utils/src/exec.ts
@@ -102,10 +102,14 @@ export function spawn(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = cp.spawn(cmd, args, opts);
-    child.on('exit', code => {
+    child.on('exit', (code: number | null, signal: string | null) => {
       if (code) {
         const error = new Error('Command failed: ' + [cmd, ...args].join(' '));
         (error as any).code = code;
+        reject(error);
+      } else if (signal) {
+        const error = new Error(`Command terminated by signal ${signal}: ` + [cmd, ...args].join(' '));
+        (error as any).signal = signal;
         reject(error);
       } else {
         resolve();


### PR DESCRIPTION
## Overview
`parallel('task-1', taskTwo())` currently succeeds even if one or both task's processes are terminated by the OS (e.g. due to memory thrashing). This can result in official build pipelines "succeeding" and publishing results which are invalid.

Looks like the cause is how we handle termination in the `spawn()` function; we're just not checking `signal`. In the case the process is terminated `code` will be `null` which is falling into our success case.

Fixing by adding a new check for `signal`. We could instead combine this with the existing one but having a process terminated, especially in some remote pipeline environment, can be very confusing so I figured a more verbose error here would be helpful.

## Test Notes
Manually tested on an internal project. We don't seem to have UTs or spawn(), but this feels like a pretty safe change.