### PR TITLE
Remove workspace-tools usage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,8 @@
   },
   "search.exclude": {
     "**/node_modules": true,
-    "**/lib": true
+    "**/lib": true,
+    "**/.yarn/releases": true
   },
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "prettier": "~3.8.0",
     "syncpack": "^9.0.0",
     "ts-jest": "~29.2.5",
-    "typescript": "~4.5.0",
-    "workspace-tools": "^0.35.2"
+    "typescript": "~4.5.0"
   },
   "resolutions": {
     "es5-ext": "0.10.53",

--- a/scripts/debugTests.js
+++ b/scripts/debugTests.js
@@ -1,14 +1,23 @@
 // @ts-check
+const fs = require('fs');
 const jest = require('jest');
-const { findPackageRoot } = require('workspace-tools');
+const path = require('path');
 
 const args = process.argv.slice(2);
 
+function findPackageRoot(/** @type {string} */ cwd) {
+  let dir = cwd;
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, 'package.json'))) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+  }
+  throw new Error("Couldn't find the package root from " + cwd);
+}
+
 function start() {
   const packagePath = findPackageRoot(process.cwd());
-  if (!packagePath) {
-    throw new Error('Could not find package.json relative to ' + process.cwd());
-  }
 
   process.chdir(packagePath);
 


### PR DESCRIPTION
The only usage of workspace-tools is trivial to replace, so remove it for simplicity.