### PR TITLE
Transpile with esModuleInterop

### DIFF
--- a/change/change-e38dddc3-2f67-49fb-9d90-b5fed9174718.json
+++ b/change/change-e38dddc3-2f67-49fb-9d90-b5fed9174718.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "major",
+      "comment": "Transpile with `esModuleInterop` (may impact types for consumers)",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "major",
+      "comment": "Transpile with `esModuleInterop` (may impact types for consumers)",
+      "packageName": "just-task",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-example-lib/tasks/customTask.ts
+++ b/packages/just-example-lib/tasks/customTask.ts
@@ -1,3 +1,3 @@
-import * as path from 'path';
-import * as fs from 'fs';
+import path from 'path';
+import fs from 'fs';
 export const packageJson = fs.readFileSync(path.join(__dirname, '../package.json'), 'utf-8');

--- a/packages/just-scripts/etc/just-scripts.api.md
+++ b/packages/just-scripts/etc/just-scripts.api.md
@@ -7,10 +7,10 @@
 import type * as ApiExtractorTypes from '@microsoft/api-extractor';
 import type { BuildOptions } from 'esbuild';
 import { Configuration } from 'webpack';
-import * as cp from 'child_process';
-import { SpawnOptions } from 'child_process';
-import { TaskFunction } from 'just-task';
-import * as ts from 'typescript';
+import type cp from 'child_process';
+import type { SpawnOptions } from 'child_process';
+import type { TaskFunction } from 'just-task';
+import type ts from 'typescript';
 import * as webpackMerge from 'webpack-merge';
 
 // @public

--- a/packages/just-scripts/src/__tests__/getMockScript.ts
+++ b/packages/just-scripts/src/__tests__/getMockScript.ts
@@ -1,6 +1,6 @@
 import { expect } from '@jest/globals';
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 /** Get the path to a mock script file (verifying that it exists) */
 export function getMockScript(

--- a/packages/just-scripts/src/copy/__tests__/executeCopyInstructions.spec.ts
+++ b/packages/just-scripts/src/copy/__tests__/executeCopyInstructions.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
-import * as mockfs from 'mock-fs';
-import * as path from 'path';
-import * as fs from 'fs';
+import mockfs from 'mock-fs';
+import path from 'path';
+import fs from 'fs';
 // import { dirSync, fileSync, DirResult, FileResult } from 'tmp';
 import { executeCopyInstructions } from '../executeCopyInstructions';
-import { CopyInstruction } from '../CopyInstruction';
+import type { CopyInstruction } from '../CopyInstruction';
 
 describe('executeCopyInstructions functional tests', () => {
   const sourceDir = 'sourceDir';

--- a/packages/just-scripts/src/copy/executeCopyInstructions.ts
+++ b/packages/just-scripts/src/copy/executeCopyInstructions.ts
@@ -1,6 +1,6 @@
 import { dirname, resolve } from 'path';
 import { readFile, writeFile, copy, ensureDir, ensureSymlink } from 'fs-extra';
-import { CopyInstruction, CopyConfig } from './CopyInstruction';
+import type { CopyInstruction, CopyConfig } from './CopyInstruction';
 import { arrayify } from '../arrayUtils/arrayify';
 import { uniqueValues } from '../arrayUtils/uniqueValues';
 

--- a/packages/just-scripts/src/index.ts
+++ b/packages/just-scripts/src/index.ts
@@ -7,9 +7,11 @@ export * from './webpack/webpack.config';
 export * from './webpack/webpack.serve.config';
 
 // Webpack configs and overlays
-import { tsOverlay, TsCheckerOptions, TsLoaderOptions, TsOverlayOptions } from './webpack/overlays/tsOverlay';
+import type { TsCheckerOptions, TsLoaderOptions, TsOverlayOptions } from './webpack/overlays/tsOverlay';
+import { tsOverlay } from './webpack/overlays/tsOverlay';
 import { htmlOverlay } from './webpack/overlays/htmlOverlay';
-import { stylesOverlay, createStylesOverlay, CssLoaderOptions } from './webpack/overlays/stylesOverlay';
+import type { CssLoaderOptions } from './webpack/overlays/stylesOverlay';
+import { stylesOverlay, createStylesOverlay } from './webpack/overlays/stylesOverlay';
 import { fileOverlay } from './webpack/overlays/fileOverlay';
 import { displayBailoutOverlay } from './webpack/overlays/displayBailoutOverlay';
 
@@ -21,24 +23,14 @@ export const webpackOverlays = {
   displayBailout: displayBailoutOverlay,
 };
 
-export {
-  tsOverlay,
-  htmlOverlay,
-  stylesOverlay,
-  fileOverlay,
-  displayBailoutOverlay,
-  createStylesOverlay,
-  CssLoaderOptions,
-  TsCheckerOptions,
-  TsLoaderOptions,
-  TsOverlayOptions,
-};
+export type { CssLoaderOptions, TsCheckerOptions, TsLoaderOptions, TsOverlayOptions };
+export { tsOverlay, htmlOverlay, stylesOverlay, fileOverlay, displayBailoutOverlay, createStylesOverlay };
 
 import * as webpackMerge from 'webpack-merge';
 export { webpackMerge };
 
 import * as copyInstructions from './copy/CopyInstruction';
-export { CopyInstruction, CopyConfig } from './copy/CopyInstruction';
+export type { CopyInstruction, CopyConfig } from './copy/CopyInstruction';
 export { copyInstructions };
 
 export * from 'just-task';

--- a/packages/just-scripts/src/jest/JestReporter.ts
+++ b/packages/just-scripts/src/jest/JestReporter.ts
@@ -7,7 +7,7 @@ import { DefaultReporter } from '@jest/reporters';
 class JestReporter extends DefaultReporter {
   private _isLoggingError = false;
 
-  public log(message: string) {
+  public log(message: string): void {
     if (this._isLoggingError) {
       process.stderr.write(message + '\n');
     } else {
@@ -15,7 +15,7 @@ class JestReporter extends DefaultReporter {
     }
   }
 
-  public printTestFileFailureMessage(...args: Parameters<DefaultReporter['printTestFileFailureMessage']>) {
+  public printTestFileFailureMessage(...args: Parameters<DefaultReporter['printTestFileFailureMessage']>): void {
     this._isLoggingError = true;
     super.printTestFileFailureMessage(...args);
     this._isLoggingError = false;

--- a/packages/just-scripts/src/monorepo/isMonoRepo.ts
+++ b/packages/just-scripts/src/monorepo/isMonoRepo.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import * as fs from 'fs';
+import path from 'path';
+import fs from 'fs';
 
 export function isMonoRepo(rootPath: string): boolean {
   const scriptsPath = path.join(rootPath, 'scripts');

--- a/packages/just-scripts/src/tasks/__tests__/apiExtractorTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/apiExtractorTask.mock.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, jest, afterEach, beforeEach } from '@jest/globals';
 import type * as apiExtractor from '@microsoft/api-extractor';
-import * as fs from 'fs-extra';
+import fs from 'fs-extra';
 import { apiExtractorVerifyTask, apiExtractorUpdateTask, fixApiFileNewlines } from '../apiExtractorTask';
 import { callTaskForTest } from './callTaskForTest';
 import { tryRequire } from '../../tryRequire';
-import path = require('path');
+import path from 'path';
 
 jest.mock('just-task/lib/logger');
 

--- a/packages/just-scripts/src/tasks/__tests__/callTaskForTest.ts
+++ b/packages/just-scripts/src/tasks/__tests__/callTaskForTest.ts
@@ -1,4 +1,4 @@
-import * as asyncDoneAsCallback from 'async-done';
+import asyncDoneAsCallback from 'async-done';
 import { promisify } from 'util';
 import type { TaskFunction } from 'just-task';
 
@@ -7,6 +7,6 @@ const asyncDone = promisify(asyncDoneAsCallback);
 /**
  * Call the task the way real code does.
  */
-export function callTaskForTest(fn: TaskFunction) {
+export function callTaskForTest(fn: TaskFunction): Promise<unknown> {
   return asyncDone(fn);
 }

--- a/packages/just-scripts/src/tasks/__tests__/cleanTask.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/cleanTask.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
-import * as fse from 'fs-extra';
+import fse from 'fs-extra';
 import { cleanTask, defaultCleanPaths } from '../cleanTask';
 import { callTaskForTest } from './callTaskForTest';
 

--- a/packages/just-scripts/src/tasks/__tests__/copyTask.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/copyTask.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
-import * as mockfs from 'mock-fs';
-import * as fse from 'fs-extra';
+import mockfs from 'mock-fs';
+import fse from 'fs-extra';
 import { copyTask } from '../copyTask';
 import { callTaskForTest } from './callTaskForTest';
 

--- a/packages/just-scripts/src/tasks/__tests__/eslintTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/eslintTask.mock.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 import { spawn } from '../../utils';
 import { eslintTask } from '../eslintTask';
 import { callTaskForTest } from './callTaskForTest';

--- a/packages/just-scripts/src/tasks/__tests__/getNormalizedSpawnArgs.ts
+++ b/packages/just-scripts/src/tasks/__tests__/getNormalizedSpawnArgs.ts
@@ -1,5 +1,6 @@
-import { expect, jest } from '@jest/globals';
-import * as path from 'path';
+import type { jest } from '@jest/globals';
+import { expect } from '@jest/globals';
+import path from 'path';
 import type { spawn } from '../../utils/exec';
 
 const packageRootDir = path.resolve(__dirname, '../../..');
@@ -11,7 +12,7 @@ const repoRootDir = path.resolve(packageRootDir, '../..');
  * @param spawnSpy Mocked or spied `spawn` function from this package
  * @returns Array of normalized command and arguments
  */
-export function getNormalizedSpawnArgs(spawnSpy: jest.SpiedFunction<typeof spawn>) {
+export function getNormalizedSpawnArgs(spawnSpy: jest.SpiedFunction<typeof spawn>): string[] {
   expect(spawnSpy).toHaveBeenCalledTimes(1);
   const [spawnCmd, spawnArgs] = spawnSpy.mock.calls[0];
   expect(spawnCmd).toBe(process.execPath);
@@ -25,7 +26,7 @@ export function getNormalizedSpawnArgs(spawnSpy: jest.SpiedFunction<typeof spawn
  * Like {@link getNormalizedSpawnArgs} but returns one array per spawn call,
  * for tasks that call spawn multiple times (e.g. prettierTask with chunked files).
  */
-export function getAllNormalizedSpawnArgs(spawnSpy: jest.SpiedFunction<typeof spawn>) {
+export function getAllNormalizedSpawnArgs(spawnSpy: jest.SpiedFunction<typeof spawn>): string[][] {
   expect(spawnSpy).toHaveBeenCalled();
   return spawnSpy.mock.calls.map(([spawnCmd, spawnArgs]) => {
     expect(spawnCmd).toBe(process.execPath);

--- a/packages/just-scripts/src/tasks/__tests__/jestTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/jestTask.mock.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 import { spawn } from '../../utils';
 import { jestTask } from '../jestTask';
 import { callTaskForTest } from './callTaskForTest';

--- a/packages/just-scripts/src/tasks/__tests__/nodeExecTask.test.ts
+++ b/packages/just-scripts/src/tasks/__tests__/nodeExecTask.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest, beforeEach, afterEach, afterAll } from '@jest/globals';
 import { fail } from 'assert';
 import type { TaskFunction } from 'just-task';
-import * as path from 'path';
+import path from 'path';
 import { getMockScript } from '../../__tests__/getMockScript';
 import { MockOutputStream } from '../../__tests__/MockOutputStream';
 import * as execModule from '../../utils/exec';

--- a/packages/just-scripts/src/tasks/__tests__/prettierTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/prettierTask.mock.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 import { spawn } from '../../utils';
 import { prettierTask, prettierCheckTask } from '../prettierTask';
 import { callTaskForTest } from './callTaskForTest';

--- a/packages/just-scripts/src/tasks/__tests__/sassTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/sassTask.mock.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
-import * as fs from 'fs';
-import * as glob from 'glob';
-import * as path from 'path';
+import fs from 'fs';
+import glob from 'glob';
+import path from 'path';
 import { sassTask } from '../sassTask';
 import { tryRequire } from '../../tryRequire';
 import { callTaskForTest } from './callTaskForTest';

--- a/packages/just-scripts/src/tasks/__tests__/tscTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/tscTask.mock.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 import { spawn } from '../../utils';
 import { tscTask, tscWatchTask } from '../tscTask';
 import { callTaskForTest } from './callTaskForTest';

--- a/packages/just-scripts/src/tasks/__tests__/tslintTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/tslintTask.mock.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 import { spawn } from '../../utils';
 import { tslintTask } from '../tslintTask';
 import { callTaskForTest } from './callTaskForTest';

--- a/packages/just-scripts/src/tasks/__tests__/webpackCliTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/webpackCliTask.mock.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 import { spawn } from '../../utils';
 import { webpackCliTask } from '../webpackCliTask';
 import { callTaskForTest } from './callTaskForTest';

--- a/packages/just-scripts/src/tasks/__tests__/webpackDevServerTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/webpackDevServerTask.mock.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 import { spawn } from '../../utils';
 import { webpackDevServerTask } from '../webpackDevServerTask';
 import { callTaskForTest } from './callTaskForTest';

--- a/packages/just-scripts/src/tasks/__tests__/webpackTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/webpackTask.mock.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
-import * as fs from 'fs';
+import fs from 'fs';
 import { webpackTask } from '../webpackTask';
 import { callTaskForTest } from './callTaskForTest';
 import { tryRequire } from '../../tryRequire';
-import * as path from 'path';
+import path from 'path';
 
 jest.mock('just-task/lib/logger');
 

--- a/packages/just-scripts/src/tasks/apiExtractorTask.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTask.ts
@@ -1,6 +1,7 @@
-import { logger, TaskFunction } from 'just-task';
-import * as fs from 'fs-extra';
-import * as path from 'path';
+import type { TaskFunction } from 'just-task';
+import { logger } from 'just-task';
+import fs from 'fs-extra';
+import path from 'path';
 import { tryRequire } from '../tryRequire';
 import type * as ApiExtractorTypes from '@microsoft/api-extractor';
 

--- a/packages/just-scripts/src/tasks/cleanTask.ts
+++ b/packages/just-scripts/src/tasks/cleanTask.ts
@@ -1,7 +1,8 @@
-import * as fse from 'fs-extra';
-import * as path from 'path';
-import { logger, TaskFunction } from 'just-task';
-import parallelLimit = require('run-parallel-limit');
+import fse from 'fs-extra';
+import path from 'path';
+import type { TaskFunction } from 'just-task';
+import { logger } from 'just-task';
+import parallelLimit from 'run-parallel-limit';
 
 export interface CleanTaskOptions {
   /**

--- a/packages/just-scripts/src/tasks/copyInstructionsTask.ts
+++ b/packages/just-scripts/src/tasks/copyInstructionsTask.ts
@@ -1,6 +1,6 @@
 import { executeCopyInstructions } from '../copy/executeCopyInstructions';
-import { CopyConfig } from '../copy/CopyInstruction';
-import { TaskFunction } from 'just-task';
+import type { CopyConfig } from '../copy/CopyInstruction';
+import type { TaskFunction } from 'just-task';
 
 /**
  * This is an advanced copy task that allows more advanced usage beyond simple copies.

--- a/packages/just-scripts/src/tasks/copyTask.ts
+++ b/packages/just-scripts/src/tasks/copyTask.ts
@@ -1,8 +1,9 @@
-import * as glob from 'glob';
-import * as fse from 'fs-extra';
-import * as path from 'path';
-import { logger, TaskFunction } from 'just-task';
-import parallelLimit = require('run-parallel-limit');
+import glob from 'glob';
+import fse from 'fs-extra';
+import path from 'path';
+import type { TaskFunction } from 'just-task';
+import { logger } from 'just-task';
+import parallelLimit from 'run-parallel-limit';
 
 export interface CopyTaskOptions {
   /** Paths to copy */

--- a/packages/just-scripts/src/tasks/esbuildTask.ts
+++ b/packages/just-scripts/src/tasks/esbuildTask.ts
@@ -1,5 +1,6 @@
 import type { BuildOptions } from 'esbuild';
-import { resolve, TaskFunction } from 'just-task';
+import type { TaskFunction } from 'just-task';
+import { resolve } from 'just-task';
 
 export type EsbuildBuildOptions = BuildOptions;
 export interface EsbuildTransformOptions {

--- a/packages/just-scripts/src/tasks/eslintTask.ts
+++ b/packages/just-scripts/src/tasks/eslintTask.ts
@@ -1,6 +1,7 @@
-import { resolve, resolveCwd, TaskFunction } from 'just-task';
+import type { TaskFunction } from 'just-task';
+import { resolve, resolveCwd } from 'just-task';
 import { logNodeCommand, spawn } from '../utils';
-import * as fs from 'fs';
+import fs from 'fs';
 
 /**
  * Task options generally follow ESLint CLI options explained here:

--- a/packages/just-scripts/src/tasks/jestTask.ts
+++ b/packages/just-scripts/src/tasks/jestTask.ts
@@ -1,7 +1,8 @@
-import { resolve, logger, resolveCwd, TaskFunction, argv } from 'just-task';
+import type { TaskFunction } from 'just-task';
+import { resolve, logger, resolveCwd, argv } from 'just-task';
 import { spawn, readPackageJson, logNodeCommand } from '../utils';
 import { existsSync } from 'fs';
-import * as supportsColor from 'supports-color';
+import supportsColor from 'supports-color';
 
 export interface JestTaskOptions {
   config?: string;

--- a/packages/just-scripts/src/tasks/nodeExecTask.ts
+++ b/packages/just-scripts/src/tasks/nodeExecTask.ts
@@ -1,6 +1,7 @@
-import { SpawnOptions } from 'child_process';
+import type { SpawnOptions } from 'child_process';
 import { spawn } from '../utils';
-import { logger, TaskFunction } from 'just-task';
+import type { TaskFunction } from 'just-task';
+import { logger } from 'just-task';
 import { resolveCwd, _tryResolve } from 'just-task/lib/resolve';
 import { getTsNodeEnv } from '../typescript/getTsNodeEnv';
 

--- a/packages/just-scripts/src/tasks/prettierTask.ts
+++ b/packages/just-scripts/src/tasks/prettierTask.ts
@@ -1,7 +1,8 @@
-import { logger, resolve, TaskFunction } from 'just-task';
+import type { TaskFunction } from 'just-task';
+import { logger, resolve } from 'just-task';
 import { logNodeCommand, spawn } from '../utils';
 import { splitArrayIntoChunks } from '../arrayUtils/splitArrayIntoChunks';
-import * as path from 'path';
+import path from 'path';
 import { arrayify } from '../arrayUtils/arrayify';
 
 interface PrettierContext {

--- a/packages/just-scripts/src/tasks/sassTask.ts
+++ b/packages/just-scripts/src/tasks/sassTask.ts
@@ -1,9 +1,10 @@
-import * as glob from 'glob';
-import * as path from 'path';
-import * as fs from 'fs';
-import { resolveCwd, TaskFunction, logger } from 'just-task';
+import glob from 'glob';
+import path from 'path';
+import fs from 'fs';
+import type { TaskFunction } from 'just-task';
+import { resolveCwd, logger } from 'just-task';
 import { tryRequire } from '../tryRequire';
-import parallelLimit = require('run-parallel-limit');
+import parallelLimit from 'run-parallel-limit';
 
 export interface SassTaskOptions {
   createSourceModule: (fileName: string, css: string) => string;

--- a/packages/just-scripts/src/tasks/tarTask.ts
+++ b/packages/just-scripts/src/tasks/tarTask.ts
@@ -1,7 +1,8 @@
-import { resolve, logger, TaskFunction } from 'just-task';
+import type { TaskFunction } from 'just-task';
+import { resolve, logger } from 'just-task';
 import { createWriteStream, createReadStream } from 'fs';
 import { createGzip, createGunzip } from 'zlib';
-import { Stream } from 'stream';
+import type { Stream } from 'stream';
 
 export interface EntryHeader {
   name: string;

--- a/packages/just-scripts/src/tasks/tscTask.ts
+++ b/packages/just-scripts/src/tasks/tscTask.ts
@@ -1,7 +1,8 @@
-import * as ts from 'typescript';
-import { resolve, logger, resolveCwd, TaskFunction } from 'just-task';
+import type ts from 'typescript';
+import type { TaskFunction } from 'just-task';
+import { resolve, logger, resolveCwd } from 'just-task';
 import { logNodeCommand, spawn } from '../utils';
-import * as fs from 'fs';
+import fs from 'fs';
 
 export type TscTaskOptions = { [key in keyof ts.CompilerOptions]?: string | boolean | string[] } & {
   nodeArgs?: string[];

--- a/packages/just-scripts/src/tasks/tslintTask.ts
+++ b/packages/just-scripts/src/tasks/tslintTask.ts
@@ -1,6 +1,7 @@
-import { resolve, logger, resolveCwd, TaskFunction } from 'just-task';
-import * as path from 'path';
-import * as fs from 'fs';
+import type { TaskFunction } from 'just-task';
+import { resolve, logger, resolveCwd } from 'just-task';
+import path from 'path';
+import fs from 'fs';
 import { logNodeCommand, spawn } from '../utils';
 
 export interface TsLintTaskOptions {

--- a/packages/just-scripts/src/tasks/webpackCliTask.ts
+++ b/packages/just-scripts/src/tasks/webpackCliTask.ts
@@ -1,4 +1,5 @@
-import { logger, TaskFunction, resolve } from 'just-task';
+import type { TaskFunction } from 'just-task';
+import { logger, resolve } from 'just-task';
 import { logNodeCommand, spawn } from '../utils';
 import { getTsNodeEnv } from '../typescript/getTsNodeEnv';
 import { findWebpackConfig } from '../webpack/findWebpackConfig';

--- a/packages/just-scripts/src/tasks/webpackDevServerTask.ts
+++ b/packages/just-scripts/src/tasks/webpackDevServerTask.ts
@@ -1,13 +1,14 @@
 // // WARNING: Careful about add more imports - only import types from webpack
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 import { logNodeCommand, spawn } from '../utils';
-import { resolve, resolveCwd, TaskFunction } from 'just-task';
-import * as fs from 'fs';
-import * as path from 'path';
-import { WebpackCliTaskOptions } from './webpackCliTask';
+import type { TaskFunction } from 'just-task';
+import { resolve, resolveCwd } from 'just-task';
+import fs from 'fs';
+import path from 'path';
+import type { WebpackCliTaskOptions } from './webpackCliTask';
 import { getTsNodeEnv } from '../typescript/getTsNodeEnv';
 import { findWebpackConfig } from '../webpack/findWebpackConfig';
-import * as semver from 'semver';
+import semver from 'semver';
 
 export interface WebpackDevServerTaskOptions extends WebpackCliTaskOptions, Configuration {
   /**

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -1,9 +1,10 @@
 // // WARNING: Careful about add more imports - only import types from webpack
 import type { Configuration, Stats } from 'webpack';
-import { logger, argv, TaskFunction, resolveCwd } from 'just-task';
+import type { TaskFunction } from 'just-task';
+import { logger, argv, resolveCwd } from 'just-task';
 import { tryRequire } from '../tryRequire';
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { merge } from 'webpack-merge';
 import { findWebpackConfig } from '../webpack/findWebpackConfig';
 import { enableTypeScript } from 'just-task/lib/enableTypeScript';

--- a/packages/just-scripts/src/utils/__tests__/exec.spec.ts
+++ b/packages/just-scripts/src/utils/__tests__/exec.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
-import * as cp from 'child_process';
-import * as path from 'path';
+import cp from 'child_process';
+import path from 'path';
 import { encodeArgs, spawn } from '../exec';
 import { getMockScript } from '../../__tests__/getMockScript';
 import { MockOutputStream } from '../../__tests__/MockOutputStream';

--- a/packages/just-scripts/src/utils/__tests__/mergePackageJson.spec.ts
+++ b/packages/just-scripts/src/utils/__tests__/mergePackageJson.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import { mergePackageJson, _shouldUpdateDep } from '../mergePackageJson';
-import { PackageJson } from '../../interfaces/PackageJson';
+import type { PackageJson } from '../../interfaces/PackageJson';
 
 describe('_shouldUpdateDep', () => {
   it('returns true if old version is undefined', () => {

--- a/packages/just-scripts/src/utils/__tests__/paths.spec.ts
+++ b/packages/just-scripts/src/utils/__tests__/paths.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, afterEach } from '@jest/globals';
-import * as path from 'path';
-import * as os from 'os';
+import path from 'path';
+import os from 'os';
 import { paths } from '../paths';
 
 describe('paths', () => {

--- a/packages/just-scripts/src/utils/__tests__/readPackageJson.spec.ts
+++ b/packages/just-scripts/src/utils/__tests__/readPackageJson.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
 import { readPackageJson } from '../readPackageJson';
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 
 describe('readPackageJson', () => {
   const testDir = 'testDir';

--- a/packages/just-scripts/src/utils/exec.ts
+++ b/packages/just-scripts/src/utils/exec.ts
@@ -1,4 +1,4 @@
-import * as cp from 'child_process';
+import type cp from 'child_process';
 import { spawn as crossSpawn } from 'cross-spawn';
 import { logger } from 'just-task';
 

--- a/packages/just-scripts/src/utils/mergePackageJson.ts
+++ b/packages/just-scripts/src/utils/mergePackageJson.ts
@@ -1,5 +1,5 @@
-import { PackageJson } from '../interfaces/PackageJson';
-import semver = require('semver');
+import type { PackageJson } from '../interfaces/PackageJson';
+import semver from 'semver';
 
 /**
  * Merges an incoming package.json with an original semantically. It can only handle merging

--- a/packages/just-scripts/src/utils/paths.ts
+++ b/packages/just-scripts/src/utils/paths.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import * as os from 'os';
+import path from 'path';
+import os from 'os';
 
 let projectPath = '';
 

--- a/packages/just-scripts/src/utils/readPackageJson.ts
+++ b/packages/just-scripts/src/utils/readPackageJson.ts
@@ -1,6 +1,6 @@
-import * as path from 'path';
-import { PackageJson } from '../interfaces/PackageJson';
-import fse = require('fs-extra');
+import path from 'path';
+import type { PackageJson } from '../interfaces/PackageJson';
+import fse from 'fs-extra';
 
 /**
  * Reads and parses the package.json file from the given folder.

--- a/packages/just-scripts/src/webpack/findWebpackConfig.ts
+++ b/packages/just-scripts/src/webpack/findWebpackConfig.ts
@@ -1,5 +1,5 @@
 import { resolveCwd } from 'just-task';
-import * as path from 'path';
+import path from 'path';
 
 export function findWebpackConfig(...targets: string[]): string | null {
   for (const target of targets) {

--- a/packages/just-scripts/src/webpack/overlays/displayBailoutOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/displayBailoutOverlay.ts
@@ -1,4 +1,4 @@
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 
 export const displayBailoutOverlay = (): Partial<Configuration> => ({
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/just-scripts/src/webpack/overlays/fileOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/fileOverlay.ts
@@ -1,5 +1,5 @@
 // // WARNING: Careful about add more imports - only import types from webpack
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 
 export const fileOverlay = (): Partial<Configuration> => ({
   module: {

--- a/packages/just-scripts/src/webpack/overlays/htmlOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/htmlOverlay.ts
@@ -1,5 +1,5 @@
 // // WARNING: Careful about add more imports - only import types from webpack
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 import { tryRequire } from '../../tryRequire';
 
 export const htmlOverlay: (options: any) => Partial<Configuration> = options => {

--- a/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
@@ -1,5 +1,6 @@
 // // WARNING: Careful about add more imports - only import types from webpack
-import { Configuration, type Loader } from 'webpack';
+import type { Configuration } from 'webpack';
+import type { Loader } from 'webpack';
 import { resolve } from 'just-task';
 import { tryRequire } from '../../tryRequire';
 

--- a/packages/just-scripts/src/webpack/overlays/tsOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/tsOverlay.ts
@@ -1,6 +1,6 @@
-import * as ts from 'typescript';
+import type ts from 'typescript';
 // // WARNING: Careful about add more imports - only import types from webpack
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 import { tryRequire } from '../../tryRequire';
 
 export interface TsLoaderOptions {

--- a/packages/just-scripts/src/webpack/webpack.config.ts
+++ b/packages/just-scripts/src/webpack/webpack.config.ts
@@ -1,6 +1,6 @@
 // // WARNING: Careful about add more imports - only import types from webpack
-import { Configuration } from 'webpack';
-import * as path from 'path';
+import type { Configuration } from 'webpack';
+import path from 'path';
 import { merge } from 'webpack-merge';
 import { tsOverlay } from './overlays/tsOverlay';
 import { fileOverlay } from './overlays/fileOverlay';

--- a/packages/just-scripts/src/webpack/webpack.serve.config.ts
+++ b/packages/just-scripts/src/webpack/webpack.serve.config.ts
@@ -1,6 +1,6 @@
 // // WARNING: Careful about add more imports - only import types from webpack
-import { Configuration } from 'webpack';
-import * as path from 'path';
+import type { Configuration } from 'webpack';
+import path from 'path';
 import { merge } from 'webpack-merge';
 import { tsOverlay } from './overlays/tsOverlay';
 import { fileOverlay } from './overlays/fileOverlay';

--- a/packages/just-task/etc/just-task.api.md
+++ b/packages/just-task/etc/just-task.api.md
@@ -4,11 +4,10 @@
 
 ```ts
 
-import { Arguments } from 'yargs-parser';
+import type { Arguments } from 'yargs-parser';
 import type { FSWatcher } from 'chokidar';
 import type { Stats } from 'fs';
-import type * as Undertaker from 'undertaker';
-import Undertaker_2 = require('undertaker');
+import Undertaker from 'undertaker';
 import type { WatchOptions } from 'chokidar';
 
 // @public
@@ -63,7 +62,7 @@ interface OptionConfig {
 }
 
 // @public (undocumented)
-export function parallel(...tasks: Task[]): Undertaker_2.TaskFunction;
+export function parallel(...tasks: Task[]): Undertaker.TaskFunction;
 
 // @public
 export function resetResolvePaths(): void;
@@ -89,7 +88,7 @@ interface ResolveOptions {
 }
 
 // @public (undocumented)
-export function series(...tasks: Task[]): Undertaker_2.TaskFunction;
+export function series(...tasks: Task[]): Undertaker.TaskFunction;
 
 // @public (undocumented)
 export type Task = string | TaskFunction;
@@ -104,7 +103,7 @@ export interface TaskFunction extends Undertaker.TaskFunction {
 }
 
 // @public (undocumented)
-export const undertaker: Undertaker_2;
+export const undertaker: Undertaker;
 
 // Warning: (ae-forgotten-export) The symbol "WatchListener" needs to be exported by the entry point index.d.ts
 //

--- a/packages/just-task/src/__tests__/logger.spec.ts
+++ b/packages/just-task/src/__tests__/logger.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest, beforeAll, beforeEach, afterAll } from '@jest/globals';
 import { logger } from '../logger';
-import chalk = require('chalk');
+import chalk from 'chalk';
 
 describe('logger', () => {
   const fakeTime = new Date().toLocaleTimeString();

--- a/packages/just-task/src/__tests__/resolve.spec.ts
+++ b/packages/just-task/src/__tests__/resolve.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { describe, expect, it, jest, afterEach, beforeEach } from '@jest/globals';
-import * as path from 'path';
+import path from 'path';
 import {
   _isFileNameLike,
   _tryResolve,
@@ -13,7 +13,7 @@ import {
 } from '../resolve';
 import * as option from '../option';
 import * as config from '../config';
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 
 describe('_isFileNameLike', () => {
   it('returns false for empty input', () => {

--- a/packages/just-task/src/__tests__/task.spec.ts
+++ b/packages/just-task/src/__tests__/task.spec.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, jest, beforeAll, beforeEach, afterAll } from '@je
 import { task } from '../task';
 import { parallel, undertaker } from '../undertaker';
 import { logger } from '../logger';
-import * as path from 'path';
+import path from 'path';
 import * as option from '../option';
-import * as UndertakerRegistry from 'undertaker-registry';
+import UndertakerRegistry from 'undertaker-registry';
 
 describe('task', () => {
   beforeAll(() => {

--- a/packages/just-task/src/__tests__/watch.spec.ts
+++ b/packages/just-task/src/__tests__/watch.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
 import { watch } from '../watch';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
 describe('watch', () => {
   it('can take a synchronous taskFunction', done => {

--- a/packages/just-task/src/config.ts
+++ b/packages/just-task/src/config.ts
@@ -1,12 +1,12 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 
 import { argv } from './option';
 import { resolve } from './resolve';
 import { mark, logger } from './logger';
 import { enableTypeScript } from './enableTypeScript';
-import yargsParser = require('yargs-parser');
-import { TaskFunction } from './interfaces';
+import type yargsParser from 'yargs-parser';
+import type { TaskFunction } from './interfaces';
 
 export function resolveConfigFile(args: yargsParser.Arguments): string | null {
   for (const entry of [

--- a/packages/just-task/src/enableTypeScript.ts
+++ b/packages/just-task/src/enableTypeScript.ts
@@ -1,7 +1,8 @@
 import { resolve } from './resolve';
 import { logger } from './logger';
 
-export function enableTypeScript({ transpileOnly = true, esm = false }): void {
+export function enableTypeScript(options?: { transpileOnly?: boolean; esm?: boolean }): void {
+  const { transpileOnly = true, esm = false } = options || {};
   const tsNodeModule = resolve('ts-node');
   if (tsNodeModule) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/just-task/src/interfaces.ts
+++ b/packages/just-task/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type * as Undertaker from 'undertaker';
+import type Undertaker from 'undertaker';
 
 export type Task = string | TaskFunction;
 

--- a/packages/just-task/src/logger.ts
+++ b/packages/just-task/src/logger.ts
@@ -1,5 +1,5 @@
-import chalk = require('chalk');
-import * as parser from 'yargs-parser';
+import chalk from 'chalk';
+import parser from 'yargs-parser';
 
 const argv = parser(process.argv.slice(2));
 

--- a/packages/just-task/src/option.ts
+++ b/packages/just-task/src/option.ts
@@ -1,5 +1,5 @@
-import { Options, Arguments } from 'yargs-parser';
-import parser = require('yargs-parser');
+import type { Options, Arguments } from 'yargs-parser';
+import parser from 'yargs-parser';
 
 export interface OptionConfig {
   /** Aliases for the argument, can be a string or array */

--- a/packages/just-task/src/resolve.ts
+++ b/packages/just-task/src/resolve.ts
@@ -1,5 +1,5 @@
 import { sync as resolveSync } from 'resolve';
-import * as path from 'path';
+import path from 'path';
 import { argv } from './option';
 
 export interface ResolveOptions {

--- a/packages/just-task/src/task.ts
+++ b/packages/just-task/src/task.ts
@@ -1,6 +1,6 @@
 import { undertaker } from './undertaker';
 import { wrapTask } from './wrapTask';
-import { TaskFunction } from './interfaces';
+import type { TaskFunction } from './interfaces';
 
 export function task(
   firstParam: string | TaskFunction,

--- a/packages/just-task/src/undertaker.ts
+++ b/packages/just-task/src/undertaker.ts
@@ -1,8 +1,8 @@
 import { logger } from './logger';
-import chalk = require('chalk');
+import chalk from 'chalk';
 import { wrapTask } from './wrapTask';
-import { Task } from './interfaces';
-import Undertaker = require('undertaker');
+import type { Task } from './interfaces';
+import Undertaker from 'undertaker';
 
 const undertaker = new Undertaker();
 const NS_PER_SEC = 1e9;

--- a/scripts/eslintConfig.mjs
+++ b/scripts/eslintConfig.mjs
@@ -39,13 +39,13 @@ export function getConfig(dirname, ...configs) {
         '@typescript-eslint/no-shadow': 'error',
         '@typescript-eslint/no-unused-expressions': ['error', { allowShortCircuit: true }],
         '@typescript-eslint/prefer-for-of': 'error',
+        '@typescript-eslint/consistent-type-imports': ['error', { disallowTypeAnnotations: false }],
+        '@typescript-eslint/consistent-type-exports': 'error',
+        '@typescript-eslint/explicit-module-boundary-types': 'error',
+        '@typescript-eslint/no-import-type-side-effects': 'error',
 
         // Should be enabled
         '@typescript-eslint/no-explicit-any': 'off',
-        // '@typescript-eslint/consistent-type-imports': ['error', { disallowTypeAnnotations: false }],
-        // '@typescript-eslint/consistent-type-exports': 'error',
-        // '@typescript-eslint/explicit-module-boundary-types': 'error',
-        // '@typescript-eslint/no-import-type-side-effects': 'error',
 
         '@typescript-eslint/no-restricted-imports': [
           'error',

--- a/scripts/tsconfig.base.json
+++ b/scripts/tsconfig.base.json
@@ -17,10 +17,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "skipLibCheck": true,
-    // TODO: enable these and remove ignoreDeprecations
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": false,
-    "ignoreDeprecations": "6.0",
     "lib": ["ES2024"],
     "types": ["node"]
   }


### PR DESCRIPTION
Enable `esModuleInterop`. This may be a breaking change in consuming types in repos without `esModuleInterop` enabled.

Also use `import type` where relevant and add lint rules to enforce.