### PR TITLE
Copy instructions should copy by default

### DIFF
--- a/change/change-e0d6790d-3823-4990-8bff-44914b63d4d3.json
+++ b/change/change-e0d6790d-3823-4990-8bff-44914b63d4d3.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "major",
+      "comment": "Copy instructions: revert to original behavior of copying by default. To create symlinks instead, pass `symlink: true`. Also, each copy instructions helper takes an object as parameters for clarity.",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-scripts/etc/just-scripts.api.md
+++ b/packages/just-scripts/etc/just-scripts.api.md
@@ -61,8 +61,8 @@ export interface CopyConfig {
 
 // @public
 function copyFilesInDirectory(params: Pick<CopyInstruction, 'symlink'> & {
-    sourceDirectoryPath: string;
-    outputDirectoryPath: string;
+    sourceDirectory: string;
+    destinationDirectory: string;
     filterFunction?: (file: string) => boolean;
 }): CopyInstruction[];
 
@@ -74,7 +74,7 @@ function copyFilesToDestinationDirectory(params: Pick<CopyInstruction, 'symlink'
 
 // @public
 function copyFilesToDestinationDirectoryWithRename(params: Pick<CopyInstruction, 'symlink'> & {
-    instrs: {
+    files: {
         sourceFilePath: string;
         destinationName: string;
     }[];

--- a/packages/just-scripts/etc/just-scripts.api.md
+++ b/packages/just-scripts/etc/just-scripts.api.md
@@ -60,25 +60,39 @@ export interface CopyConfig {
 }
 
 // @public
-function copyFilesInDirectory(sourceDirectoryPath: string, outputDirectoryPath: string, filterFunction?: (file: string) => boolean, noSymlinks?: boolean): CopyInstruction[];
+function copyFilesInDirectory(params: Pick<CopyInstruction, 'symlink'> & {
+    sourceDirectoryPath: string;
+    outputDirectoryPath: string;
+    filterFunction?: (file: string) => boolean;
+}): CopyInstruction[];
 
 // @public
-function copyFilesToDestinationDirectory(sourceFilePaths: string | string[], destinationDirectory: string, noSymlinks?: boolean): CopyInstruction[];
+function copyFilesToDestinationDirectory(params: Pick<CopyInstruction, 'symlink'> & {
+    sourceFilePaths: string | string[];
+    destinationDirectory: string;
+}): CopyInstruction[];
 
 // @public
-function copyFilesToDestinationDirectoryWithRename(instrs: {
+function copyFilesToDestinationDirectoryWithRename(params: Pick<CopyInstruction, 'symlink'> & {
+    instrs: {
+        sourceFilePath: string;
+        destinationName: string;
+    }[];
+    destinationDirectory: string;
+}): CopyInstruction[];
+
+// @public
+function copyFileToDestinationDirectoryWithRename(params: Pick<CopyInstruction, 'symlink'> & {
     sourceFilePath: string;
     destinationName: string;
-}[], destinationDirectory: string, noSymlinks?: boolean): CopyInstruction[];
-
-// @public
-function copyFileToDestinationDirectoryWithRename(sourceFilePath: string, destinationName: string, destinationDirectory: string, noSymlink?: boolean): CopyInstruction[];
+    destinationDirectory: string;
+}): CopyInstruction[];
 
 // @public (undocumented)
 export interface CopyInstruction {
     destinationFilePath: string;
-    noSymlink?: boolean;
     sourceFilePath: string | string[];
+    symlink?: boolean;
 }
 
 declare namespace copyInstructions {
@@ -287,7 +301,10 @@ export interface JestTaskOptions {
 function lib(): void;
 
 // @public
-function mergeFiles(sourceFilePaths: string[], destinationFilePath: string): CopyInstruction;
+function mergeFiles(params: {
+    sourceFilePaths: string[];
+    destinationFilePath: string;
+}): CopyInstruction;
 
 // @public
 export function nodeExecTask(options: NodeExecTaskOptions): TaskFunction;

--- a/packages/just-scripts/src/arrayUtils/uniqueValues.ts
+++ b/packages/just-scripts/src/arrayUtils/uniqueValues.ts
@@ -1,7 +1,0 @@
-/**
- * Removes duplicate numbers from an array
- * @param array - The array possibly containing duplicate values
- */
-export function uniqueValues<T>(array: T[]): T[] {
-  return Array.from(new Set<T>(array));
-}

--- a/packages/just-scripts/src/copy/CopyInstruction.ts
+++ b/packages/just-scripts/src/copy/CopyInstruction.ts
@@ -28,8 +28,14 @@ export interface CopyConfig {
 
 /**
  * Copies files into a destination directory with the same names.
- * For example `copyFilesToDestinationDirectory(['some/path/foo.js', 'bar.js'], 'dest/target')`
- * would result in the creation of files `dest/target/foo.js` and `dest/target/bar.js`.
+ * @example
+ * ```ts
+ * // Creates files dest/target/foo.js and dest/target/bar.js
+ * copyFilesToDestinationDirectory({
+ *   sourceFilePaths: ['some/path/foo.js', 'bar.js'],
+ *   destinationDirectory: 'dest/target'
+ * });
+ * ```
  */
 export function copyFilesToDestinationDirectory(
   params: Pick<CopyInstruction, 'symlink'> & {
@@ -47,8 +53,15 @@ export function copyFilesToDestinationDirectory(
 
 /**
  * Copies a file into a destination directory with a different name.
- * For example `copyFileToDestinationDirectoryWithRename('some/path/foo.js', 'bar.js', 'dest/target')`
- * would result in the creation of the file `dest/target/bar.js`.
+ * @example
+ * ```ts
+ * // Creates file dest/target/bar.js
+ * copyFileToDestinationDirectoryWithRename({
+ *   sourceFilePath: 'some/path/foo.js',
+ *   destinationName: 'bar.js',
+ *   destinationDirectory: 'dest/target'
+ * });
+ * ```
  */
 export function copyFileToDestinationDirectoryWithRename(
   params: Pick<CopyInstruction, 'symlink'> & {
@@ -63,17 +76,23 @@ export function copyFileToDestinationDirectoryWithRename(
 
 /**
  * Copies files into a destination directory with different names.
- * For example `copyFilesToDestinationDirectoryWithRename([{sourceFilePath:'some/path/foo.js', destinationName:'bar.js'}], 'dest/target')`
- * would result in the creation of the file `dest/target/bar.js`.
+ * @example
+ * ```ts
+ * // Creates file dest/target/bar.js
+ * copyFilesToDestinationDirectoryWithRename({
+ *   files: [{ sourceFilePath: 'some/path/foo.js', destinationName: 'bar.js' }],
+ *   destinationDirectory: 'dest/target'
+ * });
+ * ```
  */
 export function copyFilesToDestinationDirectoryWithRename(
   params: Pick<CopyInstruction, 'symlink'> & {
-    instrs: { sourceFilePath: string; destinationName: string }[];
+    files: { sourceFilePath: string; destinationName: string }[];
     destinationDirectory: string;
   },
 ): CopyInstruction[] {
-  const { instrs, destinationDirectory, symlink } = params;
-  return instrs.map(instr => ({
+  const { files, destinationDirectory, symlink } = params;
+  return files.map(instr => ({
     sourceFilePath: instr.sourceFilePath,
     destinationFilePath: path.join(destinationDirectory, instr.destinationName),
     symlink,
@@ -86,20 +105,20 @@ export function copyFilesToDestinationDirectoryWithRename(
  */
 export function copyFilesInDirectory(
   params: Pick<CopyInstruction, 'symlink'> & {
-    sourceDirectoryPath: string;
-    outputDirectoryPath: string;
+    sourceDirectory: string;
+    destinationDirectory: string;
     filterFunction?: (file: string) => boolean;
   },
 ): CopyInstruction[] {
-  const { sourceDirectoryPath, outputDirectoryPath, filterFunction, symlink } = params;
-  let files = readdirSync(sourceDirectoryPath);
+  const { sourceDirectory, destinationDirectory, filterFunction, symlink } = params;
+  let files = readdirSync(sourceDirectory);
 
   if (filterFunction) {
     files = files.filter(filterFunction);
   }
   return files.map(file => ({
-    sourceFilePath: path.join(sourceDirectoryPath, file),
-    destinationFilePath: path.join(outputDirectoryPath, file),
+    sourceFilePath: path.join(sourceDirectory, file),
+    destinationFilePath: path.join(destinationDirectory, file),
     symlink,
   }));
 }

--- a/packages/just-scripts/src/copy/CopyInstruction.ts
+++ b/packages/just-scripts/src/copy/CopyInstruction.ts
@@ -1,4 +1,4 @@
-import { join, basename, normalize } from 'path';
+import path from 'path';
 import { readdirSync } from 'fs';
 import { arrayify } from '../arrayUtils/arrayify';
 
@@ -15,11 +15,11 @@ export interface CopyInstruction {
   destinationFilePath: string;
 
   /**
-   * Set to true if a copy or merge should be performed, false if a symlink should be created.
-   * If multiple source files are specified (i.e. a merge), this must be true or undefined.
-   * The default value of undefined is equivalent to true for a merge, false in all other cases.
+   * Set to true to create symlinks rather than copying (the default is to copy).
+   *
+   * In the case of a file merge, this must be false or unset.
    */
-  noSymlink?: boolean;
+  symlink?: boolean;
 }
 
 export interface CopyConfig {
@@ -28,49 +28,55 @@ export interface CopyConfig {
 
 /**
  * Copies files into a destination directory with the same names.
- * For example copyFilesToDestinationDirectory(['some/path/foo.js', 'bar.js'], 'dest/target') would result in the creation of
- * files 'dest/target/foo.js' and 'dest/target/bar.js'.
+ * For example `copyFilesToDestinationDirectory(['some/path/foo.js', 'bar.js'], 'dest/target')`
+ * would result in the creation of files `dest/target/foo.js` and `dest/target/bar.js`.
  */
 export function copyFilesToDestinationDirectory(
-  sourceFilePaths: string | string[],
-  destinationDirectory: string,
-  noSymlinks?: boolean,
+  params: Pick<CopyInstruction, 'symlink'> & {
+    sourceFilePaths: string | string[];
+    destinationDirectory: string;
+  },
 ): CopyInstruction[] {
+  const { sourceFilePaths, destinationDirectory, symlink } = params;
   return arrayify(sourceFilePaths).map(sourceName => ({
-    sourceFilePath: normalize(sourceName),
-    destinationFilePath: join(destinationDirectory, basename(sourceName)),
-    noSymlink: noSymlinks,
+    sourceFilePath: path.normalize(sourceName),
+    destinationFilePath: path.join(destinationDirectory, path.basename(sourceName)),
+    symlink,
   }));
 }
 
 /**
  * Copies a file into a destination directory with a different name.
- * For example copyFileToDestinationDirectoryWithRename('some/path/foo.js', 'bar.js', 'dest/target') would result in the creation of
- * the file 'dest/target/bar.js'.
+ * For example `copyFileToDestinationDirectoryWithRename('some/path/foo.js', 'bar.js', 'dest/target')`
+ * would result in the creation of the file `dest/target/bar.js`.
  */
 export function copyFileToDestinationDirectoryWithRename(
-  sourceFilePath: string,
-  destinationName: string,
-  destinationDirectory: string,
-  noSymlink?: boolean,
+  params: Pick<CopyInstruction, 'symlink'> & {
+    sourceFilePath: string;
+    destinationName: string;
+    destinationDirectory: string;
+  },
 ): CopyInstruction[] {
-  return [{ sourceFilePath, destinationFilePath: join(destinationDirectory, destinationName), noSymlink }];
+  const { sourceFilePath, destinationName, destinationDirectory, symlink } = params;
+  return [{ sourceFilePath, destinationFilePath: path.join(destinationDirectory, destinationName), symlink }];
 }
 
 /**
  * Copies files into a destination directory with different names.
  * For example `copyFilesToDestinationDirectoryWithRename([{sourceFilePath:'some/path/foo.js', destinationName:'bar.js'}], 'dest/target')`
- * would result in the creation of the file 'dest/target/bar.js'.
+ * would result in the creation of the file `dest/target/bar.js`.
  */
 export function copyFilesToDestinationDirectoryWithRename(
-  instrs: { sourceFilePath: string; destinationName: string }[],
-  destinationDirectory: string,
-  noSymlinks?: boolean,
+  params: Pick<CopyInstruction, 'symlink'> & {
+    instrs: { sourceFilePath: string; destinationName: string }[];
+    destinationDirectory: string;
+  },
 ): CopyInstruction[] {
+  const { instrs, destinationDirectory, symlink } = params;
   return instrs.map(instr => ({
     sourceFilePath: instr.sourceFilePath,
-    destinationFilePath: join(destinationDirectory, instr.destinationName),
-    noSymlink: noSymlinks,
+    destinationFilePath: path.join(destinationDirectory, instr.destinationName),
+    symlink,
   }));
 }
 
@@ -79,20 +85,22 @@ export function copyFilesToDestinationDirectoryWithRename(
  * You can optionally provide a filter function that determines which files to copy.
  */
 export function copyFilesInDirectory(
-  sourceDirectoryPath: string,
-  outputDirectoryPath: string,
-  filterFunction?: (file: string) => boolean,
-  noSymlinks?: boolean,
+  params: Pick<CopyInstruction, 'symlink'> & {
+    sourceDirectoryPath: string;
+    outputDirectoryPath: string;
+    filterFunction?: (file: string) => boolean;
+  },
 ): CopyInstruction[] {
+  const { sourceDirectoryPath, outputDirectoryPath, filterFunction, symlink } = params;
   let files = readdirSync(sourceDirectoryPath);
 
   if (filterFunction) {
     files = files.filter(filterFunction);
   }
   return files.map(file => ({
-    sourceFilePath: join(sourceDirectoryPath, file),
-    destinationFilePath: join(outputDirectoryPath, file),
-    noSymlink: noSymlinks,
+    sourceFilePath: path.join(sourceDirectoryPath, file),
+    destinationFilePath: path.join(outputDirectoryPath, file),
+    symlink,
   }));
 }
 
@@ -101,7 +109,8 @@ export function copyFilesInDirectory(
  * This should only be used for text files and it should not be used for JavaScript
  * files that we care about the sourcemap information since this does not merge sourcemaps.
  */
-export function mergeFiles(sourceFilePaths: string[], destinationFilePath: string): CopyInstruction {
+export function mergeFiles(params: { sourceFilePaths: string[]; destinationFilePath: string }): CopyInstruction {
+  const { sourceFilePaths, destinationFilePath } = params;
   return {
     sourceFilePath: sourceFilePaths,
     destinationFilePath,

--- a/packages/just-scripts/src/copy/__tests__/CopyInstruction.spec.ts
+++ b/packages/just-scripts/src/copy/__tests__/CopyInstruction.spec.ts
@@ -107,7 +107,7 @@ describe('CopyInstruction tests', () => {
   describe('copyFilesToDestinationDirectoryWithRename', () => {
     it('renames multiple files into the destination directory', () => {
       const result = copyFilesToDestinationDirectoryWithRename({
-        instrs: [
+        files: [
           { sourceFilePath: 'src/foo.js', destinationName: 'foo-renamed.js' },
           { sourceFilePath: 'src/bar.js', destinationName: 'bar-renamed.js' },
         ],
@@ -122,7 +122,7 @@ describe('CopyInstruction tests', () => {
 
     it('returns an empty array when given no instructions', () => {
       const result = copyFilesToDestinationDirectoryWithRename({
-        instrs: [],
+        files: [],
         destinationDirectory: 'dest/target',
       });
 
@@ -131,7 +131,7 @@ describe('CopyInstruction tests', () => {
 
     it('propagates the symlink flag onto each instruction', () => {
       const result = copyFilesToDestinationDirectoryWithRename({
-        instrs: [
+        files: [
           { sourceFilePath: 'src/foo.js', destinationName: 'foo-renamed.js' },
           { sourceFilePath: 'src/bar.js', destinationName: 'bar-renamed.js' },
         ],
@@ -160,8 +160,8 @@ describe('CopyInstruction tests', () => {
 
     it('returns instructions for every file in the source directory', () => {
       const result = copyFilesInDirectory({
-        sourceDirectoryPath: sourceDir,
-        outputDirectoryPath: destDir,
+        sourceDirectory: sourceDir,
+        destinationDirectory: destDir,
       }).sort(sortBySource);
 
       expect(result).toEqual([
@@ -173,8 +173,8 @@ describe('CopyInstruction tests', () => {
 
     it('applies the filter function when provided', () => {
       const result = copyFilesInDirectory({
-        sourceDirectoryPath: sourceDir,
-        outputDirectoryPath: destDir,
+        sourceDirectory: sourceDir,
+        destinationDirectory: destDir,
         filterFunction: file => file.endsWith('.js'),
       }).sort(sortBySource);
 
@@ -186,8 +186,8 @@ describe('CopyInstruction tests', () => {
 
     it('propagates the symlink flag onto each instruction', () => {
       const result = copyFilesInDirectory({
-        sourceDirectoryPath: sourceDir,
-        outputDirectoryPath: destDir,
+        sourceDirectory: sourceDir,
+        destinationDirectory: destDir,
         symlink: true,
       }).sort(sortBySource);
 
@@ -212,8 +212,8 @@ describe('CopyInstruction tests', () => {
 
     it('returns an empty array when the filter excludes everything', () => {
       const result = copyFilesInDirectory({
-        sourceDirectoryPath: sourceDir,
-        outputDirectoryPath: destDir,
+        sourceDirectory: sourceDir,
+        destinationDirectory: destDir,
         filterFunction: () => false,
       });
 

--- a/packages/just-scripts/src/copy/__tests__/CopyInstruction.spec.ts
+++ b/packages/just-scripts/src/copy/__tests__/CopyInstruction.spec.ts
@@ -1,15 +1,237 @@
-import { describe, expect, it } from '@jest/globals';
-import { copyFilesToDestinationDirectory } from '../CopyInstruction';
-import { normalize } from 'path';
+import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
+import mockfs from 'mock-fs';
+import path from 'path';
+import {
+  copyFilesToDestinationDirectory,
+  copyFileToDestinationDirectoryWithRename,
+  copyFilesToDestinationDirectoryWithRename,
+  copyFilesInDirectory,
+  mergeFiles,
+  type CopyInstruction,
+} from '../CopyInstruction';
 
 describe('CopyInstruction tests', () => {
-  it('copies files with the same name to the target directory', () => {
-    const result = copyFilesToDestinationDirectory(['files/foo.js', 'my/path/bar.js'], 'dist/lib/');
+  const sourceDir = 'sourceDir';
+  const destDir = 'dist/lib';
 
-    expect(result.length).toEqual(2);
-    expect(result[0].sourceFilePath).toEqual(normalize('files/foo.js'));
-    expect(result[0].destinationFilePath).toEqual(normalize('dist/lib/foo.js'));
-    expect(result[1].sourceFilePath).toEqual(normalize('my/path/bar.js'));
-    expect(result[1].destinationFilePath).toEqual(normalize('dist/lib/bar.js'));
+  beforeEach(() => {
+    mockfs({
+      [sourceDir]: {
+        'foo.js': 'foo contents',
+        'bar.js': 'bar contents',
+        'baz.txt': 'baz contents',
+      },
+      'files/foo.js': 'foo',
+      'my/path/bar.js': 'bar',
+      [destDir]: {},
+    });
+  });
+
+  afterEach(() => {
+    mockfs.restore();
+  });
+
+  describe('copyFilesToDestinationDirectory', () => {
+    it('copies files with the same name to the target directory', () => {
+      const result = copyFilesToDestinationDirectory({
+        sourceFilePaths: ['files/foo.js', 'my/path/bar.js'],
+        destinationDirectory: 'dist/lib/',
+      });
+
+      expect(result).toEqual([
+        { sourceFilePath: path.normalize('files/foo.js'), destinationFilePath: path.normalize('dist/lib/foo.js') },
+        { sourceFilePath: path.normalize('my/path/bar.js'), destinationFilePath: path.normalize('dist/lib/bar.js') },
+      ]);
+    });
+
+    it('accepts a single source file path string', () => {
+      const result = copyFilesToDestinationDirectory({
+        sourceFilePaths: 'files/foo.js',
+        destinationDirectory: 'dist/lib/',
+      });
+
+      expect(result).toEqual([
+        { sourceFilePath: path.normalize('files/foo.js'), destinationFilePath: path.normalize('dist/lib/foo.js') },
+      ]);
+    });
+
+    it('propagates the symlink flag onto each instruction', () => {
+      const result = copyFilesToDestinationDirectory({
+        sourceFilePaths: ['files/foo.js', 'my/path/bar.js'],
+        destinationDirectory: 'dist/lib/',
+        symlink: true,
+      });
+
+      expect(result).toEqual([
+        {
+          sourceFilePath: path.normalize('files/foo.js'),
+          destinationFilePath: path.normalize('dist/lib/foo.js'),
+          symlink: true,
+        },
+        {
+          sourceFilePath: path.normalize('my/path/bar.js'),
+          destinationFilePath: path.normalize('dist/lib/bar.js'),
+          symlink: true,
+        },
+      ]);
+    });
+  });
+
+  describe('copyFileToDestinationDirectoryWithRename', () => {
+    it('renames a single file into the destination directory', () => {
+      const result = copyFileToDestinationDirectoryWithRename({
+        sourceFilePath: 'some/path/foo.js',
+        destinationName: 'bar.js',
+        destinationDirectory: 'dest/target',
+      });
+
+      expect(result).toEqual([
+        { sourceFilePath: 'some/path/foo.js', destinationFilePath: path.join('dest/target', 'bar.js') },
+      ]);
+    });
+
+    it('propagates the symlink flag', () => {
+      const result = copyFileToDestinationDirectoryWithRename({
+        sourceFilePath: 'some/path/foo.js',
+        destinationName: 'bar.js',
+        destinationDirectory: 'dest/target',
+        symlink: true,
+      });
+
+      expect(result).toEqual([
+        { sourceFilePath: 'some/path/foo.js', destinationFilePath: path.join('dest/target', 'bar.js'), symlink: true },
+      ]);
+    });
+  });
+
+  describe('copyFilesToDestinationDirectoryWithRename', () => {
+    it('renames multiple files into the destination directory', () => {
+      const result = copyFilesToDestinationDirectoryWithRename({
+        instrs: [
+          { sourceFilePath: 'src/foo.js', destinationName: 'foo-renamed.js' },
+          { sourceFilePath: 'src/bar.js', destinationName: 'bar-renamed.js' },
+        ],
+        destinationDirectory: 'dest/target',
+      });
+
+      expect(result).toEqual([
+        { sourceFilePath: 'src/foo.js', destinationFilePath: path.join('dest/target', 'foo-renamed.js') },
+        { sourceFilePath: 'src/bar.js', destinationFilePath: path.join('dest/target', 'bar-renamed.js') },
+      ]);
+    });
+
+    it('returns an empty array when given no instructions', () => {
+      const result = copyFilesToDestinationDirectoryWithRename({
+        instrs: [],
+        destinationDirectory: 'dest/target',
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('propagates the symlink flag onto each instruction', () => {
+      const result = copyFilesToDestinationDirectoryWithRename({
+        instrs: [
+          { sourceFilePath: 'src/foo.js', destinationName: 'foo-renamed.js' },
+          { sourceFilePath: 'src/bar.js', destinationName: 'bar-renamed.js' },
+        ],
+        destinationDirectory: 'dest/target',
+        symlink: true,
+      });
+
+      expect(result).toEqual([
+        {
+          sourceFilePath: 'src/foo.js',
+          destinationFilePath: path.join('dest/target', 'foo-renamed.js'),
+          symlink: true,
+        },
+        {
+          sourceFilePath: 'src/bar.js',
+          destinationFilePath: path.join('dest/target', 'bar-renamed.js'),
+          symlink: true,
+        },
+      ]);
+    });
+  });
+
+  describe('copyFilesInDirectory', () => {
+    const sortBySource = (a: CopyInstruction, b: CopyInstruction) =>
+      String(a.sourceFilePath).localeCompare(String(b.sourceFilePath));
+
+    it('returns instructions for every file in the source directory', () => {
+      const result = copyFilesInDirectory({
+        sourceDirectoryPath: sourceDir,
+        outputDirectoryPath: destDir,
+      }).sort(sortBySource);
+
+      expect(result).toEqual([
+        { sourceFilePath: path.join(sourceDir, 'bar.js'), destinationFilePath: path.join(destDir, 'bar.js') },
+        { sourceFilePath: path.join(sourceDir, 'baz.txt'), destinationFilePath: path.join(destDir, 'baz.txt') },
+        { sourceFilePath: path.join(sourceDir, 'foo.js'), destinationFilePath: path.join(destDir, 'foo.js') },
+      ]);
+    });
+
+    it('applies the filter function when provided', () => {
+      const result = copyFilesInDirectory({
+        sourceDirectoryPath: sourceDir,
+        outputDirectoryPath: destDir,
+        filterFunction: file => file.endsWith('.js'),
+      }).sort(sortBySource);
+
+      expect(result).toEqual([
+        { sourceFilePath: path.join(sourceDir, 'bar.js'), destinationFilePath: path.join(destDir, 'bar.js') },
+        { sourceFilePath: path.join(sourceDir, 'foo.js'), destinationFilePath: path.join(destDir, 'foo.js') },
+      ]);
+    });
+
+    it('propagates the symlink flag onto each instruction', () => {
+      const result = copyFilesInDirectory({
+        sourceDirectoryPath: sourceDir,
+        outputDirectoryPath: destDir,
+        symlink: true,
+      }).sort(sortBySource);
+
+      expect(result).toEqual([
+        {
+          sourceFilePath: path.join(sourceDir, 'bar.js'),
+          destinationFilePath: path.join(destDir, 'bar.js'),
+          symlink: true,
+        },
+        {
+          sourceFilePath: path.join(sourceDir, 'baz.txt'),
+          destinationFilePath: path.join(destDir, 'baz.txt'),
+          symlink: true,
+        },
+        {
+          sourceFilePath: path.join(sourceDir, 'foo.js'),
+          destinationFilePath: path.join(destDir, 'foo.js'),
+          symlink: true,
+        },
+      ]);
+    });
+
+    it('returns an empty array when the filter excludes everything', () => {
+      const result = copyFilesInDirectory({
+        sourceDirectoryPath: sourceDir,
+        outputDirectoryPath: destDir,
+        filterFunction: () => false,
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('mergeFiles', () => {
+    it('returns a single instruction with all source file paths', () => {
+      const result = mergeFiles({
+        sourceFilePaths: ['a.js', 'b.js', 'c.js'],
+        destinationFilePath: 'dest/merged.js',
+      });
+
+      expect(result).toEqual({
+        sourceFilePath: ['a.js', 'b.js', 'c.js'],
+        destinationFilePath: 'dest/merged.js',
+      });
+    });
   });
 });

--- a/packages/just-scripts/src/copy/__tests__/executeCopyInstructions.spec.ts
+++ b/packages/just-scripts/src/copy/__tests__/executeCopyInstructions.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
 import mockfs from 'mock-fs';
 import path from 'path';
 import fs from 'fs';
-// import { dirSync, fileSync, DirResult, FileResult } from 'tmp';
 import { executeCopyInstructions } from '../executeCopyInstructions';
 import type { CopyInstruction } from '../CopyInstruction';
 
@@ -36,6 +35,7 @@ describe('executeCopyInstructions functional tests', () => {
     const copyInstruction: CopyInstruction = {
       sourceFilePath: sourceFilePath1,
       destinationFilePath: destFilePath,
+      symlink: true,
     };
 
     expect(fs.existsSync(destFilePath)).toBeFalsy();
@@ -53,7 +53,6 @@ describe('executeCopyInstructions functional tests', () => {
     const copyInstruction: CopyInstruction = {
       sourceFilePath: [sourceFilePath1],
       destinationFilePath: destFilePath,
-      noSymlink: true,
     };
 
     expect(fs.existsSync(destFilePath)).toBeFalsy();
@@ -90,7 +89,7 @@ describe('executeCopyInstructions functional tests', () => {
     const copyInstruction: CopyInstruction = {
       sourceFilePath: [sourceFilePath1, sourceFilePath2],
       destinationFilePath: destFilePath,
-      noSymlink: false,
+      symlink: true,
     };
 
     const promise = executeCopyInstructions({

--- a/packages/just-scripts/src/copy/executeCopyInstructions.ts
+++ b/packages/just-scripts/src/copy/executeCopyInstructions.ts
@@ -2,7 +2,6 @@ import { dirname, resolve } from 'path';
 import { readFile, writeFile, copy, ensureDir, ensureSymlink } from 'fs-extra';
 import type { CopyInstruction, CopyConfig } from './CopyInstruction';
 import { arrayify } from '../arrayUtils/arrayify';
-import { uniqueValues } from '../arrayUtils/uniqueValues';
 
 /**
  * Function containing the core code for the copy task with a given config.
@@ -17,32 +16,29 @@ export async function executeCopyInstructions(config: CopyConfig | undefined): P
 
 function validateConfig(copyInstructions: CopyInstruction[]) {
   copyInstructions.forEach(instr => {
-    if (instr.noSymlink === false && Array.isArray(instr.sourceFilePath) && instr.sourceFilePath.length > 1) {
+    if (instr.symlink && Array.isArray(instr.sourceFilePath) && instr.sourceFilePath.length > 1) {
       throw new Error('Multiple source files cannot be specified when making a symlink');
     }
   });
 }
 
 function createDirectories(copyInstructions: CopyInstruction[]) {
-  return Promise.all(
-    uniqueValues(copyInstructions.map(instruction => dirname(instruction.destinationFilePath))).map(d => ensureDir(d)),
-  );
+  const directories = new Set(copyInstructions.map(instruction => dirname(instruction.destinationFilePath)));
+  return Promise.all([...directories].map(d => ensureDir(d)));
 }
 
-function executeSingleCopyInstruction(copyInstruction: CopyInstruction) {
+async function executeSingleCopyInstruction(copyInstruction: CopyInstruction) {
   const sourceFileNames = arrayify(copyInstruction.sourceFilePath);
 
   // source and dest are 1-to-1?  perform binary copy or symlink as desired.
   if (sourceFileNames.length === 1) {
-    if (copyInstruction.noSymlink) {
-      return copy(sourceFileNames[0], copyInstruction.destinationFilePath);
-    } else {
+    if (copyInstruction.symlink) {
       return ensureSymlink(resolve(sourceFileNames[0]), copyInstruction.destinationFilePath);
     }
+    return copy(sourceFileNames[0], copyInstruction.destinationFilePath);
   }
 
   // perform text merge operation.
-  return Promise.all(sourceFileNames.map(fileName => readFile(fileName))).then(fileContents => {
-    return writeFile(copyInstruction.destinationFilePath, fileContents.join('\n'));
-  });
+  const sourceFiles = await Promise.all(sourceFileNames.map(fileName => readFile(fileName)));
+  return writeFile(copyInstruction.destinationFilePath, sourceFiles.join('\n'));
 }


### PR DESCRIPTION
Reverts the behavior change from #584 / `just-scripts` v2. This restores the default behavior to match the function name.

To create symlinks, you can now pass `symlink: true`.

Each copy instructions creation function has also been updated to take an object as parameters for clarity, instead of a sequence of named params.