### PR TITLE
Remove deprecated APIs

### DIFF
--- a/change/change-1d94f455-352d-4bdb-96d6-8bd8b1544682.json
+++ b/change/change-1d94f455-352d-4bdb-96d6-8bd8b1544682.json
@@ -1,8 +1,8 @@
 {
   "changes": [
     {
-      "type": "major",
-      "comment": "`sassTask`: Remove deprecated signature (use object params signature). Also catch errors from `postcss`.",
+      "type": "patch",
+      "comment": "`sassTask`: Catch errors from `postcss`.",
       "packageName": "just-scripts",
       "email": "elcraig@microsoft.com",
       "dependentChangeType": "patch"

--- a/change/change-a5026a81-fe51-474a-8087-277cf8e64585.json
+++ b/change/change-a5026a81-fe51-474a-8087-277cf8e64585.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove deprecated `spawn` and `encodeArgs`. Neither of these properly handled security concerns or other issues, so it's better to use a more mature purpose-specific library instead (such as `shell-quote` for escaping, or `execa` or `nano-spawn` for process spawning).",
+      "type": "major",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-b8c058bd-d7d6-481a-853a-95a9df90cdea.json
+++ b/change/change-b8c058bd-d7d6-481a-853a-95a9df90cdea.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "major",
+      "comment": "Remove deprecated `resolve` and `resolveCwd` signatures (use object for second param)",
+      "packageName": "just-task",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-f95212a0-d63c-4889-95bf-a31e5e8b5201.json
+++ b/change/change-f95212a0-d63c-4889-95bf-a31e5e8b5201.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "type": "major",
-      "comment": "Remove deprecated non-object-style signatures of `apiExtractorVerifyTask`, `apiExtractorUpdateTask`, `cleanTask`, `copyTask`, and `sassTask`",
+      "comment": "`apiExtractor` tasks: Remove deprecated `fixNewlines` option (use API Extractor option `newlineKind: \"os\"` instead)",
       "packageName": "just-scripts",
       "email": "elcraig@microsoft.com",
       "dependentChangeType": "patch"

--- a/packages/just-scripts/etc/just-scripts.api.md
+++ b/packages/just-scripts/etc/just-scripts.api.md
@@ -7,7 +7,6 @@
 import type * as ApiExtractorTypes from '@microsoft/api-extractor';
 import type { BuildOptions } from 'esbuild';
 import { Configuration } from 'webpack';
-import type cp from 'child_process';
 import type { SpawnOptions } from 'child_process';
 import type { TaskFunction } from 'just-task';
 import type ts from 'typescript';
@@ -16,8 +15,6 @@ import * as webpackMerge from 'webpack-merge';
 // @public
 export interface ApiExtractorOptions extends ApiExtractorTypes.IExtractorInvokeOptions {
     configJsonFilePath?: string;
-    // @deprecated (undocumented)
-    fixNewlines?: boolean;
     onConfigLoaded?: (config: ApiExtractorTypes.IConfigFile) => void;
     onResult?: (result: any, extractorOptions: any) => void;
     projectFolder?: string;
@@ -26,14 +23,8 @@ export interface ApiExtractorOptions extends ApiExtractorTypes.IExtractorInvokeO
 // @public
 export function apiExtractorUpdateTask(options: ApiExtractorOptions): TaskFunction;
 
-// @public @deprecated (undocumented)
-export function apiExtractorUpdateTask(configJsonFilePath: string, extractorOptions: Omit<ApiExtractorOptions, 'configJsonFilePath'>): TaskFunction;
-
 // @public (undocumented)
 export function apiExtractorVerifyTask(options: ApiExtractorOptions): TaskFunction;
-
-// @public @deprecated (undocumented)
-export function apiExtractorVerifyTask(configJsonFilePath: string, extractorOptions: Omit<ApiExtractorOptions, 'configJsonFilePath'>): TaskFunction;
 
 // @public (undocumented)
 export const basicWebpackConfig: Configuration;
@@ -43,9 +34,6 @@ export const basicWebpackServeConfig: Configuration;
 
 // @public (undocumented)
 export function cleanTask(options?: CleanTaskOptions): TaskFunction;
-
-// @public @deprecated (undocumented)
-export function cleanTask(paths?: string[], limit?: number): TaskFunction;
 
 // @public (undocumented)
 export interface CleanTaskOptions {
@@ -140,9 +128,6 @@ export function defaultCleanPaths(): string[];
 
 // @public (undocumented)
 export const displayBailoutOverlay: () => Partial<Configuration>;
-
-// @public @deprecated (undocumented)
-export function encodeArgs(cmdArgs: string[]): string[];
 
 // @public (undocumented)
 export interface EntryHeader {
@@ -330,12 +315,6 @@ export interface SassTaskOptions {
     // (undocumented)
     postcssPlugins?: unknown[];
 }
-
-// @public @deprecated
-export function spawn(cmd: string, args?: ReadonlyArray<string>, opts?: cp.SpawnOptions & {
-    stdout?: NodeJS.WritableStream;
-    stderr?: NodeJS.WritableStream;
-}): Promise<void>;
 
 // @public (undocumented)
 export const stylesOverlay: () => Partial<Configuration>;

--- a/packages/just-scripts/src/index.ts
+++ b/packages/just-scripts/src/index.ts
@@ -34,5 +34,3 @@ export type { CopyInstruction, CopyConfig } from './copy/CopyInstruction';
 export { copyInstructions };
 
 export * from 'just-task';
-
-export { encodeArgs, spawn } from './utils';

--- a/packages/just-scripts/src/task-presets/lib.ts
+++ b/packages/just-scripts/src/task-presets/lib.ts
@@ -2,7 +2,7 @@ import { task, series, parallel } from 'just-task';
 import { cleanTask, tscTask, jestTask, defaultCleanPaths, tslintTask } from '../tasks';
 
 export function lib(): void {
-  task('clean', cleanTask([...defaultCleanPaths(), 'lib-commonjs']));
+  task('clean', cleanTask({ paths: [...defaultCleanPaths(), 'lib-commonjs'] }));
 
   task('ts:commonjs', tscTask({ module: 'commonjs', outDir: 'lib-commonjs' }));
   task('ts:esm', tscTask({ module: 'esnext', outDir: 'lib' }));

--- a/packages/just-scripts/src/task-presets/webapp.ts
+++ b/packages/just-scripts/src/task-presets/webapp.ts
@@ -10,7 +10,7 @@ import {
 } from '../tasks';
 
 export function webapp(): void {
-  task('clean', cleanTask([...defaultCleanPaths(), 'lib-commonjs']));
+  task('clean', cleanTask({ paths: [...defaultCleanPaths(), 'lib-commonjs'] }));
 
   task('ts:esm', tscTask({ module: 'esnext', outDir: 'lib' }));
   task('ts:watch', tscTask({ module: 'esnext', outDir: 'lib', watch: true }));

--- a/packages/just-scripts/src/tasks/__tests__/cleanTask.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/cleanTask.spec.ts
@@ -38,11 +38,4 @@ describe('cleanTask', () => {
     const removedPaths = removeSpy.mock.calls.map(call => call[0]);
     expect(removedPaths).toEqual(['build', 'output']);
   });
-
-  it('accepts paths as first argument (deprecated)', async () => {
-    const task = cleanTask(['custom-lib', 'custom-dist']);
-    await callTaskForTest(task);
-    const removedPaths = removeSpy.mock.calls.map(call => call[0]);
-    expect(removedPaths).toEqual(['custom-lib', 'custom-dist']);
-  });
 });

--- a/packages/just-scripts/src/tasks/apiExtractorTask.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTask.ts
@@ -18,11 +18,6 @@ export interface ApiExtractorOptions extends ApiExtractorTypes.IExtractorInvokeO
   configJsonFilePath?: string;
 
   /**
-   * @deprecated Update API Extractor and use option `newlineKind: 'os'`.
-   */
-  fixNewlines?: boolean;
-
-  /**
    * Callback after api-extractor is invoked.
    * @param result - Result of invoking api-extractor. Actual type is `ExtractorResult` from `@microsoft/api-extractor`.
    * @param extractorOptions - Options with which api-extractor was invoked. Actual type is `IExtractorInvokeOptions`.
@@ -47,21 +42,7 @@ interface ApiExtractorContext {
   apiExtractorModule: typeof ApiExtractorTypes;
 }
 
-export function apiExtractorVerifyTask(options: ApiExtractorOptions): TaskFunction;
-/** @deprecated Use object param version */
-export function apiExtractorVerifyTask(
-  configJsonFilePath: string,
-  extractorOptions: Omit<ApiExtractorOptions, 'configJsonFilePath'>,
-): TaskFunction;
-export function apiExtractorVerifyTask(
-  configJsonFilePathOrOption: string | ApiExtractorOptions = {},
-  extractorOptions: Omit<ApiExtractorOptions, 'configJsonFilePath'> = {},
-): TaskFunction {
-  const options =
-    typeof configJsonFilePathOrOption === 'string'
-      ? { ...extractorOptions, configJsonFilePath: configJsonFilePathOrOption }
-      : { ...configJsonFilePathOrOption };
-
+export function apiExtractorVerifyTask(options: ApiExtractorOptions): TaskFunction {
   // eslint-disable-next-line @typescript-eslint/require-await
   return async function apiExtractorVerify() {
     const context = initApiExtractor(options);
@@ -97,21 +78,7 @@ export function apiExtractorVerifyTask(
  * }
  * ```
  */
-export function apiExtractorUpdateTask(options: ApiExtractorOptions): TaskFunction;
-/** @deprecated Use object param version */
-export function apiExtractorUpdateTask(
-  configJsonFilePath: string,
-  extractorOptions: Omit<ApiExtractorOptions, 'configJsonFilePath'>,
-): TaskFunction;
-export function apiExtractorUpdateTask(
-  configJsonFilePathOrOption: string | ApiExtractorOptions = {},
-  extractorOptions: Omit<ApiExtractorOptions, 'configJsonFilePath'> = {},
-): TaskFunction {
-  const options =
-    typeof configJsonFilePathOrOption === 'string'
-      ? { ...extractorOptions, configJsonFilePath: configJsonFilePathOrOption }
-      : { ...configJsonFilePathOrOption };
-
+export function apiExtractorUpdateTask(options: ApiExtractorOptions): TaskFunction {
   // eslint-disable-next-line @typescript-eslint/require-await
   return async function apiExtractorUpdate() {
     const context = initApiExtractor(options);
@@ -158,7 +125,7 @@ function initApiExtractor(options: ApiExtractorOptions): ApiExtractorContext | u
   }
 
   const { ExtractorConfig } = apiExtractorModule;
-  const { configJsonFilePath = ExtractorConfig.FILENAME, fixNewlines, onResult, ...extractorOptions } = options;
+  const { configJsonFilePath = ExtractorConfig.FILENAME, onResult, ...extractorOptions } = options;
 
   if (!fs.existsSync(configJsonFilePath)) {
     logger.warn('Config file not found for api-extractor!');
@@ -201,11 +168,6 @@ function apiExtractorWrapper({
     options.onResult(result, extractorOptions);
   }
 
-  if (options.fixNewlines) {
-    fixApiFileNewlines(options.localBuild ? config.reportFilePath : config.reportTempFilePath, {
-      sampleFilePath: config.apiJsonFilePath,
-    });
-  }
   return result;
 }
 

--- a/packages/just-scripts/src/tasks/cleanTask.ts
+++ b/packages/just-scripts/src/tasks/cleanTask.ts
@@ -21,18 +21,8 @@ export function defaultCleanPaths(): string[] {
   return ['lib', 'temp', 'dist', 'coverage'];
 }
 
-export function cleanTask(options?: CleanTaskOptions): TaskFunction;
-/** @deprecated Use object param version */
-export function cleanTask(paths?: string[], limit?: number): TaskFunction;
-export function cleanTask(pathsOrOptions: string[] | CleanTaskOptions = {}, limit?: number): TaskFunction {
-  let paths: string[];
-  if (Array.isArray(pathsOrOptions)) {
-    paths = pathsOrOptions;
-  } else {
-    paths = pathsOrOptions.paths || defaultCleanPaths();
-    limit = limit || pathsOrOptions.limit;
-  }
-  limit = limit || 5;
+export function cleanTask(options?: CleanTaskOptions): TaskFunction {
+  const { paths = defaultCleanPaths(), limit = 5 } = options || {};
 
   return function clean(done: (err: Error | null) => void) {
     logger.info(`Removing [${paths.map(p => path.relative(process.cwd(), p)).join(', ')}]`);

--- a/packages/just-scripts/src/utils/__tests__/exec.spec.ts
+++ b/packages/just-scripts/src/utils/__tests__/exec.spec.ts
@@ -1,22 +1,10 @@
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
 import cp from 'child_process';
 import path from 'path';
-import { encodeArgs, spawn } from '../exec';
+import { spawn } from '../exec';
 import { getMockScript } from '../../__tests__/getMockScript';
 import { MockOutputStream } from '../../__tests__/MockOutputStream';
 import { fail } from 'assert';
-
-describe('encodeArgs', () => {
-  it('encodes things with spaces with double quotes', () => {
-    const args = encodeArgs(['blah blah']);
-    expect(args).toEqual(['"blah blah"']);
-  });
-
-  it('leaves normal args alone', () => {
-    const args = encodeArgs(['this-is-normal']);
-    expect(args).toEqual(['this-is-normal']);
-  });
-});
 
 describe('spawn', () => {
   const spawnSpy = jest.spyOn(cp, 'spawn');

--- a/packages/just-scripts/src/utils/exec.ts
+++ b/packages/just-scripts/src/utils/exec.ts
@@ -5,15 +5,6 @@ import { logger } from 'just-task';
 // `exec` and `execSync` were removed due to security issues (keeping filename for history)
 
 /**
- * @deprecated This prevents issues from spaces in args, but does NOT escape shell metacharacters.
- * For full escaping, consider a library such as `shell-quote` instead. (Note that `spawn` and tasks
- * from this package now use `cross-spawn` which escapes spaces internally.)
- */
-export function encodeArgs(cmdArgs: string[]): string[] {
-  return quoteSpaces(cmdArgs);
-}
-
-/**
  * Quote arguments containing spaces. Note that this does NOT do any other escaping!
  * For more complete escaping, consider a library such as `shell-quote`, or use safer APIs which
  * don't require escaping. (Note that `spawn` from this package now uses `cross-spawn` which

--- a/packages/just-task/etc/just-task.api.md
+++ b/packages/just-task/etc/just-task.api.md
@@ -72,14 +72,8 @@ export function resetResolvePaths(): void;
 // @public
 export function resolve(moduleName: string, options?: ResolveOptions): string | null;
 
-// @public @deprecated
-export function resolve(moduleName: string, cwd?: string): string | null;
-
 // @public
 export function resolveCwd(moduleName: string, options?: ResolveOptions): string | null;
-
-// @public @deprecated
-export function resolveCwd(moduleName: string, cwd?: string): string | null;
 
 // @public (undocumented)
 interface ResolveOptions {

--- a/packages/just-task/src/__tests__/resolve.spec.ts
+++ b/packages/just-task/src/__tests__/resolve.spec.ts
@@ -126,7 +126,7 @@ describe('resolveCwd', () => {
       a: { 'b.txt': '' }, // right
       'b.txt': '', // wrong
     });
-    expect(resolveCwd('b.txt', 'a')).toContain(path.join('a', 'b.txt'));
+    expect(resolveCwd('b.txt', { cwd: 'a' })).toContain(path.join('a', 'b.txt'));
   });
 
   it('ignores resolvePaths', () => {
@@ -161,7 +161,7 @@ describe('resolve', () => {
       'b.txt': '', // wrong
       c: { 'b.txt': '' },
     });
-    expect(resolve('b.txt', 'a')).toContain(path.join('a', 'b.txt'));
+    expect(resolve('b.txt', { cwd: 'a' })).toContain(path.join('a', 'b.txt'));
   });
 
   it('uses dirname of --config arg', () => {
@@ -195,7 +195,7 @@ describe('resolve', () => {
     jest.spyOn(option, 'argv').mockImplementation(() => ({ config: 'a/just-task.js' }) as any);
 
     addResolvePath('c');
-    expect(resolve('b.txt', 'd')).toContain(path.join('d', 'b.txt'));
+    expect(resolve('b.txt', { cwd: 'd' })).toContain(path.join('d', 'b.txt'));
   });
 });
 

--- a/packages/just-task/src/resolve.ts
+++ b/packages/just-task/src/resolve.ts
@@ -72,27 +72,8 @@ export function _getResolvePaths(cwd?: string): string[] {
  * @param options Resolution options, including custom cwd (defaults to `process.cwd()`)
  * @returns The module path, or null if the module can't be resolved.
  */
-export function resolve(moduleName: string, options?: ResolveOptions): string | null;
-/**
- * Resolve a module. Resolution will be tried starting from `cwd`, the location of a config file
- * passed using the `--config` command line arg, and any paths added using `addResolvePath`.
- * @deprecated Use object params signature instead.
- * @param moduleName Module name to resolve. Anything which appears to be a file name (contains .
- * and doesn't contain slashes) will be resolved relative to the working directory.
- * Other names will be resolved within node_modules.
- * @param cwd Working directory in which to start resolution. Defaults to `process.cwd()`.
- * @returns The module path, or null if the module can't be resolved.
- */
-export function resolve(moduleName: string, cwd?: string): string | null;
-export function resolve(moduleName: string, cwdOrOptions?: string | ResolveOptions): string | null {
-  let options: ResolveOptions = {};
-  if (typeof cwdOrOptions === 'string') {
-    options = { cwd: cwdOrOptions };
-  } else if (cwdOrOptions) {
-    options = cwdOrOptions;
-  }
-
-  const allResolvePaths = _getResolvePaths(options.cwd);
+export function resolve(moduleName: string, options?: ResolveOptions): string | null {
+  const allResolvePaths = _getResolvePaths(options?.cwd);
 
   for (const tryPath of allResolvePaths) {
     const resolved = _tryResolve(moduleName, { ...options, cwd: tryPath });
@@ -113,27 +94,7 @@ export function resolve(moduleName: string, cwdOrOptions?: string | ResolveOptio
  * @param options Resolution options, including custom cwd (defaults to `process.cwd()`)
  * @returns The module path, or null if the module can't be resolved.
  */
-export function resolveCwd(moduleName: string, options?: ResolveOptions): string | null;
-/**
- * Resolve a module. Resolution will *only* be tried starting from `cwd` (does not respect
- * `--config` arg or `addResolvePath`).
- * @deprecated Use object params signature instead.
- * @param moduleName Module name to resolve. Anything which appears to be a file name (contains .
- * and doesn't contain slashes) will be resolved relative to the working directory.
- * Other names will be resolved within node_modules.
- * @param cwd Working directory in which to start resolution. Defaults to `process.cwd()`.
- * @returns The module path, or null if the module can't be resolved.
- */
-export function resolveCwd(moduleName: string, cwd?: string): string | null;
-export function resolveCwd(moduleName: string, cwdOrOptions?: string | ResolveOptions): string | null {
-  let options: ResolveOptions = {};
-  if (typeof cwdOrOptions === 'string') {
-    options = { cwd: cwdOrOptions };
-  } else if (cwdOrOptions) {
-    options = cwdOrOptions;
-  }
-  if (!options.cwd) {
-    options.cwd = process.cwd();
-  }
-  return _tryResolve(moduleName, options);
+export function resolveCwd(moduleName: string, options?: ResolveOptions): string | null {
+  const cwd = options?.cwd || process.cwd();
+  return _tryResolve(moduleName, { ...options, cwd });
 }


### PR DESCRIPTION
- Remove deprecated non-object-style signatures of `apiExtractorVerifyTask`, `apiExtractorUpdateTask`, `cleanTask`, `copyTask`, and `sassTask`
- Remove deprecated `spawn` and `encodeArgs` exports (`spawn` is still used internally)
- Remove deprecated `apiExtractor*Task` `fixNewlines` option
- Remove deprecated `resolve` and `resolveCwd` signatures