### PR TITLE
Fix usage of yargs

### DIFF
--- a/change/change-46c05e17-5af0-436d-a719-6d7084e8f1d5.json
+++ b/change/change-46c05e17-5af0-436d-a719-6d7084e8f1d5.json
@@ -1,0 +1,25 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Remove unused dep on `yargs`",
+      "packageName": "just-scripts-utils",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Use `yargs-parser` instead of `yargs` to get the `--verbose` argument",
+      "packageName": "just-task-logger",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Remove an incorrect reference to `yargs` types",
+      "packageName": "just-task",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@types/jest": "27.5.2",
     "@types/mock-fs": "4.13.1",
     "@types/node": "14.18.36",
+    "@types/semver": "7.3.13",
+    "@types/yargs-parser": "20.2.2",
     "@typescript-eslint/eslint-plugin": "5.52.0",
     "@typescript-eslint/parser": "5.52.0",
     "beachball": "2.31.11",

--- a/packages/just-scripts-utils/package.json
+++ b/packages/just-scripts-utils/package.json
@@ -22,11 +22,6 @@
   "dependencies": {
     "fs-extra": "^10.0.0",
     "just-task-logger": ">=1.2.0 <2.0.0",
-    "semver": "^7.0.0",
-    "yargs": "^16.2.0"
-  },
-  "devDependencies": {
-    "@types/semver": "7.3.13",
-    "@types/yargs": "15.0.15"
+    "semver": "^7.0.0"
   }
 }

--- a/packages/just-scripts-utils/src/__tests__/__mocks__/yargs.ts
+++ b/packages/just-scripts-utils/src/__tests__/__mocks__/yargs.ts
@@ -1,6 +1,0 @@
-import { Arguments } from 'yargs';
-
-const yargs = jest.genMockFromModule<Arguments>('yargs');
-yargs.argv = {};
-
-module.exports = yargs;

--- a/packages/just-scripts/src/tasks/__tests__/callTaskForTest.ts
+++ b/packages/just-scripts/src/tasks/__tests__/callTaskForTest.ts
@@ -1,6 +1,6 @@
-import asyncDoneAsCallback = require('async-done');
+import * as asyncDoneAsCallback from 'async-done';
 import { promisify } from 'util';
-import { Arguments } from 'yargs';
+import type { Arguments } from 'yargs-parser';
 import { logger, TaskFunction, TaskContext } from 'just-task';
 
 const asyncDone = promisify(asyncDoneAsCallback);

--- a/packages/just-task-logger/package.json
+++ b/packages/just-task-logger/package.json
@@ -21,9 +21,6 @@
   },
   "dependencies": {
     "chalk": "^4.0.0",
-    "yargs": "^16.2.0"
-  },
-  "devDependencies": {
-    "@types/yargs": "15.0.15"
+    "yargs-parser": "^20.2.3"
   }
 }

--- a/packages/just-task-logger/src/__tests__/__mocks__/yargs.ts
+++ b/packages/just-task-logger/src/__tests__/__mocks__/yargs.ts
@@ -1,6 +1,0 @@
-import { Arguments } from 'yargs';
-
-const yargs = jest.genMockFromModule<Arguments>('yargs');
-yargs.argv = {};
-
-module.exports = yargs;

--- a/packages/just-task-logger/src/logger.ts
+++ b/packages/just-task-logger/src/logger.ts
@@ -1,6 +1,8 @@
 import chalk = require('chalk');
-import { argv } from 'yargs';
+import * as parser from 'yargs-parser';
 import { getDeltaAndClearMark } from './perf';
+
+const argv = parser(process.argv.slice(2));
 
 function logInternal(method: 'info' | 'warn' | 'error', symbol: string, ...args: any[]) {
   const now = new Date();

--- a/packages/just-task/package.json
+++ b/packages/just-task/package.json
@@ -38,8 +38,7 @@
     "@types/chokidar": "2.1.3",
     "@types/resolve": "1.20.2",
     "@types/undertaker": "1.2.8",
-    "@types/undertaker-registry": "1.0.1",
-    "@types/yargs-parser": "20.2.2"
+    "@types/undertaker-registry": "1.0.1"
   },
   "typing": "lib/index.d.ts"
 }

--- a/packages/just-task/src/interfaces.ts
+++ b/packages/just-task/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { Arguments } from 'yargs';
+import { Arguments } from 'yargs-parser';
 import { TaskFunctionParams } from 'undertaker';
 import { Logger } from './logger';
 import { Duplex } from 'stream';

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,11 +8,6 @@
     "github>microsoft/m365-renovate-config:keepFresh",
     "github>microsoft/m365-renovate-config:restrictNode(14)"
   ],
-  "ignorePresets": [
-    // causes an immortal PR which isn't currently wanted, because yargs and yargs-parser
-    // have different major versions
-    "github>microsoft/m365-renovate-config:groupYargs"
-  ],
 
   "labels": ["renovate"],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1747,7 +1747,7 @@
   resolved "https://registry.yarnpkg.com/@types/undertaker-registry/-/undertaker-registry-1.0.1.tgz#4306d4a03d7acedb974b66530832b90729e1d1da"
   integrity sha512-Z4TYuEKn9+RbNVk1Ll2SS4x1JeLHecolIbM/a8gveaHsW0Hr+RQMraZACwTO2VD7JvepgA6UO1A1VrbktQrIbQ==
 
-"@types/undertaker@1.2.8":
+"@types/undertaker@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@types/undertaker/-/undertaker-1.2.8.tgz#6124a5d78eb6fca84689185229654a6235c601d7"
   integrity sha512-gW3PRqCHYpo45XFQHJBhch7L6hytPsIe0QeLujlnFsjHPnXLhJcPdN6a9368d7aIQgH2I/dUTPFBlGeSNA3qOg==
@@ -1788,17 +1788,10 @@
     anymatch "^3.0.0"
     source-map "^0.6.0"
 
-"@types/yargs-parser@*", "@types/yargs-parser@20.2.2":
+"@types/yargs-parser@*", "@types/yargs-parser@20.2.2", "@types/yargs-parser@^20.0.0":
   version "20.2.2"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.2.tgz#c3924f56e32ae39ce713a1d5dec5872fedf85f6d"
   integrity sha512-sUWMriymrSqTvxCmCkf+7k392TNDcMJBHI1/rysWJxKnWAan/Zk4gZ/GEieSRo4EqIEPpbGU3Sd/0KTRoIA3pA==
-
-"@types/yargs@15.0.15":
-  version "15.0.15"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.15.tgz#e609a2b1ef9e05d90489c2f5f45bbfb2be092158"
-  integrity sha512-IziEYMU9XoVj8hWg7k+UJrXALkGFjWJhn5QFEv9q4p+v40oZhSuC135M38st8XPjICL7Ey4TV64ferBGUoJhBg==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^16.0.0":
   version "16.0.5"


### PR DESCRIPTION
Switch `just-task-logger` to use `yargs-parser` rather than the full `yargs` library. This removes the global state interference from `yargs` (simplifying tests) and is consistent with `just-task`.

Also replace usage of `yargs` types in other packages with equivalent `yargs-parser` types.