### PR TITLE
Fix type of OptionConfig.default

### DIFF
--- a/change/change-c2167604-05b6-4a0c-a8a2-0185af99310f.json
+++ b/change/change-c2167604-05b6-4a0c-a8a2-0185af99310f.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Fix type of OptionConfig.default",
+      "packageName": "just-task",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-task/src/option.ts
+++ b/packages/just-task/src/option.ts
@@ -20,8 +20,8 @@ export interface OptionConfig {
   /** Indicate a key that should be used as a counter, e.g., `-vvv = {v: 3}`. */
   count?: boolean;
 
-  /** Provide default values for keys: `{ default: { x: 33, y: 'hello world!' } }`. */
-  default?: { [key: string]: any };
+  /** Provide default value: `{ default: 'hello world!' }`. */
+  default?: any;
 
   /** Specify that a key requires n arguments: `{ narg: {x: 2} }`. */
   narg?: number;


### PR DESCRIPTION
The default value of a yargs option should usually be a primitive value, not an object. To match the typings in yargs itself, I used `any`.

Fixes #587