### PR TITLE
Exporting findGitRoot and other package functions from just-task

### DIFF
--- a/change/just-task-a9086f09-1e7e-4ee0-8db6-8ff575b3fd7c.json
+++ b/change/just-task-a9086f09-1e7e-4ee0-8db6-8ff575b3fd7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Exporting findGitRoot and other package functions from just-task",
+  "packageName": "just-task",
+  "email": "omprieto@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-task/README.md
+++ b/packages/just-task/README.md
@@ -7,7 +7,6 @@
 
 - a build task build definition library
 - sane preset build flows for node and browser projects featuring TypeScript, Webpack and jest
-- project scaffold tool that generates no-ejection needed repos that tracks template changes
 
 # Documentation
 
@@ -41,11 +40,9 @@ yarn test
 
 | Package            | Description                                                                             |
 | ------------------ | --------------------------------------------------------------------------------------- |
-| create-just        | Invoked by `npm init just`, a tool that scaffolds project repos                         |
 | just-task          | The task definition library that wraps `undertaker` and `yargs` libraries               |
 | just-scripts       | A reusable preset of frequently used tasks in node and browser projects                 |
-| just-stack-\*      | A set of templates to be used by the scaffold tool `create-just`                        |
-| just-scripts-utils | A set of utilities that are shared between `just-scripts` and `create-just`             |
+| just-scripts-utils | A set of utilities for `just-scripts`                                                   |
 | just-task-logger   | A shared pretty logger used to display timestamps along with a message                  |
 | documentation      | The Docusaurus site content and styles which generates the Github page for this library |
 

--- a/packages/just-task/src/index.ts
+++ b/packages/just-task/src/index.ts
@@ -8,3 +8,4 @@ export { clearCache } from './cache';
 export * from './logger';
 export * from './chain';
 export * from './watch';
+export * from './package';

--- a/packages/just-task/src/package/index.ts
+++ b/packages/just-task/src/package/index.ts
@@ -1,0 +1,3 @@
+export * from './findDependents';
+export * from './findGitRoot';
+export * from './findPackageRoot';


### PR DESCRIPTION
## Overview

Exporting some functionality to use within [office-bohemia-build-tools](https://office.visualstudio.com/OC/_git/office-bohemia?path=/packages/office-bohemia-build-tools) package.

- `findGitDependents`.
- `findGitRoot`.
- `findPackageRoot`.

## Test Notes

Validated that `yarn build` finishes properly.