### PR TITLE
Update readmes and homepage links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,18 @@
 [![npm version](https://badge.fury.io/js/just-task.svg)](https://badge.fury.io/js/just-task)
 [![NPM Downloads](https://img.shields.io/npm/dm/just-task.svg?style=flat)](https://www.npmjs.com/package/just-task)
 
-`Just` is a library that organizes build tasks for your JS projects. It consists of
+<!-- start shared -->
 
-- a build task definition library
-- sane preset build flows for node and browser projects featuring TypeScript, Webpack and Jest
+`Just` is a library that organizes build tasks for your JS projects. It consists of:
+
+- `just-task`: a build task definition library
+- `just-scripts`: sane preset build flows for node and browser projects featuring TypeScript, Webpack and Jest
 
 ## Documentation
 
 All the documentation is online at https://microsoft.github.io/just/
+
+<!-- end shared -->
 
 ## Building
 

--- a/change/change-2acef701-852b-4440-b7e0-77c1ff7e6403.json
+++ b/change/change-2acef701-852b-4440-b7e0-77c1ff7e6403.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Update readmes and homepage links",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Update readmes and homepage links",
+      "packageName": "just-task",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-scripts/README.md
+++ b/packages/just-scripts/README.md
@@ -1,7 +1,7 @@
-# just-task
+# just-scripts
 
-[![npm version](https://badge.fury.io/js/just-task.svg)](https://badge.fury.io/js/just-task)
-[![NPM Downloads](https://img.shields.io/npm/dm/just-task.svg?style=flat)](https://www.npmjs.com/package/just-task)
+[![npm version](https://badge.fury.io/js/just-scripts.svg)](https://badge.fury.io/js/just-scripts)
+[![NPM Downloads](https://img.shields.io/npm/dm/just-scripts.svg?style=flat)](https://www.npmjs.com/package/just-scripts)
 
 <!-- start shared -->
 

--- a/packages/just-scripts/package.json
+++ b/packages/just-scripts/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/just"
   },
+  "homepage": "https://microsoft.github.io/just/",
   "license": "MIT",
   "author": "",
   "main": "./lib/index.js",

--- a/packages/just-task/package.json
+++ b/packages/just-task/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/microsoft/just"
   },
+  "homepage": "https://microsoft.github.io/just/",
   "license": "MIT",
   "author": "Ken Chau <kchau@microsoft.com>",
   "main": "lib/index.js",

--- a/scripts/copyReadme.js
+++ b/scripts/copyReadme.js
@@ -1,6 +1,34 @@
+// @ts-check
 const fs = require('fs');
 const path = require('path');
 
-const mainReadme = path.resolve(__dirname, '../README.md');
-const justTaskReadme = path.resolve(__dirname, '../packages/just-task/README.md');
-fs.copyFileSync(mainReadme, justTaskReadme);
+const startComment = '<!-- start shared -->';
+const endComment = '<!-- end shared -->';
+
+const mainReadmePath = path.resolve(__dirname, '../README.md');
+const children = ['just-task', 'just-scripts'];
+
+const mainReadmeContent = fs.readFileSync(mainReadmePath, 'utf8');
+
+function getSharedContent(content, readmePath) {
+  if (!content.includes(startComment) || !content.includes(endComment)) {
+    console.error(`Marker comments were deleted from ${readmePath} !`);
+    console.error(
+      'Please add them back in the following format around content that should be shared between packages:',
+    );
+    console.error(startComment);
+    console.error(endComment);
+    process.exit(1);
+  }
+  return content.split('<!-- start shared -->')[1].split('<!-- end shared -->')[0];
+}
+
+const sharedContent = getSharedContent(mainReadmeContent, mainReadmePath);
+
+for (const childPkg of children) {
+  const childReadmePath = path.resolve(__dirname, `../packages/${childPkg}/README.md`);
+  const childReadmeContent = fs.readFileSync(childReadmePath, 'utf8');
+  const oldSharedContent = getSharedContent(childReadmeContent, childReadmePath);
+  const newChildReadmeContent = childReadmeContent.replace(oldSharedContent, sharedContent);
+  fs.writeFileSync(childReadmePath, newChildReadmeContent);
+}


### PR DESCRIPTION
just-scripts for some reason has never had a readme, and the one for just-task is out of date. This PR adds a script to update both readmes with only the relevant shared content from the repo readme, as well as adding homepage links to the packages.