### PR TITLE
Adding rootDir option to jest task.

### DIFF
--- a/change/just-scripts-16e659f4-3617-4268-99b9-1c3a4013f3c9.json
+++ b/change/just-scripts-16e659f4-3617-4268-99b9-1c3a4013f3c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding rootDir option to jest task.",
+  "packageName": "just-scripts",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-scripts/src/tasks/jestTask.ts
+++ b/packages/just-scripts/src/tasks/jestTask.ts
@@ -5,6 +5,7 @@ import * as supportsColor from 'supports-color';
 
 export interface JestTaskOptions {
   config?: string;
+  rootDir?: string;
   runInBand?: boolean;
   coverage?: boolean;
   updateSnapshot?: boolean;
@@ -59,6 +60,7 @@ export function jestTask(options: JestTaskOptions = {}): TaskFunction {
         ...(options.nodeArgs || []),
         jestCmd,
         ...(configFileExists ? ['--config', configFile] : []),
+        ...(options.rootDir ? ['--rootDir', options.rootDir] : []),
         ...(options.passWithNoTests ? ['--passWithNoTests'] : []),
         ...(options.clearCache ? ['--clearCache'] : []),
         ...(options.colors !== false && supportsColor.stdout ? ['--colors'] : []),


### PR DESCRIPTION
## Overview

Jest task was missing the rootDir option. Adding it.
