### PR TITLE
Remove unused dependencies `prompts` and `diff-match-patch`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,14 +37,20 @@ jobs:
       - run: yarn format:check
         if: ${{ matrix.os == 'ubuntu-latest' }}
 
-      - run: yarn lint
+      - name: build
+        run: yarn lage build api --verbose
 
-      - run: yarn lage build test api --verbose
+      - name: lint
+        run: yarn lint --verbose
+
+      - name: test
+        run: yarn test --verbose
 
       - name: Check for modified files
         uses: microsoft/beachball-actions/check-for-modified-files@cf7d34819ad50dce8894b3ff99a2a7899aefee3d # v3
 
-  # The docs have a separate installation using Node 22 due to needing newer dependencies
+  # The docs have a separate installation (previously required for newer Node version, but still
+  # helpful for keeping dependencies separate)
   docs:
     name: build docs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ jobs:
 
       - run: yarn --immutable
 
-      - run: yarn checkchange
-
       - run: yarn lage build test
 
       # TODO (release): switch back to regular release

--- a/change/change-979d66fc-d7af-4cf2-ab32-d1e4e6c74a7a.json
+++ b/change/change-979d66fc-d7af-4cf2-ab32-d1e4e6c74a7a.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Remove unused dependencies `prompts` and `diff-match-patch`",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-scripts/package.json
+++ b/packages/just-scripts/package.json
@@ -29,11 +29,9 @@
   "dependencies": {
     "chalk": "^4.0.0",
     "cross-spawn": "^7.0.6",
-    "diff-match-patch": "1.0.5",
     "fs-extra": "^11.0.0",
     "glob": "^13.0.6",
     "just-task": "workspace:^",
-    "prompts": "^2.4.0",
     "run-parallel-limit": "^1.0.6",
     "semver": "^7.8.1",
     "supports-color": "^8.1.0",
@@ -42,8 +40,6 @@
   "devDependencies": {
     "@microsoft/just-internal-scripts": "workspace:^",
     "@types/cross-spawn": "^6.0.6",
-    "@types/diff-match-patch": "^1.0.32",
-    "@types/prompts": "^2.4.2",
     "@types/run-parallel-limit": "^1.0.0",
     "@types/supports-color": "^8.1.1",
     "@types/webpack": "^4.41.33",

--- a/scripts/tsconfig.base.json
+++ b/scripts/tsconfig.base.json
@@ -17,6 +17,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "skipLibCheck": true,
+    "esModuleInterop": true,
     "lib": ["ES2024"],
     "types": ["node"]
   }

--- a/syncpack.config.js
+++ b/syncpack.config.js
@@ -1,13 +1,12 @@
 // @ts-check
 
-// https://jamiemason.github.io/syncpack/
+// https://syncpack.dev/
 /** @type {import('syncpack').RcFile} */
 const config = {
   versionGroups: [
     {
-      // Peer deps must only match each other
-      label: 'peer deps',
-      dependencies: ['**'],
+      // These are intentionally broader ranges than the devDependencies
+      label: 'Optional peer deps',
       dependencyTypes: ['peer'],
     },
   ],
@@ -20,3 +19,5 @@ const config = {
     },
   ],
 };
+
+module.exports = config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1418,13 +1418,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/diff-match-patch@npm:^1.0.32":
-  version: 1.0.36
-  resolution: "@types/diff-match-patch@npm:1.0.36"
-  checksum: 10c0/0bad011ab138baa8bde94e7815064bb881f010452463272644ddbbb0590659cb93f7aa2776ff442c6721d70f202839e1053f8aa62d801cc4166f7a3ea9130055
-  languageName: node
-  linkType: hard
-
 "@types/esrecurse@npm:^4.3.1":
   version: 4.3.1
   resolution: "@types/esrecurse@npm:4.3.1"
@@ -1514,16 +1507,6 @@ __metadata:
   dependencies:
     parse-path: "npm:*"
   checksum: 10c0/3e45c79a33582ba126250190cc00e939edbbe9f19f9772b41905ee391bb7190387129b0999295c21bad20e5a60b945ea7c5e53cec559f988a14c071639730af0
-  languageName: node
-  linkType: hard
-
-"@types/prompts@npm:^2.4.2":
-  version: 2.4.9
-  resolution: "@types/prompts@npm:2.4.9"
-  dependencies:
-    "@types/node": "npm:*"
-    kleur: "npm:^3.0.3"
-  checksum: 10c0/22fe0da6807681c85e88ba283184f4be4c8a95c744ea12a638865c98c4e0c22e7f733542f6b0f1fbca02245cdc3fe84feacf9c9adf4ddd8bc98a337fd679d8d2
   languageName: node
   linkType: hard
 
@@ -2635,13 +2618,6 @@ __metadata:
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
   checksum: 10c0/c38cfc8eeb9fda09febb44bcd85e467c970d4e3bf526095394e5a4f18bc26dd0cf6b22c69c1fa9969261521c593836db335c2795218f6d781a512aea2fb8209d
-  languageName: node
-  linkType: hard
-
-"diff-match-patch@npm:1.0.5":
-  version: 1.0.5
-  resolution: "diff-match-patch@npm:1.0.5"
-  checksum: 10c0/142b6fad627b9ef309d11bd935e82b84c814165a02500f046e2773f4ea894d10ed3017ac20454900d79d4a0322079f5b713cf0986aaf15fce0ec4a2479980c86
   languageName: node
   linkType: hard
 
@@ -4291,20 +4267,16 @@ __metadata:
   dependencies:
     "@microsoft/just-internal-scripts": "workspace:^"
     "@types/cross-spawn": "npm:^6.0.6"
-    "@types/diff-match-patch": "npm:^1.0.32"
-    "@types/prompts": "npm:^2.4.2"
     "@types/run-parallel-limit": "npm:^1.0.0"
     "@types/supports-color": "npm:^8.1.1"
     "@types/webpack": "npm:^4.41.33"
     async-done: "npm:^2.0.0"
     chalk: "npm:^4.0.0"
     cross-spawn: "npm:^7.0.6"
-    diff-match-patch: "npm:1.0.5"
     esbuild: "npm:^0.28.0"
     fs-extra: "npm:^11.0.0"
     glob: "npm:^13.0.6"
     just-task: "workspace:^"
-    prompts: "npm:^2.4.0"
     run-parallel-limit: "npm:^1.0.6"
     semver: "npm:^7.8.1"
     supports-color: "npm:^8.1.0"
@@ -4993,7 +4965,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prompts@npm:^2.4.0, prompts@npm:^2.4.2":
+"prompts@npm:^2.4.2":
   version: 2.4.2
   resolution: "prompts@npm:2.4.2"
   dependencies:


### PR DESCRIPTION
For some reason `just-scripts` had dependencies on `prompts` and `diff-match-patch` which are totally unused, so remove them.

Also fix a couple config issues.