### PR TITLE
jest task: don't include positional args twice

### DIFF
--- a/change/just-scripts-c7187b64-21f6-47ad-a1ab-6f49cafda24b.json
+++ b/change/just-scripts-c7187b64-21f6-47ad-a1ab-6f49cafda24b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "jest: don't include positional args twice",
+  "packageName": "just-scripts",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-scripts/src/tasks/jestTask.ts
+++ b/packages/just-scripts/src/tasks/jestTask.ts
@@ -72,7 +72,7 @@ export function jestTask(options: JestTaskOptions = {}): TaskFunction {
         // Only include the positional args if `options._` wasn't specified
         // (to avoid possibly including them twice)
         ...(options._ || positional),
-      ].filter(arg => !!arg);
+      ].filter(arg => !!arg) as string[];
 
       logger.info(cmd, encodeArgs(args).join(' '));
 

--- a/packages/just-scripts/src/tasks/jestTask.ts
+++ b/packages/just-scripts/src/tasks/jestTask.ts
@@ -69,8 +69,10 @@ export function jestTask(options: JestTaskOptions = {}): TaskFunction {
         ...(options.testPathPattern ? ['--testPathPattern', options.testPathPattern] : []),
         ...(options.testNamePattern ? ['--testNamePattern', options.testNamePattern] : []),
         ...(options.u || options.updateSnapshot ? ['--updateSnapshot'] : ['']),
-        ...(options._ || []).concat(positional),
-      ].filter(arg => !!arg) as Array<string>;
+        // Only include the positional args if `options._` wasn't specified
+        // (to avoid possibly including them twice)
+        ...(options._ || positional),
+      ].filter(arg => !!arg);
 
       logger.info(cmd, encodeArgs(args).join(' '));
 


### PR DESCRIPTION
If `options._` was specified to the jest task, it's likely to contain the same values as `argv()._`, so don't use both.