### PR TITLE
Fixing transitive security vulnerability

### DIFF
--- a/change/just-scripts-4075e3fb-0039-4a1d-b84d-6675c933767f.json
+++ b/change/just-scripts-4075e3fb-0039-4a1d-b84d-6675c933767f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Upgrading package-deps-hash to latest major to remove transitive security vulnerability in validator package.",
+  "packageName": "just-scripts",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/just-scripts-4075e3fb-0039-4a1d-b84d-6675c933767f.json
+++ b/change/just-scripts-4075e3fb-0039-4a1d-b84d-6675c933767f.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Upgrading package-deps-hash to latest major to remove transitive security vulnerability in validator package.",
-  "packageName": "just-scripts",
-  "email": "dzearing@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/just-task-b9e5fdca-b717-426f-a4a8-3a6cd1b61d89.json
+++ b/change/just-task-b9e5fdca-b717-426f-a4a8-3a6cd1b61d89.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Upgrading package-deps-hash to latest major to remove transitive security vulnerability in validator package.",
+  "packageName": "just-task",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-task/README.md
+++ b/packages/just-task/README.md
@@ -5,9 +5,8 @@
 
 `Just` is a library that organizes build tasks for your JS projects. It consists of
 
-- a build task build definition library
+- a build task definition library
 - sane preset build flows for node and browser projects featuring TypeScript, Webpack and jest
-- project scaffold tool that generates no-ejection needed repos that tracks template changes
 
 # Documentation
 
@@ -41,11 +40,9 @@ yarn test
 
 | Package            | Description                                                                             |
 | ------------------ | --------------------------------------------------------------------------------------- |
-| create-just        | Invoked by `npm init just`, a tool that scaffolds project repos                         |
 | just-task          | The task definition library that wraps `undertaker` and `yargs` libraries               |
 | just-scripts       | A reusable preset of frequently used tasks in node and browser projects                 |
-| just-stack-\*      | A set of templates to be used by the scaffold tool `create-just`                        |
-| just-scripts-utils | A set of utilities that are shared between `just-scripts` and `create-just`             |
+| just-scripts-utils | A set of utilities for `just-scripts`                                                   |
 | just-task-logger   | A shared pretty logger used to display timestamps along with a message                  |
 | documentation      | The Docusaurus site content and styles which generates the Github page for this library |
 

--- a/packages/just-task/package.json
+++ b/packages/just-task/package.json
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@rushstack/package-deps-hash": "^2.4.109",
+    "@rushstack/package-deps-hash": "^3.2.5",
     "bach": "^1.2.0",
     "chalk": "^4.0.0",
     "fs-extra": "^8.0.0",

--- a/packages/just-task/src/cache.ts
+++ b/packages/just-task/src/cache.ts
@@ -1,4 +1,4 @@
-import { getPackageDeps, IPackageDeps } from '@rushstack/package-deps-hash';
+import { getPackageDeps } from '@rushstack/package-deps-hash';
 import { argv } from './option';
 import { resolveCwd } from './resolve';
 import * as fs from 'fs-extra';
@@ -83,7 +83,7 @@ function getCachePath() {
 interface CacheHash {
   args: { [arg: string]: string };
   taskName: string;
-  hash: IPackageDeps;
+  hash: Record<string, string>;
   dependentHashTimestamps: { [pkgName: string]: number };
 }
 
@@ -127,11 +127,10 @@ function getHash(taskName: string): CacheHash | null {
 
   const packageRootPath = getPackageRootPath();
 
-  const packageDeps = getPackageDeps(packageRootPath);
-
-  const lockFileHashes = getLockFileHashes();
-
-  packageDeps.files = { ...packageDeps.files, ...lockFileHashes };
+  const packageDeps = {
+    ...Object.fromEntries(getPackageDeps(packageRootPath)),
+    ...getLockFileHashes()
+  };
 
   const hash = {
     args,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,12 +1242,12 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.6.1.tgz#b260e454ee4f9635ea024fc83be225e397f15363"
   integrity sha512-5bHhlTBBq82ti3qPT15TRxkYTFPPQWbnkkQkmHPtqiS1XcTB69cEKd3Jm7Cfi/vkPoyxapmePE9tyA7EzLt8SQ==
 
-"@rushstack/node-core-library@3.35.2":
-  version "3.35.2"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.35.2.tgz#21ca879b5051a5ebafa952fafcd648a07a142bcb"
-  integrity sha512-SPd0uG7mwsf3E30np9afCUhtaM1SBpibrbxOXPz82KWV6SQiPUtXeQfhXq9mSnGxOb3WLWoSDe7AFxQNex3+kQ==
+"@rushstack/node-core-library@3.45.1":
+  version "3.45.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.45.1.tgz#787361b61a48d616eb4b059641721a3dc138f001"
+  integrity sha512-BwdssTNe007DNjDBxJgInHg8ePytIPyT0La7ZZSQZF9+rSkT42AygXPGvbGsyFfEntjr4X37zZSJI7yGzL16cQ==
   dependencies:
-    "@types/node" "10.17.13"
+    "@types/node" "12.20.24"
     colors "~1.2.1"
     fs-extra "~7.0.1"
     import-lazy "~4.0.0"
@@ -1255,14 +1255,14 @@
     resolve "~1.17.0"
     semver "~7.3.0"
     timsort "~0.3.0"
-    z-schema "~3.18.3"
+    z-schema "~5.0.2"
 
-"@rushstack/package-deps-hash@^2.4.109", "@rushstack/package-deps-hash@^2.4.48":
-  version "2.4.110"
-  resolved "https://registry.yarnpkg.com/@rushstack/package-deps-hash/-/package-deps-hash-2.4.110.tgz#e1016af0d1bf3a03f44ab79fcde0057b58c82ebd"
-  integrity sha512-6PJaruKZJ7xCcs80F5yv9fedsZIvB5iSpWG7mkXLeMDVEJVM5vqyHs22YbqVb5UeALA3Q2Dyzaj++QIDng2DVQ==
+"@rushstack/package-deps-hash@^3.2.4", "@rushstack/package-deps-hash@^3.2.5":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@rushstack/package-deps-hash/-/package-deps-hash-3.2.5.tgz#365c71c7ce6a8ff01b13c212c7ec858af4e74373"
+  integrity sha512-3G9hCbEZr8D66y5vSsj0xt+RgrQwsEIBwo8NDtoSPJSmSI0duBZNeU3ZM7eS4JszhJevr5cgaFytmGHvaK22BQ==
   dependencies:
-    "@rushstack/node-core-library" "3.35.2"
+    "@rushstack/node-core-library" "3.45.1"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -1449,10 +1449,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.20.tgz#f7974863edd21d1f8a494a73e8e2b3658615c340"
   integrity sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==
 
-"@types/node@10.17.13":
-  version "10.17.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
-  integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
+"@types/node@12.20.24":
+  version "12.20.24"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.24.tgz#c37ac69cb2948afb4cef95f424fa0037971a9a5c"
+  integrity sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==
 
 "@types/node@^10.12.18":
   version "10.17.50"
@@ -2670,12 +2670,12 @@ bach@^1.0.0, bach@^1.2.0:
     now-and-later "^2.0.0"
 
 backfill-cache@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/backfill-cache/-/backfill-cache-5.3.0.tgz#7cd14b13f558f66c61a84464b0e2308e168fdf86"
-  integrity sha512-OnOojS2b14b5oEGoawhJKM94kDCNQmSL60DXdFpxYWjLv9aaZhqStN4ortQmySprNpQAM3aNHJretCBQZ+eNhA==
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/backfill-cache/-/backfill-cache-5.4.0.tgz#df45fb74d063f5c928067e7849ee9e7bc72a5fed"
+  integrity sha512-O7L2KF8JPZlFSn6JToGflTWfHOAPnCRqLnA2TYfi8V5Va60sapkMmYnY624oo8FEKM1T1e+IBwwq6JraxlyzRQ==
   dependencies:
     "@azure/storage-blob" "12.1.2"
-    "@rushstack/package-deps-hash" "^2.4.48"
+    "@rushstack/package-deps-hash" "^3.2.4"
     backfill-config "^6.2.0"
     backfill-logger "^5.1.3"
     execa "^4.0.0"
@@ -2695,16 +2695,16 @@ backfill-config@^6.2.0:
     pkg-dir "^4.2.0"
 
 backfill-hasher@^6.2.6:
-  version "6.2.6"
-  resolved "https://registry.yarnpkg.com/backfill-hasher/-/backfill-hasher-6.2.6.tgz#751466f9413f94f10965c2e5fd682197d3eecd24"
-  integrity sha512-Gf8uMlTaCi+8GQwE1Zh9hOxzTFpSXK3ZBVu3/6pFnn4Esd0GjlQsISmEdOS8KE97UfHl0sbhk26a92FFQ0GuHw==
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/backfill-hasher/-/backfill-hasher-6.3.0.tgz#cb813f00133dc89dd046d2df720f10257e645dcf"
+  integrity sha512-PlKbtXSUq8T9PsJbxPMD1+Nt4smIySB89a9gU+kGT6FdzeyTWl9sEfX15Aivm9tuDV5Uhk8yF327AUqftRoACw==
   dependencies:
-    "@rushstack/package-deps-hash" "^2.4.48"
+    "@rushstack/package-deps-hash" "^3.2.4"
     backfill-config "^6.2.0"
     backfill-logger "^5.1.3"
     find-up "^5.0.0"
     fs-extra "^8.1.0"
-    workspace-tools "^0.15.0"
+    workspace-tools "^0.18.2"
 
 backfill-logger@^5.1.3:
   version "5.1.3"
@@ -8006,7 +8006,7 @@ lodash.flatten@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
-lodash.get@^4.0.0:
+lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -8016,7 +8016,7 @@ lodash.isarguments@^3.1.0:
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
   integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
 
-lodash.isequal@^4.0.0:
+lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
@@ -11997,10 +11997,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@^8.0.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-8.2.0.tgz#3c1237290e37092355344fef78c231249dab77b9"
-  integrity sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==
+validator@^13.7.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
 vary@~1.1.2:
   version "1.1.2"
@@ -12433,10 +12433,10 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-workspace-tools@^0.15.0:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.15.1.tgz#895d4defe1417d7f4948b6afe9d36acf3a6cd64e"
-  integrity sha512-Thp+DVHkzjMF3JWWEc6VES04FhkE6QqZL7Dyknh1bJowjbAntXp6Op8/JuH0MYrww4AgQnuvB1O5waVrmsHtBg==
+workspace-tools@^0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.16.2.tgz#b7355c811dcda648d12e92ceb89f8fccacca3901"
+  integrity sha512-Z/NHo4t39DUd50MdWiPfxICyVaCjWZc/xwZxE4a/n2nAQGgeYeg6GWBY1juULPi/BGSrjSVaDQfDCj/Y80033A==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     find-up "^4.1.0"
@@ -12448,15 +12448,13 @@ workspace-tools@^0.15.0:
     multimatch "^4.0.0"
     read-yaml-file "^2.0.0"
 
-workspace-tools@^0.16.2:
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.16.2.tgz#b7355c811dcda648d12e92ceb89f8fccacca3901"
-  integrity sha512-Z/NHo4t39DUd50MdWiPfxICyVaCjWZc/xwZxE4a/n2nAQGgeYeg6GWBY1juULPi/BGSrjSVaDQfDCj/Y80033A==
+workspace-tools@^0.18.2:
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.18.2.tgz#59753b5fb7c709f72250c8fbf5ccfe1903033a7d"
+  integrity sha512-XEW7VrD5XmYNLli89cHGQESf6Jgh45ELlKJQHbAAwd67XfC+Tf+hpJZ+GLFsKPIzJ+xIUvnJE6F71ScsMfu7KA==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
     find-up "^4.1.0"
-    find-yarn-workspace-root "^1.2.1"
-    fs-extra "^9.0.0"
     git-url-parse "^11.1.2"
     globby "^11.0.0"
     jju "^1.4.0"
@@ -12657,14 +12655,14 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-z-schema@~3.18.3:
-  version "3.18.4"
-  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-3.18.4.tgz#ea8132b279533ee60be2485a02f7e3e42541a9a2"
-  integrity sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==
+z-schema@~5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/z-schema/-/z-schema-5.0.2.tgz#f410394b2c9fcb9edaf6a7511491c0bb4e89a504"
+  integrity sha512-40TH47ukMHq5HrzkeVE40Ad7eIDKaRV2b+Qpi2prLc9X9eFJFzV7tMe5aH12e6avaSS/u5l653EQOv+J9PirPw==
   dependencies:
-    lodash.get "^4.0.0"
-    lodash.isequal "^4.0.0"
-    validator "^8.0.0"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    validator "^13.7.0"
   optionalDependencies:
     commander "^2.7.1"
 


### PR DESCRIPTION
* package-deps-hash has major released, and is behind on upgrades
* this locks us into an old version of node-core-library
* this ends up pulling in validator@^8.0.0, which is marked as a severe vulnerability package.

Fixed!
