### PR TITLE
Add an option --esm to support imports of ESM packages

### DIFF
--- a/change/change-669d5fe5-2fb9-495a-80a0-65b9436673c9.json
+++ b/change/change-669d5fe5-2fb9-495a-80a0-65b9436673c9.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Add an option --esm to support imports of ESM packages",
+      "packageName": "just-task",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-task/src/cli.ts
+++ b/packages/just-task/src/cli.ts
@@ -47,6 +47,10 @@ option('defaultConfig', {
   describe:
     'path to a default just configuration file that will be used when the current project does not have a just configuration file. (includes the file name, e.g. /path/to/just.config.ts)',
 });
+option('esm', {
+  describe:
+    'Configure ts-node to support imports of ESM package (changes TS module/moduleResolution settings to Node16)',
+});
 
 const registry = undertaker.registry();
 

--- a/packages/just-task/src/config.ts
+++ b/packages/just-task/src/config.ts
@@ -21,13 +21,14 @@ export function resolveConfigFile(args: yargsParser.Arguments): string | null {
 
 export function readConfig(): { [key: string]: TaskFunction } | void {
   // uses a separate instance of yargs to first parse the config (without the --help in the way) so we can parse the configFile first regardless
-  const configFile = resolveConfigFile(argv());
+  const args = argv();
+  const configFile = resolveConfigFile(args);
 
   if (configFile && fs.existsSync(configFile)) {
     const ext = path.extname(configFile);
     if (ext === '.ts' || ext === '.tsx') {
       // TODO: add option to do typechecking as well
-      enableTypeScript({ transpileOnly: true });
+      enableTypeScript({ transpileOnly: true, esm: args.esm });
     }
 
     try {

--- a/packages/just-task/src/enableTypeScript.ts
+++ b/packages/just-task/src/enableTypeScript.ts
@@ -2,7 +2,7 @@ import { resolve } from './resolve';
 import { logger } from 'just-task-logger';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function enableTypeScript({ transpileOnly = true }): void {
+export function enableTypeScript({ transpileOnly = true, esm = false }): void {
   const tsNodeModule = resolve('ts-node');
   if (tsNodeModule) {
     const tsNode = require(tsNodeModule);
@@ -11,11 +11,11 @@ export function enableTypeScript({ transpileOnly = true }): void {
       skipProject: true,
       compilerOptions: {
         target: 'es2017',
-        module: 'commonjs',
+        module: esm ? 'node16' : 'commonjs',
         strict: false,
         skipLibCheck: true,
         skipDefaultLibCheck: true,
-        moduleResolution: 'node',
+        moduleResolution: esm ? 'node16' : 'node',
         allowJs: true,
         esModuleInterop: true,
       },


### PR DESCRIPTION
Currently if a `just.config.ts` tries to import a package which uses ESM, there's an error because `ts-node` is configured with `commonjs` output, so it transpiles the `import` to a `require` (which doesn't work on ESM).

Add a CLI option `--esm` which changes `module` and `moduleResolution` to `node16`. This isn't done by default because it might be a breaking change.