### PR TITLE
Webpack, eslint, jest, prettier task updates

### DIFF
--- a/change/change-1df15b40-e888-4e07-9f77-e1c5e0d2abfd.json
+++ b/change/change-1df15b40-e888-4e07-9f77-e1c5e0d2abfd.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "`eslintTask`: look for all valid config extensions and flat config files",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-6ccc99ae-7c7a-4e46-8130-ba3c5b344758.json
+++ b/change/change-6ccc99ae-7c7a-4e46-8130-ba3c5b344758.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Webpack `stylesOverlay`: check for `sass` in addition to `node-sass` when determining if Sass is available",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-791e88ff-47e4-4e4e-ba78-a4c8ab7ab286.json
+++ b/change/change-791e88ff-47e4-4e4e-ba78-a4c8ab7ab286.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "major",
+      "comment": "Webpack tasks: only support `webpack` and `webpack-cli` 5+",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-8fb986a3-0e62-45ee-965c-de96b810de6f.json
+++ b/change/change-8fb986a3-0e62-45ee-965c-de96b810de6f.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "`jestTask`: look for all valid config extensions",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@types/fs-extra": "^11.0.0",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^22.0.0",
-    "@types/semver": "^7.7.1",
     "beachball": "^2.65.5",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.0.0",

--- a/packages/just-scripts/package.json
+++ b/packages/just-scripts/package.json
@@ -33,7 +33,6 @@
     "glob": "^13.0.6",
     "just-task": "workspace:^",
     "run-parallel-limit": "^1.0.6",
-    "semver": "^7.8.1",
     "supports-color": "^8.1.0",
     "webpack-merge": "^6.0.1"
   },

--- a/packages/just-scripts/src/tasks/__tests__/eslintTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/eslintTask.mock.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
 import mockfs from 'mock-fs';
 import { spawn } from '../../utils';
-import { eslintTask } from '../eslintTask';
+import { eslintTask, type EsLintTaskOptions } from '../eslintTask';
 import { callTaskForTest } from './callTaskForTest';
 import { getNormalizedSpawnArgs } from './getNormalizedSpawnArgs';
 
@@ -105,16 +105,21 @@ describe('eslintTask (mocked)', () => {
   });
 
   describe('config file detection', () => {
-    it('detects .eslintrc.js', async () => {
+    it.each([
+      '.eslintrc',
+      '.eslintrc.cjs',
+      '.eslintrc.json',
+      'eslint.config.js',
+      'eslint.config.mjs',
+      'eslint.config.ts',
+    ])('detects %s', async name => {
       mockfs({
         ...mockFsEslint(),
-        '.eslintrc.js': 'a file',
+        [name]: 'a file',
       });
       const task = eslintTask();
       await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(
-        expect.arrayContaining(['--config', '${packageRoot}/.eslintrc.js']),
-      );
+      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--config', '${packageRoot}/' + name]));
     });
 
     it('uses custom configPath', async () => {
@@ -129,63 +134,35 @@ describe('eslintTask (mocked)', () => {
   });
 
   describe('CLI options', () => {
-    it('passes --fix', async () => {
-      const task = eslintTask({ fix: true });
+    // Any new options not directly passed as CLI flags should be added to the omitted values
+    type CliOptions = Omit<EsLintTaskOptions, 'files' | 'configPath' | 'timing' | 'useFlatConfig'>;
+
+    // Verify each relevant option is passed through to the CLI (it's been an issue in the past)
+    const cliFlags: {
+      [K in keyof Required<CliOptions>]: { flag: string; value?: EsLintTaskOptions[K] };
+    } = {
+      ignorePath: { flag: '--ignore-path', value: '.gitignore' },
+      resolvePluginsPath: { flag: '--resolve-plugins-relative-to', value: 'foo' },
+      fix: { flag: '--fix' },
+      extensions: { flag: '--ext', value: '.js,.jsx,.ts,.tsx' },
+      noEslintRc: { flag: '--no-eslintrc' },
+      maxWarnings: { flag: '--max-warnings', value: 0 },
+      cache: { flag: '--cache' },
+      cacheLocation: { flag: '--cache-location', value: '.cache/eslint' },
+      outputFile: { flag: '--output-file', value: 'eslint-report.json' },
+      format: { flag: '--format', value: 'json' },
+      quiet: { flag: '--quiet' },
+      reportUnusedDisableDirectives: { flag: '--report-unused-disable-directives' },
+    };
+
+    it.each(Object.keys(cliFlags))('passes %s to CLI', async opt => {
+      const { flag, value } = cliFlags[opt as keyof typeof cliFlags];
+      const task = eslintTask({ [opt]: value === undefined ? true : value });
       await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--fix']));
+      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(value ? [flag, String(value)] : [flag]));
     });
 
-    it('passes --max-warnings', async () => {
-      const task = eslintTask({ maxWarnings: 0 });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--max-warnings', '0']));
-    });
-
-    it('passes --cache', async () => {
-      const task = eslintTask({ cache: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--cache']));
-    });
-
-    it('passes --cache-location', async () => {
-      const task = eslintTask({ cacheLocation: '.cache/eslint' });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--cache-location', '.cache/eslint']));
-    });
-
-    it('passes --output-file', async () => {
-      const task = eslintTask({ outputFile: 'eslint-report.json' });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(
-        expect.arrayContaining(['--output-file', 'eslint-report.json']),
-      );
-    });
-
-    it('passes --format', async () => {
-      const task = eslintTask({ format: 'json' });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--format', 'json']));
-    });
-
-    it('passes --quiet', async () => {
-      const task = eslintTask({ quiet: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--quiet']));
-    });
-
-    it('passes --no-eslintrc', async () => {
-      const task = eslintTask({ noEslintRc: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--no-eslintrc']));
-    });
-
-    it('passes --report-unused-disable-directives', async () => {
-      const task = eslintTask({ reportUnusedDisableDirectives: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--report-unused-disable-directives']));
-    });
-
-    it('passes --ignore-path', async () => {
+    it('detects .eslintignore and passes as --ignore-path', async () => {
       mockfs({
         ...mockFsEslint(),
         '.eslintrc.json': 'a file',

--- a/packages/just-scripts/src/tasks/__tests__/jestTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/jestTask.mock.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
 import mockfs from 'mock-fs';
 import { spawn } from '../../utils';
-import { jestTask } from '../jestTask';
+import { jestTask, type JestTaskOptions } from '../jestTask';
 import { callTaskForTest } from './callTaskForTest';
 import { getNormalizedSpawnArgs } from './getNormalizedSpawnArgs';
 
@@ -99,6 +99,22 @@ describe('jestTask (mocked)', () => {
       expect(getNormalizedSpawnArgs(mockSpawn)).toEqual([...mockJestArgs, '--colors']);
     });
 
+    it.each(['js', 'cjs', 'mjs', 'ts'])('finds jest.config.%s', async ext => {
+      const configFile = `jest.config.${ext}`;
+      mockfs({
+        ...mockFsJest(),
+        [configFile]: 'a file',
+      });
+      const task = jestTask();
+      await callTaskForTest(task);
+      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual([
+        ...mockJestArgs,
+        '--config',
+        `\${packageRoot}/${configFile}`,
+        '--colors',
+      ]);
+    });
+
     it('uses custom config option', async () => {
       mockfs({
         ...mockFsJest(),
@@ -116,96 +132,39 @@ describe('jestTask (mocked)', () => {
   });
 
   describe('CLI options', () => {
-    it('passes --coverage', async () => {
-      const task = jestTask({ coverage: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--coverage']));
-    });
+    // Any new options not directly passed as CLI flags (or options tested elsewhere with more
+    // detailed fixtures) should be added to the omitted values. Otherwise, add a test below.
+    type CliOptions = Omit<JestTaskOptions, 'config' | 'env' | 'nodeArgs' | '_'>;
 
-    it('passes --watch', async () => {
-      const task = jestTask({ watch: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--watch']));
-    });
+    // Verify each relevant option is passed through to the CLI (it's been an issue in the past).
+    // Flags with different names should specify `flag`.
+    // Boolean flags should have undefined values.
+    const cliFlags: {
+      [K in keyof Required<CliOptions>]: { flag?: string; value?: JestTaskOptions[K] };
+    } = {
+      rootDir: { value: 'src' },
+      runInBand: {},
+      coverage: {},
+      updateSnapshot: {},
+      u: { flag: '--updateSnapshot' },
+      watch: {},
+      colors: {},
+      passWithNoTests: {},
+      clearCache: {},
+      silent: {},
+      testPathPattern: { value: '**/*' },
+      testPathPatterns: { value: '**/*' },
+      testNamePattern: { value: 'foo' },
+      maxWorkers: { value: 4 },
+    };
 
-    it('passes --runInBand', async () => {
-      const task = jestTask({ runInBand: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--runInBand']));
-    });
+    it.each(Object.keys(cliFlags))('passes %s to CLI', async opt => {
+      const flagInfo = cliFlags[opt as keyof typeof cliFlags];
+      const { flag = `--${opt}`, value } = flagInfo;
 
-    it('passes --passWithNoTests', async () => {
-      const task = jestTask({ passWithNoTests: true });
+      const task = jestTask({ [opt]: value ?? true });
       await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--passWithNoTests']));
-    });
-
-    it('passes --clearCache', async () => {
-      const task = jestTask({ clearCache: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--clearCache']));
-    });
-
-    it('passes --silent', async () => {
-      const task = jestTask({ silent: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--silent']));
-    });
-
-    it('passes --rootDir', async () => {
-      const task = jestTask({ rootDir: 'src' });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--rootDir', 'src']));
-    });
-
-    it('passes --testPathPattern', async () => {
-      const task = jestTask({ testPathPattern: 'src/test' });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--testPathPattern', 'src/test']));
-    });
-
-    it('passes --testPathPatterns', async () => {
-      const task = jestTask({ testPathPatterns: 'src/test' });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--testPathPatterns', 'src/test']));
-    });
-
-    it('passes --testNamePattern', async () => {
-      const task = jestTask({ testNamePattern: 'should do something' });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(
-        expect.arrayContaining(['--testNamePattern', 'should do something']),
-      );
-    });
-
-    it('passes --updateSnapshot', async () => {
-      const task = jestTask({ updateSnapshot: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--updateSnapshot']));
-    });
-
-    it('passes --updateSnapshot via u shorthand', async () => {
-      const task = jestTask({ u: true });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--updateSnapshot']));
-    });
-
-    it('passes --maxWorkers', async () => {
-      const task = jestTask({ maxWorkers: 4 });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--maxWorkers', '4']));
-    });
-
-    it('includes --colors when supportsColor.stdout is truthy', async () => {
-      const task = jestTask();
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--colors']));
-    });
-
-    it('omits --colors when colors option is false', async () => {
-      const task = jestTask({ colors: false });
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).not.toEqual(expect.arrayContaining(['--colors']));
+      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(value ? [flag, String(value)] : [flag]));
     });
   });
 
@@ -219,10 +178,10 @@ describe('jestTask (mocked)', () => {
     it('prepends nodeArgs before jest command', async () => {
       const task = jestTask({ nodeArgs: ['--max-old-space-size=4096'] });
       await callTaskForTest(task);
+      // node <nodeArgs> path/to/jest <jestArgs>
       const args = getNormalizedSpawnArgs(mockSpawn);
-      const nodeArgIndex = args.indexOf('--max-old-space-size=4096');
-      const jestCmdIndex = args.indexOf('${repoRoot}/node_modules/jest/bin/jest.js');
-      expect(nodeArgIndex).toBeLessThan(jestCmdIndex);
+      expect(args[1]).toBe('--max-old-space-size=4096');
+      expect(args[2]).toBe('${repoRoot}/node_modules/jest/bin/jest.js');
     });
 
     it('passes env to spawn', async () => {

--- a/packages/just-scripts/src/tasks/__tests__/webpackDevServerTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/webpackDevServerTask.mock.spec.ts
@@ -18,19 +18,11 @@ const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
 
 const relativeRepoRoot = '../..';
 
-function mockFsWebpackCliV4() {
+function getMockDeps() {
   return {
     [`${relativeRepoRoot}/node_modules/webpack-cli/package.json`]: JSON.stringify({ version: '4.10.0' }),
     [`${relativeRepoRoot}/node_modules/webpack/bin/webpack.js`]: 'a file',
     [`${relativeRepoRoot}/node_modules/webpack/package.json`]: '{"main":"lib/index.js"}',
-  };
-}
-
-function mockFsWebpackCliV3() {
-  return {
-    [`${relativeRepoRoot}/node_modules/webpack-cli/package.json`]: JSON.stringify({ version: '3.3.12' }),
-    [`${relativeRepoRoot}/node_modules/webpack-dev-server/bin/webpack-dev-server.js`]: 'a file',
-    [`${relativeRepoRoot}/node_modules/webpack-dev-server/package.json`]: '{"main":"lib/Server.js"}',
   };
 }
 
@@ -47,9 +39,9 @@ describe('webpackDevServerTask (mocked)', () => {
     });
   });
 
-  describe('webpack-cli >= 4.0.0 (webpack serve)', () => {
+  describe('arguments', () => {
     it('uses webpack serve command', async () => {
-      mockfs({ ...mockFsWebpackCliV4() });
+      mockfs({ ...getMockDeps() });
       const task = webpackDevServerTask();
       await callTaskForTest(task);
       expect(getNormalizedSpawnArgs(mockSpawn)).toEqual([
@@ -60,28 +52,28 @@ describe('webpackDevServerTask (mocked)', () => {
     });
 
     it('passes --open when open option is true', async () => {
-      mockfs({ ...mockFsWebpackCliV4() });
+      mockfs({ ...getMockDeps() });
       const task = webpackDevServerTask({ open: true });
       await callTaskForTest(task);
       expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--open']));
     });
 
     it('passes --mode', async () => {
-      mockfs({ ...mockFsWebpackCliV4() });
+      mockfs({ ...getMockDeps() });
       const task = webpackDevServerTask({ mode: 'development' });
       await callTaskForTest(task);
       expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--mode', 'development']));
     });
 
     it('passes webpackCliArgs', async () => {
-      mockfs({ ...mockFsWebpackCliV4() });
+      mockfs({ ...getMockDeps() });
       const task = webpackDevServerTask({ webpackCliArgs: ['--port', '3000'] });
       await callTaskForTest(task);
       expect(getNormalizedSpawnArgs(mockSpawn)).toEqual(expect.arrayContaining(['--port', '3000']));
     });
 
     it('passes nodeArgs before command', async () => {
-      mockfs({ ...mockFsWebpackCliV4() });
+      mockfs({ ...getMockDeps() });
       const task = webpackDevServerTask({ nodeArgs: ['--max-old-space-size=4096'] });
       await callTaskForTest(task);
       const args = getNormalizedSpawnArgs(mockSpawn);
@@ -89,22 +81,10 @@ describe('webpackDevServerTask (mocked)', () => {
     });
   });
 
-  describe('webpack-cli < 4.0.0 (webpack-dev-server)', () => {
-    it('uses webpack-dev-server command directly', async () => {
-      mockfs({ ...mockFsWebpackCliV3() });
-      const task = webpackDevServerTask();
-      await callTaskForTest(task);
-      expect(getNormalizedSpawnArgs(mockSpawn)).toEqual([
-        '${nodeExecPath}',
-        '${repoRoot}/node_modules/webpack-dev-server/bin/webpack-dev-server.js',
-      ]);
-    });
-  });
-
   describe('config handling', () => {
     it('passes --config when webpack config exists', async () => {
       mockfs({
-        ...mockFsWebpackCliV4(),
+        ...getMockDeps(),
         'webpack.serve.config.js': 'a file',
       });
       const task = webpackDevServerTask();
@@ -116,7 +96,7 @@ describe('webpackDevServerTask (mocked)', () => {
 
     it('falls back to webpack.config.js', async () => {
       mockfs({
-        ...mockFsWebpackCliV4(),
+        ...getMockDeps(),
         'webpack.config.js': 'a file',
       });
       const task = webpackDevServerTask();

--- a/packages/just-scripts/src/tasks/eslintTask.ts
+++ b/packages/just-scripts/src/tasks/eslintTask.ts
@@ -41,7 +41,8 @@ export interface EsLintTaskOptions {
 }
 
 export function eslintTask(options: EsLintTaskOptions = {}): TaskFunction {
-  return function eslint() {
+  // undertaker apparently requires returning a promise, async function, or function that calls done()
+  return async function eslint() {
     const {
       files,
       configPath,
@@ -62,45 +63,46 @@ export function eslintTask(options: EsLintTaskOptions = {}): TaskFunction {
     const eslintCmd = resolve('eslint/bin/eslint.js');
     // Try all possible extensions in the order listed here: https://eslint.org/docs/user-guide/configuring#configuration-file-formats
     const eslintConfigPath =
-      configPath || resolveCwd('.eslintrc', { extensions: ['.js', '.cjs', '.yaml', '.yml', '.json'] });
+      configPath ||
+      resolveCwd('eslint.config', { extensions: ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts'] }) ||
+      resolveCwd('.eslintrc', { extensions: ['.js', '.cjs', '.yaml', '.yml', '.json'] });
 
-    if (eslintCmd && eslintConfigPath && fs.existsSync(eslintConfigPath)) {
-      const eslintIgnorePath = ignorePath || resolveCwd('.eslintignore');
-
-      const eslintArgs = [
-        eslintCmd,
-        ...(files ? files : ['.']),
-        ...['--ext', extensions ? extensions : '.js,.jsx,.ts,.tsx'],
-        ...(noEslintRc ? ['--no-eslintrc'] : []),
-        ...(eslintConfigPath ? ['--config', eslintConfigPath] : []),
-        ...(eslintIgnorePath ? ['--ignore-path', eslintIgnorePath] : []),
-        ...(resolvePluginsPath ? ['--resolve-plugins-relative-to', resolvePluginsPath] : []),
-        ...(fix ? ['--fix'] : []),
-        ...(maxWarnings !== undefined ? ['--max-warnings', `${maxWarnings}`] : []),
-        ...(cache ? ['--cache'] : []),
-        ...(cacheLocation ? ['--cache-location', cacheLocation] : []),
-        ...(outputFile ? ['--output-file', outputFile] : []),
-        ...(format ? ['--format', format] : []),
-        ...(quiet ? ['--quiet'] : []),
-        ...(options.reportUnusedDisableDirectives ? ['--report-unused-disable-directives'] : []),
-        '--color',
-      ];
-
-      const env: NodeJS.ProcessEnv = { ...process.env };
-
-      if (timing) {
-        env.TIMING = '1';
-      }
-
-      if (useFlatConfig !== undefined) {
-        env.ESLINT_USE_FLAT_CONFIG = JSON.stringify(useFlatConfig);
-      }
-
-      logNodeCommand(eslintArgs);
-      return spawn(process.execPath, eslintArgs, { stdio: 'inherit', env });
+    if (!eslintCmd || !eslintConfigPath || !fs.existsSync(eslintConfigPath)) {
+      return;
     }
 
-    // undertaker apparently requires returning a promise, async function, or function that calls done()
-    return Promise.resolve();
+    const eslintIgnorePath = ignorePath || resolveCwd('.eslintignore');
+
+    const eslintArgs = [
+      eslintCmd,
+      ...(files ? files : ['.']),
+      ...['--ext', extensions ? extensions : '.js,.jsx,.ts,.tsx'],
+      ...(noEslintRc ? ['--no-eslintrc'] : []),
+      ...(eslintConfigPath ? ['--config', eslintConfigPath] : []),
+      ...(eslintIgnorePath ? ['--ignore-path', eslintIgnorePath] : []),
+      ...(resolvePluginsPath ? ['--resolve-plugins-relative-to', resolvePluginsPath] : []),
+      ...(fix ? ['--fix'] : []),
+      ...(maxWarnings !== undefined ? ['--max-warnings', `${maxWarnings}`] : []),
+      ...(cache ? ['--cache'] : []),
+      ...(cacheLocation ? ['--cache-location', cacheLocation] : []),
+      ...(outputFile ? ['--output-file', outputFile] : []),
+      ...(format ? ['--format', format] : []),
+      ...(quiet ? ['--quiet'] : []),
+      ...(options.reportUnusedDisableDirectives ? ['--report-unused-disable-directives'] : []),
+      '--color',
+    ];
+
+    const env: NodeJS.ProcessEnv = { ...process.env };
+
+    if (timing) {
+      env.TIMING = '1';
+    }
+
+    if (useFlatConfig !== undefined) {
+      env.ESLINT_USE_FLAT_CONFIG = JSON.stringify(useFlatConfig);
+    }
+
+    logNodeCommand(eslintArgs);
+    return spawn(process.execPath, eslintArgs, { stdio: 'inherit', env });
   };
 }

--- a/packages/just-scripts/src/tasks/jestTask.ts
+++ b/packages/just-scripts/src/tasks/jestTask.ts
@@ -40,11 +40,15 @@ export interface JestTaskOptions {
 }
 
 export function jestTask(options: JestTaskOptions = {}): TaskFunction {
-  const jestConfigFile = resolveCwd('./jest.config.js');
-  const packageConfigPath = process.cwd();
+  const jestConfigFile = resolveCwd('./jest.config', { extensions: ['.js', '.cjs', '.mjs', '.ts', '.mts', '.cts'] });
 
-  return function jest() {
+  // undertaker apparently requires returning a promise, async function, or function that calls done()
+  return async function jest() {
     const jestCmd = resolve('jest/bin/jest.js');
+    if (!jestCmd) {
+      return;
+    }
+
     const configFile = options.config || jestConfigFile;
     const configFileExists = configFile && existsSync(configFile);
 
@@ -52,47 +56,46 @@ export function jestTask(options: JestTaskOptions = {}): TaskFunction {
     if (configFileExists) {
       logger.verbose(`Using jest config file ${configFile}`);
     } else {
-      const packageConfig = readPackageJson(packageConfigPath);
+      const packageConfig = readPackageJson(process.cwd());
       if (packageConfig && packageConfig.jest) {
         packageConfigExists = true;
         logger.verbose(`Using jest config from package.json`);
       }
     }
 
-    if ((configFileExists || packageConfigExists) && jestCmd) {
-      logger.info(`Running Jest`);
-
-      const positional = argv()._.slice(1);
-
-      const args = [
-        ...(options.nodeArgs || []),
-        jestCmd,
-        ...(configFileExists ? ['--config', configFile] : []),
-        ...(options.rootDir ? ['--rootDir', options.rootDir] : []),
-        ...(options.passWithNoTests ? ['--passWithNoTests'] : []),
-        ...(options.clearCache ? ['--clearCache'] : []),
-        ...(options.colors !== false && supportsColor.stdout ? ['--colors'] : []),
-        ...(options.runInBand ? ['--runInBand'] : []),
-        ...(options.coverage ? ['--coverage'] : []),
-        ...(options.watch ? ['--watch'] : []),
-        ...(options.silent ? ['--silent'] : []),
-        ...(options.testPathPattern ? ['--testPathPattern', options.testPathPattern] : []),
-        ...(options.testPathPatterns ? ['--testPathPatterns', options.testPathPatterns] : []),
-        ...(options.testNamePattern ? ['--testNamePattern', options.testNamePattern] : []),
-        ...(options.maxWorkers ? ['--maxWorkers', `${options.maxWorkers}`] : []),
-        ...(options.u || options.updateSnapshot ? ['--updateSnapshot'] : []),
-        // Only include the positional args if `options._` wasn't specified
-        // (to avoid possibly including them twice)
-        ...(options._ || positional).map(String),
-      ].filter(arg => !!arg);
-
-      logNodeCommand(args);
-
-      return spawn(process.execPath, args, { stdio: 'inherit', env: options.env });
+    if (!(configFileExists || packageConfigExists)) {
+      logger.warn('No jest configuration found; skipping');
+      return;
     }
 
-    logger.warn('no jest configuration found, skipping jest');
-    // undertaker apparently requires returning a promise, async function, or function that calls done()
-    return Promise.resolve();
+    logger.info(`Running Jest`);
+
+    const positional = argv()._.slice(1);
+
+    const args = [
+      ...(options.nodeArgs || []),
+      jestCmd,
+      ...(configFileExists ? ['--config', configFile] : []),
+      ...(options.rootDir ? ['--rootDir', options.rootDir] : []),
+      ...(options.passWithNoTests ? ['--passWithNoTests'] : []),
+      ...(options.clearCache ? ['--clearCache'] : []),
+      ...(options.colors !== false && supportsColor.stdout ? ['--colors'] : []),
+      ...(options.runInBand ? ['--runInBand'] : []),
+      ...(options.coverage ? ['--coverage'] : []),
+      ...(options.watch ? ['--watch'] : []),
+      ...(options.silent ? ['--silent'] : []),
+      ...(options.testPathPattern ? ['--testPathPattern', options.testPathPattern] : []),
+      ...(options.testPathPatterns ? ['--testPathPatterns', options.testPathPatterns] : []),
+      ...(options.testNamePattern ? ['--testNamePattern', options.testNamePattern] : []),
+      ...(options.maxWorkers ? ['--maxWorkers', `${options.maxWorkers}`] : []),
+      ...(options.u || options.updateSnapshot ? ['--updateSnapshot'] : []),
+      // Only include the positional args if `options._` wasn't specified
+      // (to avoid possibly including them twice)
+      ...(options._ || positional).map(String),
+    ].filter(arg => !!arg);
+
+    logNodeCommand(args);
+
+    return spawn(process.execPath, args, { stdio: 'inherit', env: options.env });
   };
 }

--- a/packages/just-scripts/src/tasks/prettierTask.ts
+++ b/packages/just-scripts/src/tasks/prettierTask.ts
@@ -2,13 +2,20 @@ import type { TaskFunction } from 'just-task';
 import { logger, resolve } from 'just-task';
 import { logNodeCommand, spawn } from '../utils';
 import { splitArrayIntoChunks } from '../arrayUtils/splitArrayIntoChunks';
-import path from 'path';
 import { arrayify } from '../arrayUtils/arrayify';
 
 interface PrettierContext {
   prettierBin: string;
   configPath?: string;
   ignorePath?: string;
+  /**
+   * Files to format (globs are supported and passed directly to prettier).
+   * Will split into chunks of 20.
+   *
+   * Default is `${cwd}/** /*.{ts,tsx,js,jsx,json,scss,html,yml,md}` but it's better to just
+   * specify `['.']` and properly set up `.prettierignore` and pass it as `ignorePath`.
+   * Note that prettier v3 respects `.gitignore` by default.
+   */
   files: string[];
   check: boolean;
 }
@@ -32,7 +39,7 @@ export function prettierTask(options: PrettierTaskOptions = {}): TaskFunction {
         ...{ ignorePath: options.ignorePath || undefined },
         ...{
           files: arrayify(
-            options.files || path.resolve(process.cwd(), '**', '*.{ts,tsx,js,jsx,json,scss,html,yml,md}'),
+            options.files || `${process.cwd().replace(/\\/g, '/')}/**/*.{ts,tsx,js,jsx,json,scss,html,yml,md}`,
           ),
         },
         check: !!options.check,
@@ -51,13 +58,14 @@ export function prettierCheckTask(options: PrettierTaskOptions = {}): TaskFuncti
   return prettierTask({ ...options, check: true });
 }
 
-function runPrettierAsync(context: PrettierContext) {
-  const MaxFileEntriesPerChunk = 20;
+const MaxFileEntriesPerChunk = 20;
+
+async function runPrettierAsync(context: PrettierContext) {
   const { prettierBin, configPath, ignorePath, files, check } = context;
 
   const chunks = splitArrayIntoChunks(files, MaxFileEntriesPerChunk);
 
-  return chunks.reduce((finishPromise, chunk) => {
+  for (const chunk of chunks) {
     const prettierArgs = [
       prettierBin,
       ...(configPath ? ['--config', configPath] : []),
@@ -68,6 +76,6 @@ function runPrettierAsync(context: PrettierContext) {
 
     logNodeCommand(prettierArgs);
 
-    return finishPromise.then(() => spawn(process.execPath, prettierArgs, { stdio: 'inherit' }));
-  }, Promise.resolve());
+    await spawn(process.execPath, prettierArgs, { stdio: 'inherit' });
+  }
 }

--- a/packages/just-scripts/src/tasks/webpackDevServerTask.ts
+++ b/packages/just-scripts/src/tasks/webpackDevServerTask.ts
@@ -8,7 +8,6 @@ import path from 'path';
 import type { WebpackCliTaskOptions } from './webpackCliTask';
 import { getTsNodeEnv } from '../typescript/getTsNodeEnv';
 import { findWebpackConfig } from '../webpack/findWebpackConfig';
-import semver from 'semver';
 
 export interface WebpackDevServerTaskOptions extends WebpackCliTaskOptions, Configuration {
   /**
@@ -49,34 +48,26 @@ export interface WebpackDevServerTaskOptions extends WebpackCliTaskOptions, Conf
 }
 
 export function webpackDevServerTask(options: WebpackDevServerTaskOptions = {}): TaskFunction {
-  const configPath =
-    options && options.config
-      ? resolveCwd(path.join('.', options.config))
-      : findWebpackConfig('webpack.serve.config.js', 'webpack.config.js');
+  const configPath = options?.config
+    ? // don't attempt to resolve as a package
+      resolveCwd(path.isAbsolute(options.config) ? options.config : path.join('.', options.config))
+    : findWebpackConfig('webpack.serve.config.js', 'webpack.config.js');
 
-  // for webpack-cli < 4, use webpack-dev-server directly, for webpack-cli >= 4, use "webpack serve"
   const webpackCliPackageJsonPath = resolve('webpack-cli/package.json');
-
   if (!webpackCliPackageJsonPath) {
     throw new Error('Missing webpack-cli package. Please install webpack-cli as a devDependency.');
   }
 
-  const webpackCliVersion = (JSON.parse(fs.readFileSync(webpackCliPackageJsonPath, 'utf-8')) as { version: string })
-    .version;
-
-  const useWebpackServe = semver.gte(webpackCliVersion, '4.0.0');
-
-  const devServerCmd = useWebpackServe
-    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      [resolve('webpack/bin/webpack.js')!, 'serve']
-    : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      [resolve('webpack-dev-server/bin/webpack-dev-server.js')!];
+  const webpackBinPath = resolve('webpack/bin/webpack.js');
+  if (!webpackBinPath) {
+    throw new Error(`Cannot find webpack CLI`);
+  }
 
   return function webpackDevServer() {
-    let args = [...(options.nodeArgs || []), ...devServerCmd];
+    const args = [...(options.nodeArgs || []), webpackBinPath, 'serve'];
 
     if (configPath && fs.existsSync(configPath)) {
-      args = [...args, '--config', configPath];
+      args.push('--config', configPath);
       options.env = {
         ...options.env,
         ...(configPath.endsWith('.ts') && getTsNodeEnv(options.tsconfig, options.transpileOnly)),
@@ -88,11 +79,11 @@ export function webpackDevServerTask(options: WebpackDevServerTaskOptions = {}):
     }
 
     if (options.mode) {
-      args = [...args, '--mode', options.mode];
+      args.push('--mode', options.mode);
     }
 
     if (options.webpackCliArgs) {
-      args = [...args, ...options.webpackCliArgs];
+      args.push(...options.webpackCliArgs);
     }
 
     logNodeCommand(args);

--- a/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
@@ -64,7 +64,7 @@ function createStyleLoaderRule(cssOptions: CssLoaderOptions, preprocessor: 'sass
 }
 
 export const createStylesOverlay = function (options: CssLoaderOptions = {}): Partial<Configuration> {
-  const sassLoader = resolve('node-sass') && resolve('sass-loader');
+  const sassLoader = (resolve('sass') || resolve('node-sass')) && resolve('sass-loader');
   const cssLoader = resolve('css-loader');
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,7 +1129,6 @@ __metadata:
     "@types/fs-extra": "npm:^11.0.0"
     "@types/mock-fs": "npm:^4.13.1"
     "@types/node": "npm:^22.0.0"
-    "@types/semver": "npm:^7.7.1"
     beachball: "npm:^2.65.5"
     eslint: "npm:^10.0.0"
     eslint-config-prettier: "npm:^10.0.0"
@@ -1521,13 +1520,6 @@ __metadata:
   version: 1.0.3
   resolution: "@types/run-parallel-limit@npm:1.0.3"
   checksum: 10c0/499bf6640cf0c9ed6a20922117a247bcdaff8427ebde7f8237333f9966a82affe8504ae9c846193d4d19127be6aa291a10a8221b389a2bc47de6295c49146538
-  languageName: node
-  linkType: hard
-
-"@types/semver@npm:^7.7.1":
-  version: 7.7.1
-  resolution: "@types/semver@npm:7.7.1"
-  checksum: 10c0/c938aef3bf79a73f0f3f6037c16e2e759ff40c54122ddf0b2583703393d8d3127130823facb880e694caa324eb6845628186aac1997ee8b31dc2d18fafe26268
   languageName: node
   linkType: hard
 
@@ -4278,7 +4270,6 @@ __metadata:
     glob: "npm:^13.0.6"
     just-task: "workspace:^"
     run-parallel-limit: "npm:^1.0.6"
-    semver: "npm:^7.8.1"
     supports-color: "npm:^8.1.0"
     webpack-merge: "npm:^6.0.1"
   bin:
@@ -5142,7 +5133,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.7.4, semver@npm:^7.8.0, semver@npm:^7.8.1":
+"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.7.4, semver@npm:^7.8.0":
   version: 7.8.1
   resolution: "semver@npm:7.8.1"
   bin:


### PR DESCRIPTION
- Webpack tasks: only support `webpack` and `webpack-cli` 5+
- `eslintTask`: look for all valid config extensions and flat config files
- `jestTask`: look for all valid config extensions
- `prettierTask`: use forward slashes in default cwd glob
- Webpack `stylesOverlay`: check for `sass` in addition to `node-sass` when determining if Sass is available