### PR TITLE
Add support for symlink creation in the copy task

### DIFF
--- a/change/just-scripts-cce9110c-fd68-43dc-9ffe-47e53688cd45.json
+++ b/change/just-scripts-cce9110c-fd68-43dc-9ffe-47e53688cd45.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "major",
   "comment": "Add support for symlink creation in the copy task",
   "packageName": "just-scripts",
   "email": "benw@microsoft.com",

--- a/change/just-scripts-cce9110c-fd68-43dc-9ffe-47e53688cd45.json
+++ b/change/just-scripts-cce9110c-fd68-43dc-9ffe-47e53688cd45.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for symlink creation in the copy task",
+  "packageName": "just-scripts",
+  "email": "benw@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/just-scripts/src/copy/CopyInstruction.ts
+++ b/packages/just-scripts/src/copy/CopyInstruction.ts
@@ -15,10 +15,11 @@ export interface CopyInstruction {
   destinationFilePath: string;
 
   /**
-   * True of a symlink should be created, false if a copy or merge should be performed.
-   * If multiple source files are specified (i.e. a merge), this must be falsy.
+   * Set to true if a copy or merge should be performed, false if a symlink should be created.
+   * If multiple source files are specified (i.e. a merge), this must be true or undefined.
+   * The default value of undefined is equivalent to true for a merge, false in all other cases.
    */
-  makeSymlink?: boolean;
+  noSymlink?: boolean;
 }
 
 export interface CopyConfig {
@@ -33,12 +34,12 @@ export interface CopyConfig {
 export function copyFilesToDestinationDirectory(
   sourceFilePaths: string | string[],
   destinationDirectory: string,
-  makeSymlinks?: boolean,
+  noSymlinks?: boolean,
 ): CopyInstruction[] {
   return arrayify(sourceFilePaths).map(sourceName => ({
     sourceFilePath: normalize(sourceName),
     destinationFilePath: join(destinationDirectory, basename(sourceName)),
-    makeSymlink: makeSymlinks,
+    noSymlink: noSymlinks,
   }));
 }
 
@@ -51,9 +52,9 @@ export function copyFileToDestinationDirectoryWithRename(
   sourceFilePath: string,
   destinationName: string,
   destinationDirectory: string,
-  makeSymlink?: boolean,
+  noSymlink?: boolean,
 ): CopyInstruction[] {
-  return [{ sourceFilePath, destinationFilePath: join(destinationDirectory, destinationName), makeSymlink }];
+  return [{ sourceFilePath, destinationFilePath: join(destinationDirectory, destinationName), noSymlink }];
 }
 
 /**
@@ -64,12 +65,12 @@ export function copyFileToDestinationDirectoryWithRename(
 export function copyFilesToDestinationDirectoryWithRename(
   instrs: { sourceFilePath: string; destinationName: string }[],
   destinationDirectory: string,
-  makeSymlinks?: boolean,
+  noSymlinks?: boolean,
 ): CopyInstruction[] {
   return instrs.map(instr => ({
     sourceFilePath: instr.sourceFilePath,
     destinationFilePath: join(destinationDirectory, instr.destinationName),
-    makeSymlink: makeSymlinks,
+    noSymlink: noSymlinks,
   }));
 }
 
@@ -81,7 +82,7 @@ export function copyFilesInDirectory(
   sourceDirectoryPath: string,
   outputDirectoryPath: string,
   filterFunction?: (file: string) => boolean,
-  makeSymlinks?: boolean,
+  noSymlinks?: boolean,
 ): CopyInstruction[] {
   let files = readdirSync(sourceDirectoryPath);
 
@@ -91,7 +92,7 @@ export function copyFilesInDirectory(
   return files.map(file => ({
     sourceFilePath: join(sourceDirectoryPath, file),
     destinationFilePath: join(outputDirectoryPath, file),
-    makeSymlink: makeSymlinks,
+    noSymlink: noSymlinks,
   }));
 }
 

--- a/packages/just-scripts/src/copy/CopyInstruction.ts
+++ b/packages/just-scripts/src/copy/CopyInstruction.ts
@@ -13,6 +13,12 @@ export interface CopyInstruction {
    * The path+filename of the destination file.
    */
   destinationFilePath: string;
+
+  /**
+   * True of a symlink should be created, false if a copy or merge should be performed.
+   * If multiple source files are specified (i.e. a merge), this must be falsy.
+   */
+  makeSymlink?: boolean;
 }
 
 export interface CopyConfig {
@@ -24,10 +30,15 @@ export interface CopyConfig {
  * For example copyFilesToDestinationDirectory(['some/path/foo.js', 'bar.js'], 'dest/target') would result in the creation of
  * files 'dest/target/foo.js' and 'dest/target/bar.js'.
  */
-export function copyFilesToDestinationDirectory(sourceFilePaths: string | string[], destinationDirectory: string): CopyInstruction[] {
+export function copyFilesToDestinationDirectory(
+  sourceFilePaths: string | string[],
+  destinationDirectory: string,
+  makeSymlinks?: boolean,
+): CopyInstruction[] {
   return arrayify(sourceFilePaths).map(sourceName => ({
     sourceFilePath: normalize(sourceName),
     destinationFilePath: join(destinationDirectory, basename(sourceName)),
+    makeSymlink: makeSymlinks,
   }));
 }
 
@@ -40,8 +51,9 @@ export function copyFileToDestinationDirectoryWithRename(
   sourceFilePath: string,
   destinationName: string,
   destinationDirectory: string,
+  makeSymlink?: boolean,
 ): CopyInstruction[] {
-  return [{ sourceFilePath, destinationFilePath: join(destinationDirectory, destinationName) }];
+  return [{ sourceFilePath, destinationFilePath: join(destinationDirectory, destinationName), makeSymlink }];
 }
 
 /**
@@ -52,10 +64,12 @@ export function copyFileToDestinationDirectoryWithRename(
 export function copyFilesToDestinationDirectoryWithRename(
   instrs: { sourceFilePath: string; destinationName: string }[],
   destinationDirectory: string,
+  makeSymlinks?: boolean,
 ): CopyInstruction[] {
   return instrs.map(instr => ({
     sourceFilePath: instr.sourceFilePath,
     destinationFilePath: join(destinationDirectory, instr.destinationName),
+    makeSymlink: makeSymlinks,
   }));
 }
 
@@ -67,6 +81,7 @@ export function copyFilesInDirectory(
   sourceDirectoryPath: string,
   outputDirectoryPath: string,
   filterFunction?: (file: string) => boolean,
+  makeSymlinks?: boolean,
 ): CopyInstruction[] {
   let files = readdirSync(sourceDirectoryPath);
 
@@ -76,6 +91,7 @@ export function copyFilesInDirectory(
   return files.map(file => ({
     sourceFilePath: join(sourceDirectoryPath, file),
     destinationFilePath: join(outputDirectoryPath, file),
+    makeSymlink: makeSymlinks,
   }));
 }
 

--- a/packages/just-scripts/src/copy/__tests__/executeCopyInstructions.spec.ts
+++ b/packages/just-scripts/src/copy/__tests__/executeCopyInstructions.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 // import { dirSync, fileSync, DirResult, FileResult } from 'tmp';
 import { executeCopyInstructions } from '../executeCopyInstructions';
+import { CopyInstruction } from '../CopyInstruction';
 
 describe('executeCopyInstructions functional tests', () => {
   const sourceDir = 'sourceDir';
@@ -31,10 +32,9 @@ describe('executeCopyInstructions functional tests', () => {
   });
 
   it('executes single source copy instructions (symlink)', async () => {
-    const copyInstruction = {
+    const copyInstruction: CopyInstruction = {
       sourceFilePath: sourceFilePath1,
       destinationFilePath: destFilePath,
-      makeSymlink: true,
     };
 
     expect(fs.existsSync(destFilePath)).toBeFalsy();
@@ -49,9 +49,10 @@ describe('executeCopyInstructions functional tests', () => {
   });
 
   it('executes single source (arrayified) copy instructions (copy)', async () => {
-    const copyInstruction = {
+    const copyInstruction: CopyInstruction = {
       sourceFilePath: [sourceFilePath1],
       destinationFilePath: destFilePath,
+      noSymlink: true,
     };
 
     expect(fs.existsSync(destFilePath)).toBeFalsy();
@@ -66,7 +67,7 @@ describe('executeCopyInstructions functional tests', () => {
   });
 
   it('merges output', async () => {
-    const copyInstruction = {
+    const copyInstruction: CopyInstruction = {
       sourceFilePath: [sourceFilePath1, sourceFilePath2],
       destinationFilePath: destFilePath,
     };
@@ -85,10 +86,10 @@ describe('executeCopyInstructions functional tests', () => {
   });
 
   it('fails to validate merge + symlink copy instruction', async () => {
-    const copyInstruction = {
+    const copyInstruction: CopyInstruction = {
       sourceFilePath: [sourceFilePath1, sourceFilePath2],
       destinationFilePath: destFilePath,
-      makeSymlink: true,
+      noSymlink: false,
     };
 
     const promise = executeCopyInstructions({

--- a/packages/just-scripts/src/copy/__tests__/executeCopyInstructions.spec.ts
+++ b/packages/just-scripts/src/copy/__tests__/executeCopyInstructions.spec.ts
@@ -95,7 +95,7 @@ describe('executeCopyInstructions functional tests', () => {
       copyInstructions: [copyInstruction],
     });
 
-    expect(promise).rejects.toThrow();
+    await expect(promise).rejects.toThrow();
   });
 
   /**

--- a/packages/just-scripts/src/copy/executeCopyInstructions.ts
+++ b/packages/just-scripts/src/copy/executeCopyInstructions.ts
@@ -17,7 +17,7 @@ export async function executeCopyInstructions(config: CopyConfig | undefined): P
 
 function validateConfig(copyInstructions: CopyInstruction[]) {
   copyInstructions.forEach(instr => {
-    if (instr.makeSymlink && Array.isArray(instr.sourceFilePath) && instr.sourceFilePath.length > 1) {
+    if (instr.noSymlink === false && Array.isArray(instr.sourceFilePath) && instr.sourceFilePath.length > 1) {
       throw new Error('Multiple source files cannot be specified when making a symlink');
     }
   });
@@ -34,10 +34,10 @@ function executeSingleCopyInstruction(copyInstruction: CopyInstruction) {
 
   // source and dest are 1-to-1?  perform binary copy or symlink as desired.
   if (sourceFileNames.length === 1) {
-    if (copyInstruction.makeSymlink) {
-      return ensureSymlink(resolve(sourceFileNames[0]), copyInstruction.destinationFilePath);
-    } else {
+    if (copyInstruction.noSymlink) {
       return copy(sourceFileNames[0], copyInstruction.destinationFilePath);
+    } else {
+      return ensureSymlink(resolve(sourceFileNames[0]), copyInstruction.destinationFilePath);
     }
   }
 


### PR DESCRIPTION
## Overview

The copy task now creates symlinks by default, and the CopyInstruction interface contains an optional field to force copying if needed.

## Test Notes

Unit tests have been updated to ensure proper functionality.