### PR TITLE
Hoist widely-used devDependencies

### DIFF
--- a/change/change-3e6a8d26-f331-4d88-b054-cf4648b1967f.json
+++ b/change/change-3e6a8d26-f331-4d88-b054-cf4648b1967f.json
@@ -1,0 +1,32 @@
+{
+  "changes": [
+    {
+      "type": "none",
+      "comment": "Hoist widely-used devDependencies",
+      "packageName": "just-scripts-utils",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Hoist widely-used devDependencies",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Hoist widely-used devDependencies",
+      "packageName": "just-task-logger",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Hoist widely-used devDependencies",
+      "packageName": "just-task",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -30,14 +30,20 @@
     "node": ">=14"
   },
   "devDependencies": {
+    "@types/fs-extra": "9.0.13",
+    "@types/jest": "26.0.24",
+    "@types/node": "14.18.33",
     "@typescript-eslint/eslint-plugin": "5.43.0",
     "@typescript-eslint/parser": "5.43.0",
     "beachball": "2.31.5",
     "eslint": "8.28.0",
     "gh-pages": "4.0.0",
+    "jest": "26.6.3",
     "lage": "1.9.5",
+    "mock-fs": "4.14.0",
     "prettier": "2.7.1",
     "syncpack": "8.3.9",
+    "ts-jest": "26.5.6",
     "typescript": "4.1.3",
     "vuepress": "1.9.7",
     "vuepress-plugin-mermaidjs": "1.9.1"

--- a/packages/example-lib/package.json
+++ b/packages/example-lib/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "just-scripts": ">=2.1.0 <3.0.0",
-    "ts-node": "9.1.1",
-    "typescript": "4.1.3"
+    "ts-node": "9.1.1"
   }
 }

--- a/packages/just-scripts-utils/package.json
+++ b/packages/just-scripts-utils/package.json
@@ -31,23 +31,16 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@types/fs-extra": "9.0.13",
     "@types/glob": "7.2.0",
-    "@types/jest": "26.0.24",
     "@types/jju": "1.4.2",
     "@types/marked": "4.0.7",
     "@types/marked-terminal": "3.1.3",
     "@types/mock-fs": "4.13.1",
-    "@types/node": "14.18.33",
     "@types/semver": "7.3.13",
     "@types/tar": "6.1.3",
     "@types/tar-fs": "2.0.1",
     "@types/yargs": "15.0.14",
     "gunzip-maybe": "1.4.2",
-    "jest": "26.6.3",
-    "mock-fs": "4.14.0",
-    "tar-fs": "2.1.1",
-    "ts-jest": "26.5.6",
-    "typescript": "4.1.3"
+    "tar-fs": "2.1.1"
   }
 }

--- a/packages/just-scripts/package.json
+++ b/packages/just-scripts/package.json
@@ -38,20 +38,13 @@
   },
   "devDependencies": {
     "@types/diff-match-patch": "1.0.32",
-    "@types/fs-extra": "9.0.13",
     "@types/glob": "7.2.0",
-    "@types/jest": "26.0.24",
-    "@types/node": "14.18.33",
     "@types/prompts": "2.4.1",
     "@types/run-parallel-limit": "1.0.0",
     "@types/supports-color": "8.1.1",
     "@types/tar": "6.1.3",
     "@types/webpack": "4.41.33",
     "async-done": "2.0.0",
-    "jest": "26.6.3",
-    "jest-cli": "26.6.3",
-    "mock-fs": "4.14.0",
-    "typescript": "4.1.3",
     "esbuild": "0.9.6"
   }
 }

--- a/packages/just-task-logger/package.json
+++ b/packages/just-task-logger/package.json
@@ -24,12 +24,6 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@types/jest": "26.0.24",
-    "@types/node": "14.18.33",
-    "@types/yargs": "15.0.14",
-    "jest": "26.6.3",
-    "mock-fs": "4.14.0",
-    "ts-jest": "26.5.6",
-    "typescript": "4.1.3"
+    "@types/yargs": "15.0.14"
   }
 }

--- a/packages/just-task/package.json
+++ b/packages/just-task/package.json
@@ -36,18 +36,11 @@
   },
   "devDependencies": {
     "@types/chokidar": "2.1.3",
-    "@types/fs-extra": "9.0.13",
-    "@types/jest": "26.0.24",
     "@types/mock-fs": "4.13.1",
-    "@types/node": "14.18.33",
     "@types/resolve": "1.20.2",
     "@types/undertaker": "1.2.8",
     "@types/undertaker-registry": "1.0.1",
-    "@types/yargs-parser": "20.2.2",
-    "jest": "26.6.3",
-    "mock-fs": "4.14.0",
-    "ts-jest": "26.5.6",
-    "typescript": "4.1.3"
+    "@types/yargs-parser": "20.2.2"
   },
   "typing": "lib/index.d.ts"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7597,7 +7597,7 @@ jest-changed-files@^26.6.2:
     execa "^4.0.0"
     throat "^5.0.0"
 
-jest-cli@26.6.3, jest-cli@^26.6.3:
+jest-cli@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-26.6.3.tgz#43117cfef24bc4cd691a174a8796a532e135e92a"
   integrity sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==


### PR DESCRIPTION
Hoist widely-used devDependencies to the repo root to reduce redundancy and increase installation layout determinancy.