### PR TITLE
nodeExecTask env fix

### DIFF
--- a/change/change-96625df6-ec4c-4f4c-9cfc-b74f3ada8684.json
+++ b/change/change-96625df6-ec4c-4f4c-9cfc-b74f3ada8684.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Fix nodeExecTask to preserve process.env unless explicitly overridden",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-scripts/etc/just-scripts.api.md
+++ b/packages/just-scripts/etc/just-scripts.api.md
@@ -294,7 +294,7 @@ function lib(): void;
 // @public
 function mergeFiles(sourceFilePaths: string[], destinationFilePath: string): CopyInstruction;
 
-// @public (undocumented)
+// @public
 export function nodeExecTask(options: NodeExecTaskOptions): TaskFunction;
 
 // @public (undocumented)

--- a/packages/just-scripts/src/tasks/nodeExecTask.ts
+++ b/packages/just-scripts/src/tasks/nodeExecTask.ts
@@ -15,7 +15,8 @@ export interface NodeExecTaskOptions {
   args: string[];
 
   /**
-   * Environment variables to be passed to the spawned process
+   * Environment variables to be passed to the spawned process.
+   * Defaults to `process.env`.
    */
   env?: NodeJS.ProcessEnv;
 
@@ -43,6 +44,12 @@ export interface NodeExecTaskOptions {
   spawnOptions?: SpawnOptions;
 }
 
+/**
+ * Create a task to execute a command in a new process.
+ *
+ * **WARNING: If the `shell` option is enabled, do not pass unsanitized user input to this task.
+ * Any input containing shell metacharacters may be used to trigger arbitrary command execution.**
+ */
 export function nodeExecTask(options: NodeExecTaskOptions): TaskFunction {
   return function () {
     const { spawnOptions, enableTypeScript, tsconfig, transpileOnly } = options;
@@ -51,14 +58,14 @@ export function nodeExecTask(options: NodeExecTaskOptions): TaskFunction {
     const nodeExecPath = process.execPath;
 
     const args = [...(options.args || [])];
-    const env = { ...options.env };
+    //  Preserve the default behavior of inheriting process.env if no options are specified
+    let env = options.env ? { ...options.env } : { ...process.env };
     const isTS = enableTypeScript && tsNodeRegister;
 
     if (isTS) {
-      args.unshift(tsNodeRegister);
-      args.unshift('-r');
+      args.unshift('-r', tsNodeRegister);
 
-      Object.assign(env, getTsNodeEnv(tsconfig, transpileOnly));
+      env = { ...env, ...getTsNodeEnv(tsconfig, transpileOnly) };
     }
 
     logger.info([`Executing${isTS ? ' [TS]' : ''}:`, nodeExecPath, ...args].join(' '));


### PR DESCRIPTION
Always preserve the default `spawn` behavior of inheriting `process.env` unless explicitly overridden.

Accidentally overwriting the implicit default env if not specified was introduced for JS in [this change](https://github.com/microsoft/just/pull/815/changes#diff-28230d447bdd71eccb33400741e75999e8e1bec80eef3b185007e0090b0eccc2L47), but has been an issue with TS for much longer: doing `options.env = { ...options.env, ...getTsNodeEnv(tsconfig, transpileOnly) }` if `options.env` was unset would accidentally pass through only the TS values.