### PR TITLE
Copy instructions should copy by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,11 @@
 name: Release
 
 on:
+  # Temporarily disabling scheduled releases to evaluate whether any other major changes are desired.
   # release daily at 8am UTC (midnight or 1am pacific)
   # https://crontab-generator.org/
-  schedule:
-    - cron: '0 8 * * *'
+  # schedule:
+  #   - cron: '0 8 * * *'
   # or manual trigger
   workflow_dispatch:
 

--- a/change/change-e0d6790d-3823-4990-8bff-44914b63d4d3.json
+++ b/change/change-e0d6790d-3823-4990-8bff-44914b63d4d3.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "major",
+      "comment": "Revert to original copy instructions behavior of copying by default. To create symlinks instead, pass `symlink: true`.",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-scripts/src/arrayUtils/uniqueValues.ts
+++ b/packages/just-scripts/src/arrayUtils/uniqueValues.ts
@@ -1,7 +1,0 @@
-/**
- * Removes duplicate numbers from an array
- * @param array - The array possibly containing duplicate values
- */
-export function uniqueValues<T>(array: T[]): T[] {
-  return Array.from(new Set<T>(array));
-}

--- a/packages/just-scripts/src/copy/CopyInstruction.ts
+++ b/packages/just-scripts/src/copy/CopyInstruction.ts
@@ -15,11 +15,10 @@ export interface CopyInstruction {
   destinationFilePath: string;
 
   /**
-   * Set to true if a copy or merge should be performed, false if a symlink should be created.
-   * If multiple source files are specified (i.e. a merge), this must be true or undefined.
-   * The default value of undefined is equivalent to true for a merge, false in all other cases.
+   * Set to true to create symlinks rather than copying.
+   * If multiple source files are specified (i.e. a merge), this must be false or unset.
    */
-  noSymlink?: boolean;
+  symlink?: boolean;
 }
 
 export interface CopyConfig {
@@ -34,12 +33,12 @@ export interface CopyConfig {
 export function copyFilesToDestinationDirectory(
   sourceFilePaths: string | string[],
   destinationDirectory: string,
-  noSymlinks?: boolean,
+  symlink?: boolean,
 ): CopyInstruction[] {
   return arrayify(sourceFilePaths).map(sourceName => ({
     sourceFilePath: normalize(sourceName),
     destinationFilePath: join(destinationDirectory, basename(sourceName)),
-    noSymlink: noSymlinks,
+    symlink,
   }));
 }
 
@@ -52,9 +51,9 @@ export function copyFileToDestinationDirectoryWithRename(
   sourceFilePath: string,
   destinationName: string,
   destinationDirectory: string,
-  noSymlink?: boolean,
+  symlink?: boolean,
 ): CopyInstruction[] {
-  return [{ sourceFilePath, destinationFilePath: join(destinationDirectory, destinationName), noSymlink }];
+  return [{ sourceFilePath, destinationFilePath: join(destinationDirectory, destinationName), symlink }];
 }
 
 /**
@@ -65,12 +64,12 @@ export function copyFileToDestinationDirectoryWithRename(
 export function copyFilesToDestinationDirectoryWithRename(
   instrs: { sourceFilePath: string; destinationName: string }[],
   destinationDirectory: string,
-  noSymlinks?: boolean,
+  symlink?: boolean,
 ): CopyInstruction[] {
   return instrs.map(instr => ({
     sourceFilePath: instr.sourceFilePath,
     destinationFilePath: join(destinationDirectory, instr.destinationName),
-    noSymlink: noSymlinks,
+    symlink,
   }));
 }
 
@@ -82,7 +81,7 @@ export function copyFilesInDirectory(
   sourceDirectoryPath: string,
   outputDirectoryPath: string,
   filterFunction?: (file: string) => boolean,
-  noSymlinks?: boolean,
+  symlink?: boolean,
 ): CopyInstruction[] {
   let files = readdirSync(sourceDirectoryPath);
 
@@ -92,7 +91,7 @@ export function copyFilesInDirectory(
   return files.map(file => ({
     sourceFilePath: join(sourceDirectoryPath, file),
     destinationFilePath: join(outputDirectoryPath, file),
-    noSymlink: noSymlinks,
+    symlink,
   }));
 }
 

--- a/packages/just-scripts/src/copy/__tests__/executeCopyInstructions.spec.ts
+++ b/packages/just-scripts/src/copy/__tests__/executeCopyInstructions.spec.ts
@@ -1,7 +1,6 @@
 import * as mockfs from 'mock-fs';
 import * as path from 'path';
 import * as fs from 'fs';
-// import { dirSync, fileSync, DirResult, FileResult } from 'tmp';
 import { executeCopyInstructions } from '../executeCopyInstructions';
 import { CopyInstruction } from '../CopyInstruction';
 
@@ -35,6 +34,7 @@ describe('executeCopyInstructions functional tests', () => {
     const copyInstruction: CopyInstruction = {
       sourceFilePath: sourceFilePath1,
       destinationFilePath: destFilePath,
+      symlink: true,
     };
 
     expect(fs.existsSync(destFilePath)).toBeFalsy();
@@ -52,7 +52,6 @@ describe('executeCopyInstructions functional tests', () => {
     const copyInstruction: CopyInstruction = {
       sourceFilePath: [sourceFilePath1],
       destinationFilePath: destFilePath,
-      noSymlink: true,
     };
 
     expect(fs.existsSync(destFilePath)).toBeFalsy();
@@ -89,7 +88,7 @@ describe('executeCopyInstructions functional tests', () => {
     const copyInstruction: CopyInstruction = {
       sourceFilePath: [sourceFilePath1, sourceFilePath2],
       destinationFilePath: destFilePath,
-      noSymlink: false,
+      symlink: true,
     };
 
     const promise = executeCopyInstructions({

--- a/packages/just-scripts/src/copy/executeCopyInstructions.ts
+++ b/packages/just-scripts/src/copy/executeCopyInstructions.ts
@@ -2,7 +2,6 @@ import { dirname, resolve } from 'path';
 import { readFile, writeFile, copy, ensureDir, ensureSymlink } from 'fs-extra';
 import { CopyInstruction, CopyConfig } from './CopyInstruction';
 import { arrayify } from '../arrayUtils/arrayify';
-import { uniqueValues } from '../arrayUtils/uniqueValues';
 
 /**
  * Function containing the core code for the copy task with a given config.
@@ -17,34 +16,29 @@ export async function executeCopyInstructions(config: CopyConfig | undefined): P
 
 function validateConfig(copyInstructions: CopyInstruction[]) {
   copyInstructions.forEach(instr => {
-    if (instr.noSymlink === false && Array.isArray(instr.sourceFilePath) && instr.sourceFilePath.length > 1) {
+    if (instr.symlink && Array.isArray(instr.sourceFilePath) && instr.sourceFilePath.length > 1) {
       throw new Error('Multiple source files cannot be specified when making a symlink');
     }
   });
 }
 
 function createDirectories(copyInstructions: CopyInstruction[]) {
-  return Promise.all(
-    uniqueValues(copyInstructions.map(instruction => dirname(instruction.destinationFilePath))).map(dirname =>
-      ensureDir(dirname),
-    ),
-  );
+  const directories = new Set(copyInstructions.map(instruction => dirname(instruction.destinationFilePath)));
+  return Promise.all([...directories].map(dirname => ensureDir(dirname)));
 }
 
-function executeSingleCopyInstruction(copyInstruction: CopyInstruction) {
+async function executeSingleCopyInstruction(copyInstruction: CopyInstruction) {
   const sourceFileNames = arrayify(copyInstruction.sourceFilePath);
 
   // source and dest are 1-to-1?  perform binary copy or symlink as desired.
   if (sourceFileNames.length === 1) {
-    if (copyInstruction.noSymlink) {
-      return copy(sourceFileNames[0], copyInstruction.destinationFilePath);
-    } else {
+    if (copyInstruction.symlink) {
       return ensureSymlink(resolve(sourceFileNames[0]), copyInstruction.destinationFilePath);
     }
+    return copy(sourceFileNames[0], copyInstruction.destinationFilePath);
   }
 
   // perform text merge operation.
-  return Promise.all(sourceFileNames.map(fileName => readFile(fileName))).then(fileContents => {
-    return writeFile(copyInstruction.destinationFilePath, fileContents.join('\n'));
-  });
+  const sourceFiles = await Promise.all(sourceFileNames.map(fileName => readFile(fileName)));
+  return writeFile(copyInstruction.destinationFilePath, sourceFiles.join('\n'));
 }


### PR DESCRIPTION
Reverts the behavior change from #584 / `just-scripts` v2. This requires a new major version (v3) but eases upgrades for anyone who is still on v1, and restores the default behavior to match the function name.

To create symlinks, you can now pass `symlink: true`.

**NOTE: This PR also temporarily disables scheduled releases** until I can take a look at whether there's any other low-hanging fruit for this major change.