### PR TITLE
Add .cjs config support

### DIFF
--- a/change/change-89ce5016-69e1-46b3-bd87-88406b2ee323.json
+++ b/change/change-89ce5016-69e1-46b3-bd87-88406b2ee323.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "Add .cjs config support",
+      "packageName": "just-task",
+      "email": "tigeroakes@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/example-lib/package.json
+++ b/packages/example-lib/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "just-scripts": ">=2.3.2 <3.0.0",
-    "ts-node": "^9.1.1"
+    "ts-node": "^10.8.0"
   }
 }

--- a/packages/just-task/src/__tests__/resolve.spec.ts
+++ b/packages/just-task/src/__tests__/resolve.spec.ts
@@ -196,65 +196,68 @@ describe('resolve', () => {
   });
 });
 
-describe('resolveConfigFile', () => {
-  afterEach(() => {
-    mockfs.restore();
-    resetResolvePaths();
-  });
-
-  it('default chooses local config', () => {
-    mockfs({
-      config: {
-        'configArgument.ts': 'formConfig',
-        'defaultConfigArgument.ts': 'formDefaultConfig',
-      },
-      'just.config.ts': 'localConfig',
+describe.each(['just.config.js', 'just.config.cjs', 'just.config.ts', 'just.config.cts', 'just-task.js'])(
+  'resolveConfigFile (%s)',
+  configPath => {
+    afterEach(() => {
+      mockfs.restore();
+      resetResolvePaths();
     });
-    const resolvedConfig = config.resolveConfigFile({ config: undefined, defaultConfig: undefined } as any);
-    expect(resolvedConfig).toContain('just.config.ts');
-  });
 
-  it('config argument wins over local config and defaultConfig', () => {
-    mockfs({
-      config: {
-        'configArgument.ts': 'formConfig',
-        'defaultConfigArgument.ts': 'formDefaultConfig',
-      },
-      'just.config.ts': 'localConfig',
+    it('default chooses local config', () => {
+      mockfs({
+        config: {
+          'configArgument.ts': 'formConfig',
+          'defaultConfigArgument.ts': 'formDefaultConfig',
+        },
+        [configPath]: 'localConfig',
+      });
+      const resolvedConfig = config.resolveConfigFile({ config: undefined, defaultConfig: undefined } as any);
+      expect(resolvedConfig).toContain(configPath);
     });
-    const resolvedConfig = config.resolveConfigFile({
-      config: './config/configArgument.ts',
-      defaultConfig: './config/defaultConfigArgument.ts',
-    } as any);
-    expect(resolvedConfig).toContain('configArgument.ts');
-  });
 
-  it('local config file wins over defaultConfig', () => {
-    mockfs({
-      config: {
-        'configArgument.ts': 'formConfig',
-        'defaultConfigArgument.ts': 'formDefaultConfig',
-      },
-      'just.config.ts': 'localConfig',
+    it('config argument wins over local config and defaultConfig', () => {
+      mockfs({
+        config: {
+          'configArgument.ts': 'formConfig',
+          'defaultConfigArgument.ts': 'formDefaultConfig',
+        },
+        [configPath]: 'localConfig',
+      });
+      const resolvedConfig = config.resolveConfigFile({
+        config: './config/configArgument.ts',
+        defaultConfig: './config/defaultConfigArgument.ts',
+      } as any);
+      expect(resolvedConfig).toContain('configArgument.ts');
     });
-    const resolvedConfig = config.resolveConfigFile({
-      config: undefined,
-      defaultConfig: './config/defaultConfigArgument.ts',
-    } as any);
-    expect(resolvedConfig).toContain('just.config.ts');
-  });
 
-  it('default config is used as last fallback', () => {
-    mockfs({
-      config: {
-        'configArgument.ts': 'formConfig',
-        'defaultConfigArgument.ts': 'formDefaultConfig',
-      },
+    it('local config file wins over defaultConfig', () => {
+      mockfs({
+        config: {
+          'configArgument.ts': 'formConfig',
+          'defaultConfigArgument.ts': 'formDefaultConfig',
+        },
+        [configPath]: 'localConfig',
+      });
+      const resolvedConfig = config.resolveConfigFile({
+        config: undefined,
+        defaultConfig: './config/defaultConfigArgument.ts',
+      } as any);
+      expect(resolvedConfig).toContain(configPath);
     });
-    const resolvedConfig = config.resolveConfigFile({
-      config: undefined,
-      defaultConfig: './config/defaultConfigArgument.ts',
-    } as any);
-    expect(resolvedConfig).toContain('defaultConfigArgument.ts');
-  });
-});
+
+    it('default config is used as last fallback', () => {
+      mockfs({
+        config: {
+          'configArgument.ts': 'formConfig',
+          'defaultConfigArgument.ts': 'formDefaultConfig',
+        },
+      });
+      const resolvedConfig = config.resolveConfigFile({
+        config: undefined,
+        defaultConfig: './config/defaultConfigArgument.ts',
+      } as any);
+      expect(resolvedConfig).toContain('defaultConfigArgument.ts');
+    });
+  },
+);

--- a/packages/just-task/src/config.ts
+++ b/packages/just-task/src/config.ts
@@ -9,7 +9,15 @@ import yargsParser = require('yargs-parser');
 import { TaskFunction } from './interfaces';
 
 export function resolveConfigFile(args: yargsParser.Arguments): string | null {
-  for (const entry of [args.config, './just.config.js', './just-task.js', './just.config.ts', args.defaultConfig]) {
+  for (const entry of [
+    args.config,
+    './just.config.js',
+    './just.config.cjs',
+    './just-task.js',
+    './just.config.ts',
+    './just.config.cts',
+    args.defaultConfig,
+  ]) {
     const configFile = resolve(entry);
     if (configFile) {
       return configFile;
@@ -26,7 +34,7 @@ export function readConfig(): { [key: string]: TaskFunction } | void {
 
   if (configFile && fs.existsSync(configFile)) {
     const ext = path.extname(configFile);
-    if (ext === '.ts' || ext === '.tsx') {
+    if (ext === '.cts' || ext === '.ts' || ext === '.tsx') {
       // TODO: add option to do typechecking as well
       enableTypeScript({ transpileOnly: true, esm: args.esm });
     }

--- a/packages/just-task/src/enableTypeScript.ts
+++ b/packages/just-task/src/enableTypeScript.ts
@@ -19,7 +19,7 @@ export function enableTypeScript({ transpileOnly = true, esm = false }): void {
         allowJs: true,
         esModuleInterop: true,
       },
-      files: ['just.config.ts'],
+      files: ['just.config.ts', 'just.config.cts'],
     });
   } else {
     logger.error(`In order to use TypeScript with just.config.ts, you need to install "ts-node" module:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,6 +1008,13 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz#8ff71d51053cd5ee4981e5a501d80a536244f7fd"
   integrity sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -1276,6 +1283,11 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
@@ -1290,6 +1302,14 @@
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.19"
@@ -1443,6 +1463,26 @@
   integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
   dependencies:
     defer-to-connect "^1.0.1"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/argparse@1.0.38":
   version "1.0.38"
@@ -2365,10 +2405,22 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^8.1.1:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  dependencies:
+    acorn "^8.11.0"
+
 acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+
+acorn@^8.11.0, acorn@^8.4.1:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
+  integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
 acorn@^8.9.0:
   version "8.10.0"
@@ -10266,7 +10318,7 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@^0.5.17, source-map-support@~0.5.12:
+source-map-support@~0.5.12:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -10859,16 +10911,23 @@ ts-jest@^29.0.5:
     semver "^7.5.3"
     yargs-parser "^21.0.1"
 
-ts-node@^9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
-  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+ts-node@^10.8.0:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
   dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
     create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.17"
+    v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
 tslib@^1.8.1:
@@ -11273,6 +11332,11 @@ uuid@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-to-istanbul@^9.0.1:
   version "9.1.0"


### PR DESCRIPTION
Part of #572

## Overview
Adds support for just.config.cjs.

## Test Notes
Manually tested different setups in the example-lib folder, in addition to adding unit tests. The TypeScript, ts-node, and lage versions need updating but I didn't want to commit the TS and lage changes in this PR just in case it breaks something.