### PR TITLE
Add option to modify API Extractor config before running

### DIFF
--- a/change/just-scripts-852e71c1-c2c2-4e1b-9fd0-1d8681e6b37a.json
+++ b/change/just-scripts-852e71c1-c2c2-4e1b-9fd0-1d8681e6b37a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add option to modify API Extractor config before executing",
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Overview

Add an option `onConfigLoaded` to the API Extractor task which allows modifying the config file before running API Extractor. This will allow removing a [convoluted workaround](https://github.com/microsoft/fluentui/blob/f1be0a9728e05ca33ad67e77ae7d1cba3384106f/scripts/tasks/api-extractor.ts#L66) we currently have to use in Fluent UI to modify the config in some circumstances.

## Test Notes

Tried it with `yarn link` and it worked