### PR TITLE
Pass env variables through to eslint cli

### DIFF
--- a/change/change-290d4ad3-023d-4553-ab2b-08e83fbf8c9e.json
+++ b/change/change-290d4ad3-023d-4553-ab2b-08e83fbf8c9e.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Pass env variables through to eslint cli",
+      "packageName": "just-scripts",
+      "email": "stchur@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-scripts/src/tasks/eslintTask.ts
+++ b/packages/just-scripts/src/tasks/eslintTask.ts
@@ -80,7 +80,7 @@ export function eslintTask(options: EsLintTaskOptions = {}): TaskFunction {
         '--color',
       ];
 
-      const env: Record<string, string> = {};
+      const env: NodeJS.ProcessEnv = { ...process.env };
 
       if (timing) {
         env.TIMING = '1';


### PR DESCRIPTION
## Overview
ESLint documentation clearly indicates that node ENV variables _should_ be available in custom formatters, and indeed, if I invoke eslint locally like so:
`npx eslint -f path/to/my/formatters.js`

It works! And I can see/accessible the desired ENV variables.

However, in Bohemia, we invoke eslint through just-script's `eslintTask`, and that task does not pass ENV variables on through.  Rather, it creates a mostly empty env object and passes that through.  As a result, my customer formatter was not receiving the ENV variable it expected.

This simple PR just modifies the `env` variable passed through to the `eslintTask` by spreading `...process.env` into it when it is initialized.