### PR TITLE
Remove unused handlebars dep

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,6 @@
   "json.format.enable": false,
   "javascript.preferences.quoteStyle": "single",
   "typescript.preferences.quoteStyle": "single",
-  "[handlebars]": {
-    "editor.formatOnSave": false
-  },
   "files.associations": {
     "**/package.json.hbs": "json",
     "**/*.json.hbs": "jsonc",

--- a/change/just-scripts-utils-8a638cfa-0aff-47b5-8127-32249a67b9bf.json
+++ b/change/just-scripts-utils-8a638cfa-0aff-47b5-8127-32249a67b9bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove unused handlebars dep",
+  "packageName": "just-scripts-utils",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-scripts-utils/package.json
+++ b/packages/just-scripts-utils/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "fs-extra": "^8.0.0",
     "glob": "^7.1.3",
-    "handlebars": "^4.7.7",
     "jju": "^1.4.0",
     "just-task-logger": ">=1.1.1 <2.0.0",
     "marked": "^2.0.0",
@@ -31,7 +30,6 @@
   "devDependencies": {
     "@types/fs-extra": "^8.0.0",
     "@types/glob": "^7.1.3",
-    "@types/handlebars": "^4.1.0",
     "@types/jest": "^26.0.20",
     "@types/jju": "^1.4.1",
     "@types/marked": "^1.2.2",


### PR DESCRIPTION
just-scripts-utils no longer uses handlebars, so remove the dependency.