### PR TITLE
Add support for dart-sass

### DIFF
--- a/change/just-scripts-39e3a41f-220a-452e-899c-e11ca2589b78.json
+++ b/change/just-scripts-39e3a41f-220a-452e-899c-e11ca2589b78.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add support for dart-sass",
+  "packageName": "just-scripts",
+  "email": "tristan.watanabe@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-scripts/src/tasks/sassTask.ts
+++ b/packages/just-scripts/src/tasks/sassTask.ts
@@ -28,14 +28,14 @@ export function sassTask(
   postcssPlugins = postcssPlugins || [];
 
   return function sass(done: (err?: Error) => void) {
-    const nodeSass = tryRequire('node-sass');
+    const sass = tryRequire('sass') || tryRequire('node-sass');
     const postcss = tryRequire('postcss');
     const autoprefixer = tryRequire('autoprefixer');
     const postcssRtl = tryRequire('postcss-rtl');
     const clean = tryRequire('postcss-clean');
 
-    if (!nodeSass || !postcss || !autoprefixer) {
-      logger.warn('One of these [node-sass, postcss, autoprefixer] is not installed, so this task has no effect');
+    if (!sass || !postcss || !autoprefixer) {
+      logger.warn('One of these [sass, postcss, autoprefixer] is not installed, so this task has no effect');
       done();
       return;
     }
@@ -48,7 +48,7 @@ export function sassTask(
         (fileName: string) =>
           function (cb: any) {
             fileName = path.resolve(fileName);
-            nodeSass.render(
+            sass.render(
               {
                 file: fileName,
                 importer: patchSassUrl,

--- a/packages/just-scripts/src/tasks/sassTask.ts
+++ b/packages/just-scripts/src/tasks/sassTask.ts
@@ -35,7 +35,7 @@ export function sassTask(
     const clean = tryRequire('postcss-clean');
 
     if (!sass || !postcss || !autoprefixer) {
-      logger.warn('One of these [sass, postcss, autoprefixer] is not installed, so this task has no effect');
+      logger.warn('One or more dependencies (sass or node-sass, postcss, autoprefixer) is not installed, so this task has no effect');
       done();
       return;
     }


### PR DESCRIPTION
## Overview
- The use of the deprecated package `node-sass` is hardcoded and blocks upgrade attempts to `dart-sass` in other repos. This PR now looks for `dart-sass` (now known as `sass`) first and falls back to old behavior to prevent breaking current users.

Related to this [issue ](https://github.com/microsoft/fluentui/issues/22250)
