### PR TITLE
Add some missing exports in just-scripts

### DIFF
--- a/change/change-0bca84b5-bd0f-451d-ad22-717846a53e35.json
+++ b/change/change-0bca84b5-bd0f-451d-ad22-717846a53e35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Export CssLoaderOptions and PrettierTaskOptions which both appear on the type signature for the public API of just-scripts",
+      "packageName": "just-scripts",
+      "email": "1581488+christiango@users.noreply.github.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-scripts/etc/just-scripts.api.md
+++ b/packages/just-scripts/etc/just-scripts.api.md
@@ -28,16 +28,14 @@ export interface ApiExtractorOptions extends ApiExtractorTypes.IExtractorInvokeO
 // @public
 export function apiExtractorUpdateTask(options: ApiExtractorOptions): TaskFunction;
 
-// Warning: (ae-forgotten-export) The symbol "Omit_2" needs to be exported by the entry point index.d.ts
-//
 // @public @deprecated (undocumented)
-export function apiExtractorUpdateTask(configJsonFilePath: string, extractorOptions: Omit_2<ApiExtractorOptions, 'configJsonFilePath'>): TaskFunction;
+export function apiExtractorUpdateTask(configJsonFilePath: string, extractorOptions: Omit<ApiExtractorOptions, 'configJsonFilePath'>): TaskFunction;
 
 // @public (undocumented)
 export function apiExtractorVerifyTask(options: ApiExtractorOptions): TaskFunction;
 
 // @public @deprecated (undocumented)
-export function apiExtractorVerifyTask(configJsonFilePath: string, extractorOptions: Omit_2<ApiExtractorOptions, 'configJsonFilePath'>): TaskFunction;
+export function apiExtractorVerifyTask(configJsonFilePath: string, extractorOptions: Omit<ApiExtractorOptions, 'configJsonFilePath'>): TaskFunction;
 
 // @public (undocumented)
 export const basicWebpackConfig: Configuration;
@@ -128,8 +126,6 @@ export interface CreateOptions {
     map?: (header: EntryHeader) => EntryHeader;
 }
 
-// Warning: (ae-forgotten-export) The symbol "CssLoaderOptions" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export const createStylesOverlay: (options?: CssLoaderOptions) => Partial<Configuration>;
 
@@ -137,7 +133,7 @@ export const createStylesOverlay: (options?: CssLoaderOptions) => Partial<Config
 export function createTarTask(options?: CreateOptions): TaskFunction;
 
 // @public (undocumented)
-interface CssLoaderOptions {
+export interface CssLoaderOptions {
     // (undocumented)
     localIdentName?: string;
     // (undocumented)
@@ -305,18 +301,13 @@ export interface NodeExecTaskOptions {
 }
 
 // @public (undocumented)
-type Omit_2<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
-
-// Warning: (ae-forgotten-export) The symbol "PrettierTaskOptions" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
 export function prettierCheckTask(options?: PrettierTaskOptions): TaskFunction;
 
 // @public (undocumented)
 export function prettierTask(options?: PrettierTaskOptions): TaskFunction;
 
 // @public (undocumented)
-interface PrettierTaskOptions {
+export interface PrettierTaskOptions {
     // (undocumented)
     configPath?: string;
     // (undocumented)
@@ -453,13 +444,11 @@ export interface TsLoaderOptions {
     transpileOnly: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "TsOverlayOptions" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
 export const tsOverlay: (overlayOptions?: TsOverlayOptions | undefined) => Partial<Configuration>;
 
 // @public (undocumented)
-interface TsOverlayOptions {
+export interface TsOverlayOptions {
     // (undocumented)
     checkerOptions?: Partial<TsCheckerOptions>;
     // (undocumented)

--- a/packages/just-scripts/src/index.ts
+++ b/packages/just-scripts/src/index.ts
@@ -7,7 +7,7 @@ export * from './webpack/webpack.config';
 export * from './webpack/webpack.serve.config';
 
 // Webpack configs and overlays
-import { tsOverlay, TsCheckerOptions, TsLoaderOptions } from './webpack/overlays/tsOverlay';
+import { tsOverlay, TsCheckerOptions, TsLoaderOptions, TsOverlayOptions } from './webpack/overlays/tsOverlay';
 import { htmlOverlay } from './webpack/overlays/htmlOverlay';
 import { stylesOverlay, createStylesOverlay, CssLoaderOptions } from './webpack/overlays/stylesOverlay';
 import { fileOverlay } from './webpack/overlays/fileOverlay';
@@ -31,6 +31,7 @@ export {
   CssLoaderOptions,
   TsCheckerOptions,
   TsLoaderOptions,
+  TsOverlayOptions,
 };
 
 import * as webpackMerge from 'webpack-merge';

--- a/packages/just-scripts/src/index.ts
+++ b/packages/just-scripts/src/index.ts
@@ -9,7 +9,7 @@ export * from './webpack/webpack.serve.config';
 // Webpack configs and overlays
 import { tsOverlay, TsCheckerOptions, TsLoaderOptions } from './webpack/overlays/tsOverlay';
 import { htmlOverlay } from './webpack/overlays/htmlOverlay';
-import { stylesOverlay, createStylesOverlay } from './webpack/overlays/stylesOverlay';
+import { stylesOverlay, createStylesOverlay, CssLoaderOptions } from './webpack/overlays/stylesOverlay';
 import { fileOverlay } from './webpack/overlays/fileOverlay';
 import { displayBailoutOverlay } from './webpack/overlays/displayBailoutOverlay';
 
@@ -28,6 +28,7 @@ export {
   fileOverlay,
   displayBailoutOverlay,
   createStylesOverlay,
+  CssLoaderOptions,
   TsCheckerOptions,
   TsLoaderOptions,
 };

--- a/packages/just-scripts/src/tasks/apiExtractorTask.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTask.ts
@@ -46,8 +46,6 @@ interface ApiExtractorContext {
   apiExtractorModule: typeof ApiExtractorTypes;
 }
 
-type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
-
 export function apiExtractorVerifyTask(options: ApiExtractorOptions): TaskFunction;
 /** @deprecated Use object param version */
 export function apiExtractorVerifyTask(

--- a/packages/just-scripts/src/tasks/prettierTask.ts
+++ b/packages/just-scripts/src/tasks/prettierTask.ts
@@ -12,7 +12,7 @@ interface PrettierContext {
   check: boolean;
 }
 
-interface PrettierTaskOptions {
+export interface PrettierTaskOptions {
   files?: string[] | string;
   ignorePath?: string;
   configPath?: string;

--- a/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
@@ -9,7 +9,7 @@ const sassTest = /\.(scss|sass)$/;
 const sassModuleTest = /\.module\.(scss|sass)$/;
 const defaultIdentName = '[name]_[local]_[hash:base64:5]';
 
-interface CssLoaderOptions {
+export interface CssLoaderOptions {
   modules?: boolean;
   localIdentName?: string;
 }


### PR DESCRIPTION
## Overview
On our team, we run our just scripts through typescript using // @ts-check comments.

For the new typescript 5.4 release candidate, we are getting errors like this when importing just like this:

```javascript
const just = require('just-scripts');
```

The error messages:
```
TS9006: Declaration emit for this file requires using private name 'PrettierTaskOptions' from module '"D:/office-bohemia/node_modules/just-scripts/lib/tasks/prettierTask"'. An explicit type annotation may unblock declaration emit.
```

To resolve these, we're adding the missing exports for types that appear on the public API signature of just-scripts

## Test Notes
Only an update to the types exports