### PR TITLE
More consistent dependency resolution

### DIFF
--- a/change/change-38b1e7b1-5861-47f3-b04b-049249b84de2.json
+++ b/change/change-38b1e7b1-5861-47f3-b04b-049249b84de2.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "When loading dependencies with `tryRequire`, warn if the dep is resolved but can't be loaded, instead of silently continuing (may indicate an ESM/CJS interop issue or some other issue)",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "minor",
+      "comment": "Add `dirname` option to `resolve`. This allows resolving from the calling package in addition to `just-task`.",
+      "packageName": "just-task",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-8435101a-ee8d-4c2b-824b-0f66ba6e37a5.json
+++ b/change/change-8435101a-ee8d-4c2b-824b-0f66ba6e37a5.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "All tasks either log or throw if a no-op due to a missing dependency or config file. (Which tasks log vs throwing is the same as before, but now documented.)",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-c6e27017-27fa-49cf-b8cb-5e94d69b076b.json
+++ b/change/change-c6e27017-27fa-49cf-b8cb-5e94d69b076b.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Resolution of all dependencies is also tried relative to the `just-scripts` package (in addition to the same locations as before: `cwd`, config file location, any custom paths, `just-task` location)",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/change/change-db6319f2-fb06-4992-a5f9-01ac4ead147d.json
+++ b/change/change-db6319f2-fb06-4992-a5f9-01ac4ead147d.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Webpack configs and overlays: use resolved loader paths in the config rather than names, to ensure custom resolution locations are respected. If the loader isn't found (which previously would have caused an error later), throw an error. (Overlays that previously treated their dependencies as optional keep that behavior, even though it's inconsistent across overlays.)",
+      "type": "minor",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-scripts/etc/just-scripts.api.md
+++ b/packages/just-scripts/etc/just-scripts.api.md
@@ -6,7 +6,7 @@
 
 import type * as ApiExtractorTypes from '@microsoft/api-extractor';
 import type { BuildOptions } from 'esbuild';
-import { Configuration } from 'webpack';
+import type { Configuration } from 'webpack';
 import type { SpawnOptions } from 'child_process';
 import { TaskFunction } from 'just-task';
 import type ts from 'typescript';
@@ -23,7 +23,7 @@ export interface ApiExtractorOptions extends ApiExtractorTypes.IExtractorInvokeO
 // @public
 export function apiExtractorUpdateTask(options: ApiExtractorOptions): TaskFunction;
 
-// @public (undocumented)
+// @public
 export function apiExtractorVerifyTask(options: ApiExtractorOptions): TaskFunction;
 
 // @public (undocumented)
@@ -123,8 +123,8 @@ export interface CreateOptions {
     map?: (header: EntryHeader) => EntryHeader;
 }
 
-// @public (undocumented)
-export const createStylesOverlay: (options?: CssLoaderOptions) => Partial<Configuration>;
+// @public
+export function createStylesOverlay(options?: CssLoaderOptions): Configuration;
 
 // @public
 export function createTarTask(options?: CreateOptions): TaskFunction;
@@ -141,7 +141,7 @@ export interface CssLoaderOptions {
 export function defaultCleanPaths(): string[];
 
 // @public (undocumented)
-export const displayBailoutOverlay: () => Partial<Configuration>;
+export function displayBailoutOverlay(): Configuration;
 
 // @public (undocumented)
 export interface EntryHeader {
@@ -181,7 +181,7 @@ export interface EsbuildTransformOptions {
     include: string[] | string;
 }
 
-// @public (undocumented)
+// @public
 export function eslintTask(options?: EsLintTaskOptions): TaskFunction;
 
 // @public
@@ -231,13 +231,13 @@ export interface ExtractOptions {
 // @public
 export function extractTarTask(options?: ExtractOptions): TaskFunction;
 
-// @public (undocumented)
-export const fileOverlay: () => Partial<Configuration>;
+// @public
+export function fileOverlay(): Configuration;
 
-// @public (undocumented)
-export const htmlOverlay: (options: any) => Partial<Configuration>;
+// @public
+export function htmlOverlay(options: unknown): Configuration;
 
-// @public (undocumented)
+// @public
 export function jestTask(options?: JestTaskOptions): TaskFunction;
 
 // @public (undocumented)
@@ -301,7 +301,7 @@ export interface NodeExecTaskOptions {
 // @public (undocumented)
 export function prettierCheckTask(options?: PrettierTaskOptions): TaskFunction;
 
-// @public (undocumented)
+// @public
 export function prettierTask(options?: PrettierTaskOptions): TaskFunction;
 
 // @public (undocumented)
@@ -316,7 +316,7 @@ export interface PrettierTaskOptions {
     ignorePath?: string;
 }
 
-// @public (undocumented)
+// @public
 export function sassTask(options: SassTaskOptions): TaskFunction;
 
 // @public (undocumented)
@@ -327,8 +327,8 @@ export interface SassTaskOptions {
     postcssPlugins?: unknown[];
 }
 
-// @public (undocumented)
-export const stylesOverlay: () => Partial<Configuration>;
+// @public
+export function stylesOverlay(): Configuration;
 
 declare namespace taskPresets {
     export {
@@ -422,8 +422,8 @@ export interface TsLoaderOptions {
     transpileOnly: boolean;
 }
 
-// @public (undocumented)
-export const tsOverlay: (overlayOptions?: TsOverlayOptions) => Partial<Configuration>;
+// @public
+export function tsOverlay(overlayOptions?: TsOverlayOptions): Partial<Configuration>;
 
 // @public (undocumented)
 export interface TsOverlayOptions {
@@ -448,10 +448,10 @@ export interface WebpackCliTaskOptions {
     webpackCliArgs?: string[];
 }
 
-// @public (undocumented)
-export const webpackConfig: (config: Partial<Configuration>) => Configuration;
+// @public
+export function webpackConfig(config: Partial<Configuration>): Configuration;
 
-// @public (undocumented)
+// @public
 export function webpackDevServerTask(options?: WebpackDevServerTaskOptions): TaskFunction;
 
 // @public (undocumented)
@@ -471,17 +471,17 @@ export { webpackMerge }
 
 // @public (undocumented)
 export const webpackOverlays: {
-    typescript: (overlayOptions?: TsOverlayOptions) => Partial<Configuration>;
-    html: (options: any) => Partial<Configuration>;
-    styles: () => Partial<Configuration>;
-    file: () => Partial<Configuration>;
-    displayBailout: () => Partial<Configuration>;
+    typescript: typeof tsOverlay;
+    html: typeof htmlOverlay;
+    styles: typeof stylesOverlay;
+    file: typeof fileOverlay;
+    displayBailout: typeof displayBailoutOverlay;
 };
 
-// @public (undocumented)
-export const webpackServeConfig: (config: Partial<Configuration>) => Configuration;
+// @public
+export function webpackServeConfig(config: Partial<Configuration>): Configuration;
 
-// @public (undocumented)
+// @public
 export function webpackTask(options?: WebpackTaskOptions): TaskFunction;
 
 // @public (undocumented)

--- a/packages/just-scripts/src/copy/executeCopyInstructions.ts
+++ b/packages/just-scripts/src/copy/executeCopyInstructions.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from 'path';
+import path from 'path';
 import { readFile, writeFile, copy, ensureDir, ensureSymlink } from 'fs-extra';
 import type { CopyInstruction, CopyConfig } from './CopyInstruction';
 import { arrayify } from '../arrayUtils/arrayify';
@@ -23,7 +23,7 @@ function validateConfig(copyInstructions: CopyInstruction[]) {
 }
 
 function createDirectories(copyInstructions: CopyInstruction[]) {
-  const directories = new Set(copyInstructions.map(instruction => dirname(instruction.destinationFilePath)));
+  const directories = new Set(copyInstructions.map(instruction => path.dirname(instruction.destinationFilePath)));
   return Promise.all([...directories].map(d => ensureDir(d)));
 }
 
@@ -33,7 +33,7 @@ async function executeSingleCopyInstruction(copyInstruction: CopyInstruction) {
   // source and dest are 1-to-1?  perform binary copy or symlink as desired.
   if (sourceFileNames.length === 1) {
     if (copyInstruction.symlink) {
-      return ensureSymlink(resolve(sourceFileNames[0]), copyInstruction.destinationFilePath);
+      return ensureSymlink(path.resolve(sourceFileNames[0]), copyInstruction.destinationFilePath);
     }
     return copy(sourceFileNames[0], copyInstruction.destinationFilePath);
   }

--- a/packages/just-scripts/src/tasks/__tests__/esbuildTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/esbuildTask.mock.spec.ts
@@ -30,7 +30,7 @@ describe('esbuildTask (mocked)', () => {
 
   it('throws if esbuild is not resolved', () => {
     mockResolve.mockReturnValueOnce(null);
-    expect(() => esbuildTask()).toThrow('cannot find esbuild');
+    expect(() => esbuildTask()).toThrow('Cannot find esbuild');
   });
 
   it('calls esbuild.build with provided options', async () => {

--- a/packages/just-scripts/src/tasks/__tests__/tscTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/tscTask.mock.spec.ts
@@ -253,7 +253,7 @@ describe(`tscTask (mocked)`, () => {
       mockfs({
         'tsconfig.json': 'a file',
       });
-      expect(() => tscTask()).toThrow('cannot find tsc');
+      expect(() => tscTask()).toThrow('Cannot find typescript CLI (typescript/lib/tsc.js)');
     });
   });
 

--- a/packages/just-scripts/src/tasks/__tests__/webpackCliTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/webpackCliTask.mock.spec.ts
@@ -37,7 +37,7 @@ describe('webpackCliTask (mocked)', () => {
   describe('error conditions', () => {
     it('throws if webpack-cli is not found', () => {
       mockfs({});
-      expect(() => webpackCliTask()).toThrow('cannot find webpack-cli');
+      expect(() => webpackCliTask()).toThrow('Cannot find webpack-cli');
     });
   });
 

--- a/packages/just-scripts/src/tasks/__tests__/webpackDevServerTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/webpackDevServerTask.mock.spec.ts
@@ -20,7 +20,7 @@ const relativeRepoRoot = '../..';
 
 function getMockDeps() {
   return {
-    [`${relativeRepoRoot}/node_modules/webpack-cli/package.json`]: JSON.stringify({ version: '4.10.0' }),
+    [`${relativeRepoRoot}/node_modules/webpack-cli/package.json`]: '{}',
     [`${relativeRepoRoot}/node_modules/webpack/bin/webpack.js`]: 'a file',
     [`${relativeRepoRoot}/node_modules/webpack/package.json`]: '{"main":"lib/index.js"}',
   };
@@ -36,6 +36,13 @@ describe('webpackDevServerTask (mocked)', () => {
     it('throws if webpack-cli is not found', () => {
       mockfs({});
       expect(() => webpackDevServerTask()).toThrow('Missing webpack-cli package');
+    });
+
+    it('throws if webpack is not found', () => {
+      const deps = getMockDeps() as Record<string, string>;
+      delete deps[`${relativeRepoRoot}/node_modules/webpack/bin/webpack.js`];
+      mockfs(deps);
+      expect(() => webpackDevServerTask()).toThrow('Cannot find webpack (webpack/bin/webpack.js)');
     });
   });
 

--- a/packages/just-scripts/src/tasks/apiExtractorTask.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTask.ts
@@ -90,21 +90,22 @@ export function apiExtractorUpdateTask(options: ApiExtractorOptions): TaskFuncti
 
     const apiExtractorResult = apiExtractorWrapper(context);
 
-    if (!apiExtractorResult.succeeded) {
-      logger.warn(`- Update API: API file is out of date, updating...`);
-      fs.mkdirpSync(path.dirname(context.config.reportFilePath)); // ensure destination exists
-      fs.copyFileSync(context.config.reportTempFilePath, context.config.reportFilePath);
-
-      logger.info(`- Update API: successfully updated API file, verifying the updates...`);
-
-      const updateResult = apiExtractorWrapper(context);
-      if (!updateResult || !updateResult.succeeded) {
-        throw new Error(`- Update API: failed to verify API updates.`);
-      } else {
-        logger.info(`- Update API: successully verified API file. Please commit API file as part of your changes.`);
-      }
-    } else {
+    if (apiExtractorResult.succeeded) {
       logger.info(`- Update API: API file is already up to date, no update needed.`);
+      return;
+    }
+
+    logger.warn(`- Update API: API file is out of date, updating...`);
+    fs.mkdirpSync(path.dirname(context.config.reportFilePath)); // ensure destination exists
+    fs.copyFileSync(context.config.reportTempFilePath, context.config.reportFilePath);
+
+    logger.info(`- Update API: successfully updated API file, verifying the updates...`);
+
+    const updateResult = apiExtractorWrapper(context);
+    if (updateResult.succeeded) {
+      logger.info(`- Update API: successully verified API file. Please commit API file as part of your changes.`);
+    } else {
+      throw new Error(`- Update API: failed to verify API updates.`);
     }
   };
 }
@@ -166,9 +167,7 @@ function apiExtractorWrapper({
 
   logger.info(`Extracting Public API surface from '${config.mainEntryPointFilePath}'`);
   const result = Extractor.invoke(config, extractorOptions);
-  if (options.onResult) {
-    options.onResult(result, extractorOptions);
-  }
+  options.onResult?.(result, extractorOptions);
 
   return result;
 }

--- a/packages/just-scripts/src/tasks/apiExtractorTask.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTask.ts
@@ -39,24 +39,31 @@ interface ApiExtractorContext {
   apiExtractorModule: typeof ApiExtractorTypes;
 }
 
+/**
+ * Create a task to verify the API report. Errors if the report is out of date.
+ *
+ * Logs a warning if `@microsoft/api-extractor` or a config file is not found.
+ */
 export function apiExtractorVerifyTask(options: ApiExtractorOptions): TaskFunction {
   // eslint-disable-next-line @typescript-eslint/require-await
   return async function apiExtractorVerify() {
     const context = initApiExtractor(options);
-    if (context) {
-      const apiExtractorResult = apiExtractorWrapper(context);
+    if (!context) return;
 
-      if (apiExtractorResult && !apiExtractorResult.succeeded) {
-        throw new Error(
-          'The public API file is out of date. Please run the API snapshot and commit the updated API file.',
-        );
-      }
+    const apiExtractorResult = apiExtractorWrapper(context);
+
+    if (apiExtractorResult && !apiExtractorResult.succeeded) {
+      throw new Error(
+        'The public API file is out of date. Please run the API snapshot and commit the updated API file.',
+      );
     }
   };
 }
 
 /**
- * Updates the API extractor snapshot
+ * Create a task to update the API report file.
+ *
+ * Logs a warning if `@microsoft/api-extractor` or a config file is not found.
  *
  * Sample config which should be saved as api-extractor.json:
  * ```
@@ -79,40 +86,38 @@ export function apiExtractorUpdateTask(options: ApiExtractorOptions): TaskFuncti
   // eslint-disable-next-line @typescript-eslint/require-await
   return async function apiExtractorUpdate() {
     const context = initApiExtractor(options);
-    if (context) {
-      let apiExtractorResult = apiExtractorWrapper(context);
+    if (!context) return;
 
-      if (apiExtractorResult) {
-        if (!apiExtractorResult.succeeded) {
-          logger.warn(`- Update API: API file is out of date, updating...`);
-          fs.mkdirpSync(path.dirname(context.config.reportFilePath)); // ensure destination exists
-          fs.copyFileSync(context.config.reportTempFilePath, context.config.reportFilePath);
+    const apiExtractorResult = apiExtractorWrapper(context);
 
-          logger.info(`- Update API: successfully updated API file, verifying the updates...`);
+    if (!apiExtractorResult.succeeded) {
+      logger.warn(`- Update API: API file is out of date, updating...`);
+      fs.mkdirpSync(path.dirname(context.config.reportFilePath)); // ensure destination exists
+      fs.copyFileSync(context.config.reportTempFilePath, context.config.reportFilePath);
 
-          apiExtractorResult = apiExtractorWrapper(context);
-          if (!apiExtractorResult || !apiExtractorResult.succeeded) {
-            throw new Error(`- Update API: failed to verify API updates.`);
-          } else {
-            logger.info(`- Update API: successully verified API file. Please commit API file as part of your changes.`);
-          }
-        } else {
-          logger.info(`- Update API: API file is already up to date, no update needed.`);
-        }
+      logger.info(`- Update API: successfully updated API file, verifying the updates...`);
+
+      const updateResult = apiExtractorWrapper(context);
+      if (!updateResult || !updateResult.succeeded) {
+        throw new Error(`- Update API: failed to verify API updates.`);
+      } else {
+        logger.info(`- Update API: successully verified API file. Please commit API file as part of your changes.`);
       }
+    } else {
+      logger.info(`- Update API: API file is already up to date, no update needed.`);
     }
   };
 }
 
 /**
  * Load the api-extractor module (if available) and the config file.
- * Returns undefined if api-extractor or the config file couldn't be found.
+ * Logs a warning and returns undefined if api-extractor or the config file couldn't be found.
  */
 function initApiExtractor(options: ApiExtractorOptions): ApiExtractorContext | undefined {
   const apiExtractorModule = tryRequire<typeof ApiExtractorTypes>('@microsoft/api-extractor');
 
   if (!apiExtractorModule) {
-    logger.warn('@microsoft/api-extractor package not detected. This task will have no effect.');
+    logger.warn('@microsoft/api-extractor package not found, so this task has no effect.');
     return;
   }
 
@@ -125,7 +130,7 @@ function initApiExtractor(options: ApiExtractorOptions): ApiExtractorContext | u
   const { configJsonFilePath = ExtractorConfig.FILENAME, onResult, ...extractorOptions } = options;
 
   if (!fs.existsSync(configJsonFilePath)) {
-    logger.warn('Config file not found for api-extractor!');
+    logger.warn('API Extractor config file not found, so this task has no effect.');
     return;
   }
 
@@ -156,7 +161,7 @@ function apiExtractorWrapper({
   config,
   extractorOptions,
   options,
-}: ApiExtractorContext): ApiExtractorTypes.ExtractorResult | undefined {
+}: ApiExtractorContext): ApiExtractorTypes.ExtractorResult {
   const { Extractor } = apiExtractorModule;
 
   logger.info(`Extracting Public API surface from '${config.mainEntryPointFilePath}'`);

--- a/packages/just-scripts/src/tasks/esbuildTask.ts
+++ b/packages/just-scripts/src/tasks/esbuildTask.ts
@@ -1,6 +1,6 @@
 import type { BuildOptions } from 'esbuild';
 import type { TaskFunction } from 'just-task';
-import { resolve } from 'just-task';
+import { resolveWrapper } from '../tryRequire';
 
 export type EsbuildBuildOptions = BuildOptions;
 export interface EsbuildTransformOptions {
@@ -9,14 +9,16 @@ export interface EsbuildTransformOptions {
 }
 
 /**
- * creates a esbuild task function, checking for esbuild's presence; can be used for bundling or building
+ * Create a task to run esbuild; can be used for bundling or building.
+ *
+ * Throws if `esbuild` is not found.
  */
 export function esbuildTask(options: EsbuildBuildOptions = {}): TaskFunction {
   // Resolve first from cwd, then through resolution paths
-  const esbuildModuleResolution = resolve('esbuild');
+  const esbuildModuleResolution = resolveWrapper('esbuild');
 
   if (!esbuildModuleResolution) {
-    throw new Error('cannot find esbuild, please add it to your devDependencies');
+    throw new Error('Cannot find esbuild, please add it to your devDependencies');
   }
 
   return async function esbuild() {

--- a/packages/just-scripts/src/tasks/eslintTask.ts
+++ b/packages/just-scripts/src/tasks/eslintTask.ts
@@ -1,7 +1,7 @@
-import type { TaskFunction } from 'just-task';
-import { resolve, resolveCwd } from 'just-task';
+import { logger, resolveCwd, type TaskFunction } from 'just-task';
 import { logNodeCommand, spawn } from '../utils';
 import fs from 'fs';
+import { resolveWrapper } from '../tryRequire';
 
 /**
  * Task options generally follow ESLint CLI options explained here:
@@ -40,6 +40,10 @@ export interface EsLintTaskOptions {
   reportUnusedDisableDirectives?: boolean;
 }
 
+/**
+ * Create a task to run eslint.
+ * Logs a warning if `eslint` or a config file is not found.
+ */
 export function eslintTask(options: EsLintTaskOptions = {}): TaskFunction {
   // undertaker apparently requires returning a promise, async function, or function that calls done()
   return async function eslint() {
@@ -60,14 +64,26 @@ export function eslintTask(options: EsLintTaskOptions = {}): TaskFunction {
       quiet,
       useFlatConfig,
     } = options;
-    const eslintCmd = resolve('eslint/bin/eslint.js');
+
+    const eslintPath = 'eslint/bin/eslint.js';
+    const eslintCmd = resolveWrapper(eslintPath);
+    if (!eslintCmd) {
+      logger.warn(`eslint CLI (${eslintPath}) not found, so this task has no effect.`);
+      return;
+    }
+
     // Try all possible extensions in the order listed here: https://eslint.org/docs/user-guide/configuring#configuration-file-formats
     const eslintConfigPath =
       configPath ||
       resolveCwd('eslint.config', { extensions: ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts'] }) ||
       resolveCwd('.eslintrc', { extensions: ['.js', '.cjs', '.yaml', '.yml', '.json'] });
 
-    if (!eslintCmd || !eslintConfigPath || !fs.existsSync(eslintConfigPath)) {
+    if (!eslintConfigPath) {
+      logger.warn('No ESLint config file found, so this task has no effect.');
+      return;
+    }
+    if (!fs.existsSync(eslintConfigPath)) {
+      logger.warn(`ESLint config file not found at path: ${eslintConfigPath}. This task will have no effect.`);
       return;
     }
 

--- a/packages/just-scripts/src/tasks/jestTask.ts
+++ b/packages/just-scripts/src/tasks/jestTask.ts
@@ -1,7 +1,8 @@
-import { resolve, logger, resolveCwd, argv, type TaskFunction } from 'just-task';
+import { logger, resolveCwd, argv, type TaskFunction } from 'just-task';
 import { spawn, readPackageJson, logNodeCommand } from '../utils';
 import { existsSync } from 'fs';
 import supportsColor from 'supports-color';
+import { resolveWrapper } from '../tryRequire';
 
 export interface JestTaskOptions {
   config?: string;
@@ -39,13 +40,18 @@ export interface JestTaskOptions {
   env?: NodeJS.ProcessEnv;
 }
 
+/**
+ * Create a task to run jest. Logs a warning if `jest` or a config file isn't found.
+ */
 export function jestTask(options: JestTaskOptions = {}): TaskFunction {
   const jestConfigFile = resolveCwd('./jest.config', { extensions: ['.js', '.cjs', '.mjs', '.ts', '.mts', '.cts'] });
 
   // undertaker apparently requires returning a promise, async function, or function that calls done()
   return async function jest() {
-    const jestCmd = resolve('jest/bin/jest.js');
+    const jestPath = 'jest/bin/jest.js';
+    const jestCmd = resolveWrapper(jestPath);
     if (!jestCmd) {
+      logger.warn(`jest CLI (${jestPath}) not found, so this task has no effect.`);
       return;
     }
 

--- a/packages/just-scripts/src/tasks/prettierTask.ts
+++ b/packages/just-scripts/src/tasks/prettierTask.ts
@@ -1,8 +1,8 @@
-import type { TaskFunction } from 'just-task';
-import { logger, resolve } from 'just-task';
+import { logger, type TaskFunction } from 'just-task';
 import { logNodeCommand, spawn } from '../utils';
 import { splitArrayIntoChunks } from '../arrayUtils/splitArrayIntoChunks';
 import { arrayify } from '../arrayUtils/arrayify';
+import { resolveWrapper } from '../tryRequire';
 
 interface PrettierContext {
   prettierBin: string;
@@ -27,9 +27,12 @@ export interface PrettierTaskOptions {
   check?: boolean;
 }
 
+/**
+ * Create a task to run prettier via its CLI. Logs a warning if `prettier` is not found.
+ */
 export function prettierTask(options: PrettierTaskOptions = {}): TaskFunction {
   // check v2 or v3 path
-  const prettierBin = resolve('prettier/bin-prettier.js') || resolve('prettier/bin/prettier.cjs');
+  const prettierBin = resolveWrapper('prettier/bin-prettier.js') || resolveWrapper('prettier/bin/prettier.cjs');
 
   if (prettierBin) {
     return function prettier() {
@@ -50,7 +53,7 @@ export function prettierTask(options: PrettierTaskOptions = {}): TaskFunction {
   // undertaker apparently requires returning a promise, async function, or function that calls done()
   // eslint-disable-next-line @typescript-eslint/require-await
   return async () => {
-    logger.warn('Prettier is not available, ignoring this task');
+    logger.warn('prettier not found, so this task has no effect.');
   };
 }
 

--- a/packages/just-scripts/src/tasks/sassTask.ts
+++ b/packages/just-scripts/src/tasks/sassTask.ts
@@ -1,8 +1,7 @@
 import { globSync } from 'glob';
 import path from 'path';
 import fs from 'fs';
-import type { TaskFunction } from 'just-task';
-import { resolveCwd, logger } from 'just-task';
+import { resolveCwd, logger, type TaskFunction } from 'just-task';
 import { tryRequire } from '../tryRequire';
 import parallelLimit from 'run-parallel-limit';
 
@@ -19,6 +18,13 @@ type SassModule = {
   ) => void;
 };
 
+/**
+ * Create a task to run sass.
+ *
+ * Logs a warning if any required dependencies are not found.
+ * - Required: `sass` or `node-sass`; `postcss`; `autoprefixer`.
+ * - Optional: `postcss-rtl`, `postcss-clean`, and any postcss plugins passed in through `options`.
+ */
 export function sassTask(options: SassTaskOptions): TaskFunction {
   const { createSourceModule, postcssPlugins = [] } = options;
 
@@ -34,9 +40,14 @@ export function sassTask(options: SassTaskOptions): TaskFunction {
     const clean = tryRequire<() => unknown>('postcss-clean');
 
     if (!sassModule || !postcss || !autoprefixer) {
-      logger.warn(
-        'One or more dependencies (sass or node-sass, postcss, autoprefixer) is not installed, so this task has no effect',
-      );
+      const missing = [
+        !sassModule && 'one of sass or node-sass',
+        !postcss && 'postcss',
+        !autoprefixer && 'autoprefixer',
+      ]
+        .filter(Boolean)
+        .join(', ');
+      logger.warn(`Required dependencies not found (${missing}), so this task has no effect.`);
       done();
       return;
     }

--- a/packages/just-scripts/src/tasks/tarTask.ts
+++ b/packages/just-scripts/src/tasks/tarTask.ts
@@ -1,8 +1,8 @@
-import type { TaskFunction } from 'just-task';
-import { resolve, logger } from 'just-task';
+import { logger, type TaskFunction } from 'just-task';
 import { createWriteStream, createReadStream } from 'fs';
 import { createGzip, createGunzip } from 'zlib';
 import type { Stream } from 'stream';
+import { resolveWrapper } from '../tryRequire';
 
 export interface EntryHeader {
   name: string;
@@ -32,7 +32,7 @@ export interface CreateOptions {
   /** output file */
   file: string;
 
-  /** whether to gzip or not, either a boolean or uses the `zlib.Gzip` options like level, memLevel  */
+  /** Whether to gzip or not. @default true */
   gzip?:
     | boolean
     | {
@@ -56,54 +56,11 @@ export interface CreateOptions {
   entries?: string[];
 }
 
-/**
- * Creates an tar (optionally gzipped) archive
- * @param options
- */
-export function createTarTask(options: CreateOptions = { file: 'archive.tar.gz' }): TaskFunction {
-  const resolvedTar = resolve('tar-fs');
-
-  // Inject default options
-  options = { cwd: process.cwd(), gzip: true, ...options };
-
-  // Validate whether tar-fs is installed
-  if (!resolvedTar) {
-    logger.error('Please make sure to have "tar-fs" as a dependency in your package.json');
-    throw new Error('Required dependency "tar-fs" is not installed!');
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const tar = require(resolvedTar);
-
-  const { entries, file, cwd, ...restOptions } = options;
-
-  return function archive(done) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    let tarStream = tar.pack(cwd, {
-      entries,
-      finalize: true,
-      finish: () => {
-        done();
-      },
-      ...restOptions,
-    });
-
-    if (options.gzip) {
-      const gzip = typeof options.gzip === 'boolean' ? createGzip() : createGzip(options.gzip);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      tarStream = tarStream.pipe(gzip);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    tarStream.pipe(createWriteStream(options.file));
-  };
-}
-
 export interface ExtractOptions {
   /** output file */
   file: string;
 
-  /** whether to gzip or not, either a boolean or uses the `zlib.Gzip` options like level, memLevel  */
+  /** Whether the archive is gzipped @default true */
   gzip?: boolean;
 
   /** the context path of the tar pack */
@@ -132,23 +89,46 @@ export interface ExtractOptions {
 }
 
 /**
- * Creates an tar (optionally gzipped) archive
- * @param options
+ * Create a task to create a tar (optionally gzipped) archive.
+ * Throws if `tar-fs` is not found.
+ */
+export function createTarTask(options: CreateOptions = { file: 'archive.tar.gz' }): TaskFunction {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const tar = getTarFs();
+  options = getOptionsWithDefaults(options);
+
+  const { entries, file, cwd, ...restOptions } = options;
+
+  return function archive(done) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    let tarStream = tar.pack(cwd, {
+      entries,
+      finalize: true,
+      finish: () => {
+        done();
+      },
+      ...restOptions,
+    });
+
+    if (options.gzip) {
+      const gzip = typeof options.gzip === 'boolean' ? createGzip() : createGzip(options.gzip);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      tarStream = tarStream.pipe(gzip);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    tarStream.pipe(createWriteStream(options.file));
+  };
+}
+
+/**
+ * Create a task to extract a tar (optionally gzipped) archive.
+ * Throws if `tar-fs` is not found.
  */
 export function extractTarTask(options: ExtractOptions = { file: 'archive.tar.gz' }): TaskFunction {
-  const resolvedTar = resolve('tar-fs');
-
-  // Inject default options
-  options = { cwd: process.cwd(), gzip: true, ...options };
-
-  // Validate whether tar-fs is installed
-  if (!resolvedTar) {
-    logger.error('Please make sure to have "tar-fs" as a dependency in your package.json');
-    throw new Error('Required dependency "tar-fs" is not installed!');
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const tar = require(resolvedTar);
+  const tar = getTarFs();
+  options = getOptionsWithDefaults(options);
 
   const { cwd, file, ...restOptions } = options;
 
@@ -171,4 +151,24 @@ export function extractTarTask(options: ExtractOptions = { file: 'archive.tar.gz
       }),
     );
   };
+}
+
+/** fill in `cwd` and `gzip: true` defaults */
+function getOptionsWithDefaults<T extends CreateOptions | ExtractOptions>(options: T): T {
+  return {
+    cwd: process.cwd(),
+    gzip: true,
+    ...options,
+  };
+}
+
+/** Find `tar-fs` and throw if not installed */
+function getTarFs() {
+  const resolvedTar = resolveWrapper('tar-fs');
+  if (!resolvedTar) {
+    logger.error('Please make sure to have "tar-fs" as a dependency in your package.json');
+    throw new Error('Required dependency "tar-fs" is not installed!');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return require(resolvedTar);
 }

--- a/packages/just-scripts/src/tasks/tarTask.ts
+++ b/packages/just-scripts/src/tasks/tarTask.ts
@@ -56,38 +56,6 @@ export interface CreateOptions {
   entries?: string[];
 }
 
-export interface ExtractOptions {
-  /** output file */
-  file: string;
-
-  /** Whether the archive is gzipped @default true */
-  gzip?: boolean;
-
-  /** the context path of the tar pack */
-  cwd?: string;
-
-  /** filter (ignore) entries */
-  filter?: (path: string, header: EntryHeader) => boolean;
-
-  /** change the header in the entry (e.g. to replace prefix) */
-  map?: (header: EntryHeader) => EntryHeader;
-
-  /** mode for files (e.g. `parseInt(755, 8)`)*/
-  fmode?: number;
-
-  /** mode for directories (e.g. `parseInt(755, 8)`) */
-  dmode?: number;
-
-  /** set whether all files and dirs are readable */
-  readable?: boolean;
-
-  /** set whether all files and dirs are writable */
-  writable?: boolean;
-
-  /** whether to dereference links */
-  dereference?: boolean;
-}
-
 /**
  * Create a task to create a tar (optionally gzipped) archive.
  * Throws if `tar-fs` is not found.
@@ -119,6 +87,38 @@ export function createTarTask(options: CreateOptions = { file: 'archive.tar.gz' 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     tarStream.pipe(createWriteStream(options.file));
   };
+}
+
+export interface ExtractOptions {
+  /** output file */
+  file: string;
+
+  /** Whether the archive is gzipped @default true */
+  gzip?: boolean;
+
+  /** the context path of the tar pack */
+  cwd?: string;
+
+  /** filter (ignore) entries */
+  filter?: (path: string, header: EntryHeader) => boolean;
+
+  /** change the header in the entry (e.g. to replace prefix) */
+  map?: (header: EntryHeader) => EntryHeader;
+
+  /** mode for files (e.g. `parseInt(755, 8)`)*/
+  fmode?: number;
+
+  /** mode for directories (e.g. `parseInt(755, 8)`) */
+  dmode?: number;
+
+  /** set whether all files and dirs are readable */
+  readable?: boolean;
+
+  /** set whether all files and dirs are writable */
+  writable?: boolean;
+
+  /** whether to dereference links */
+  dereference?: boolean;
 }
 
 /**

--- a/packages/just-scripts/src/tasks/tscTask.ts
+++ b/packages/just-scripts/src/tasks/tscTask.ts
@@ -1,8 +1,9 @@
 import type ts from 'typescript';
 import type { TaskFunction } from 'just-task';
-import { resolve, logger, resolveCwd } from 'just-task';
+import { logger, resolveCwd } from 'just-task';
 import { logNodeCommand, spawn } from '../utils';
 import fs from 'fs';
+import { resolveWrapper } from '../tryRequire';
 
 export type TscTaskOptions = { [key in keyof ts.CompilerOptions]?: string | boolean | string[] } & {
   nodeArgs?: string[];
@@ -10,12 +11,15 @@ export type TscTaskOptions = { [key in keyof ts.CompilerOptions]?: string | bool
 
 /**
  * Returns a task that runs the TSC CLI.
+ *
+ * Throws if the `tsc` CLI (`typescript/lib/tsc.js`) is not found.
  */
 export function tscTask(options: TscTaskOptions = {}): TaskFunction {
-  const tscCmd = resolve('typescript/lib/tsc.js');
+  const tscPath = 'typescript/lib/tsc.js';
+  const tscCmd = resolveWrapper(tscPath);
 
   if (!tscCmd) {
-    throw new Error('cannot find tsc');
+    throw new Error(`Cannot find typescript CLI (${tscPath})`);
   }
 
   return function tsc() {
@@ -35,6 +39,8 @@ export function tscTask(options: TscTaskOptions = {}): TaskFunction {
 
 /**
  * Returns a task that runs the TSC CLI in watch mode.
+ *
+ * Throws if the `tsc` CLI is not found.
  */
 export function tscWatchTask(options: TscTaskOptions = {}): TaskFunction {
   return tscTask({ ...options, watch: true });

--- a/packages/just-scripts/src/tasks/webpackCliTask.ts
+++ b/packages/just-scripts/src/tasks/webpackCliTask.ts
@@ -1,8 +1,9 @@
 import type { TaskFunction } from 'just-task';
-import { logger, resolve } from 'just-task';
+import { logger } from 'just-task';
 import { logNodeCommand, spawn } from '../utils';
 import { getTsNodeEnv } from '../typescript/getTsNodeEnv';
 import { findWebpackConfig } from '../webpack/findWebpackConfig';
+import { resolveWrapper } from '../tryRequire';
 
 export interface WebpackCliTaskOptions {
   /**
@@ -33,13 +34,14 @@ export interface WebpackCliTaskOptions {
 }
 
 /**
- * webpackCliTask - task for running webpack as a cli command
+ * Creates a task for running `webpack-cli`.
+ * Throws if `webpack-cli` is not found.
  */
 export function webpackCliTask(options: WebpackCliTaskOptions = {}): TaskFunction {
-  const webpackCliCmd = resolve('webpack-cli/bin/cli.js');
-
+  const cliPath = 'webpack-cli/bin/cli.js';
+  const webpackCliCmd = resolveWrapper(cliPath);
   if (!webpackCliCmd) {
-    throw new Error('cannot find webpack-cli, please install it');
+    throw new Error(`Cannot find webpack-cli (${cliPath})`);
   }
 
   return function webpackCli() {

--- a/packages/just-scripts/src/tasks/webpackDevServerTask.ts
+++ b/packages/just-scripts/src/tasks/webpackDevServerTask.ts
@@ -2,12 +2,13 @@
 import type { Configuration } from 'webpack';
 import { logNodeCommand, spawn } from '../utils';
 import type { TaskFunction } from 'just-task';
-import { resolve, resolveCwd } from 'just-task';
+import { resolveCwd } from 'just-task';
 import fs from 'fs';
 import path from 'path';
 import type { WebpackCliTaskOptions } from './webpackCliTask';
 import { getTsNodeEnv } from '../typescript/getTsNodeEnv';
 import { findWebpackConfig } from '../webpack/findWebpackConfig';
+import { resolveWrapper } from '../tryRequire';
 
 export interface WebpackDevServerTaskOptions extends WebpackCliTaskOptions, Configuration {
   /**
@@ -47,20 +48,24 @@ export interface WebpackDevServerTaskOptions extends WebpackCliTaskOptions, Conf
   transpileOnly?: boolean;
 }
 
+/**
+ * Create a task for running a webpack dev server.
+ * Throws if `webpack` is not found.
+ */
 export function webpackDevServerTask(options: WebpackDevServerTaskOptions = {}): TaskFunction {
   const configPath = options?.config
     ? // don't attempt to resolve as a package
       resolveCwd(path.isAbsolute(options.config) ? options.config : path.join('.', options.config))
     : findWebpackConfig('webpack.serve.config.js', 'webpack.config.js');
 
-  const webpackCliPackageJsonPath = resolve('webpack-cli/package.json');
+  const webpackCliPackageJsonPath = resolveWrapper('webpack-cli/package.json');
   if (!webpackCliPackageJsonPath) {
     throw new Error('Missing webpack-cli package. Please install webpack-cli as a devDependency.');
   }
-
-  const webpackBinPath = resolve('webpack/bin/webpack.js');
+  const webpackBin = 'webpack/bin/webpack.js';
+  const webpackBinPath = resolveWrapper(webpackBin);
   if (!webpackBinPath) {
-    throw new Error(`Cannot find webpack CLI`);
+    throw new Error(`Cannot find webpack (${webpackBin})`);
   }
 
   return function webpackDevServer() {

--- a/packages/just-scripts/src/tasks/webpackDevServerTask.ts
+++ b/packages/just-scripts/src/tasks/webpackDevServerTask.ts
@@ -50,7 +50,7 @@ export interface WebpackDevServerTaskOptions extends WebpackCliTaskOptions, Conf
 
 /**
  * Create a task for running a webpack dev server.
- * Throws if `webpack` is not found.
+ * Throws if `webpack` or `webpack-cli` is not found.
  */
 export function webpackDevServerTask(options: WebpackDevServerTaskOptions = {}): TaskFunction {
   const configPath = options?.config

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -31,9 +31,12 @@ export interface WebpackTaskOptions extends Configuration {
   onCompile?: (err: Error, stats: any) => void | Promise<void>;
 }
 
+/**
+ * Create a task for running webpack. Logs a warning if `webpack` isn't found.
+ */
 export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
   return async function webpack() {
-    const wp = tryRequire('webpack') as typeof import('webpack') | undefined;
+    const wp = tryRequire<typeof import('webpack')>('webpack');
 
     if (!wp) {
       logger.warn('webpack is not installed, this task no effect');

--- a/packages/just-scripts/src/tryRequire.ts
+++ b/packages/just-scripts/src/tryRequire.ts
@@ -1,8 +1,11 @@
-import { resolve } from 'just-task';
+import { logger, resolve } from 'just-task';
 
-export function tryRequire<T = any>(specifier: string): T | null {
-  const resolved = resolve(specifier);
-
+/**
+ * Try requiring a module, respecting the resolution logic from {@link resolve} and including
+ * `just-scripts` as a resolution starting point.
+ */
+export function tryRequire<T>(specifier: string): T | null {
+  const resolved = resolveWrapper(specifier);
   if (!resolved) {
     return null;
   }
@@ -10,6 +13,17 @@ export function tryRequire<T = any>(specifier: string): T | null {
   try {
     return require(resolved) as T;
   } catch (e) {
+    // If the path is resolved but the module can't be loaded, this implies some issue (likely
+    // ESM/CJS interop) which should be surfaced to the user
+    logger.warn(`Error loading "${specifier}" (resolved: "${resolved}"): ${e instanceof Error ? e.message : e}`);
     return null;
   }
+}
+
+/**
+ * Calls {@link resolve} with the `dirname` set to this file, so that resolution is also
+ * tried from the `just-scripts` package location.
+ */
+export function resolveWrapper(modulePath: string): string | null {
+  return resolve(modulePath, { dirname: __dirname });
 }

--- a/packages/just-scripts/src/utils/exec.ts
+++ b/packages/just-scripts/src/utils/exec.ts
@@ -5,42 +5,25 @@ import { logger } from 'just-task';
 // `exec` and `execSync` were removed due to security issues (keeping filename for history)
 
 /**
- * Quote arguments containing spaces. Note that this does NOT do any other escaping!
- * For more complete escaping, consider a library such as `shell-quote`, or use safer APIs which
- * don't require escaping. (Note that `spawn` from this package now uses `cross-spawn` which
- * escapes spaces internally.)
+ * Log `Running: <process.execPath> <...args>`
  */
-function quoteSpaces(cmdArgs: string[]): string[] {
-  // Taken from https://github.com/xxorax/node-shell-escape/blob/master/shell-escape.js
-  // However, we needed to use double quotes because that's the norm in more platforms
-  if (!cmdArgs) {
-    return cmdArgs;
-  }
-
-  return cmdArgs.map(arg => {
+export function logNodeCommand(...args: (string | string[])[]): void {
+  const flatArgs = args.flat().map(arg => {
+    // Based on https://github.com/xxorax/node-shell-escape/blob/master/shell-escape.js
+    // but note this is NOT a complete safe quoting implementation (just for logging)
     if (/[^\w/:=-]/.test(arg)) {
       arg = `"${arg.replace(/"/g, '"\\"')}"`;
       arg = arg.replace(/^(?:"")+/g, '').replace(/\\"""/g, '\\"');
     }
-
     return arg;
   });
-}
 
-/**
- * Log `Running: <process.execPath> <...args>`
- */
-export function logNodeCommand(...args: (string | string[])[]): void {
-  logger.info(`Running: ${process.execPath} ${quoteSpaces(args.flat()).join(' ')}`);
+  logger.info(`Running: ${process.execPath} ${flatArgs.join(' ')}`);
 }
 
 /**
  * Execute a command in a new process. Uses `cross-spawn` to avoid issues with spaces in arguments,
- * but does not do any additional escaping. (For further enhancements, consider using the `execa`
- * library instead.)
- *
- * **WARNING: If the `shell` option is enabled, do not pass unsanitized user input to this function.
- * Any input containing shell metacharacters may be used to trigger arbitrary command execution.**
+ * but does not do any additional escaping.
  *
  * @param cmd Command to execute
  * @param args Args for the command. Quoting spaces is handled internally by `cross-spawn`.
@@ -57,7 +40,7 @@ export function logNodeCommand(...args: (string | string[])[]): void {
 export function spawn(
   cmd: string,
   args: ReadonlyArray<string> = [],
-  opts: cp.SpawnOptions & { stdout?: NodeJS.WritableStream; stderr?: NodeJS.WritableStream } = {},
+  opts: Omit<cp.SpawnOptions, 'shell'> & { stdout?: NodeJS.WritableStream; stderr?: NodeJS.WritableStream } = {},
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     let child: cp.ChildProcess;
@@ -73,13 +56,11 @@ export function spawn(
       child.off('error', onError);
       if (code) {
         const error = new Error('Command failed: ' + [cmd, ...args].join(' '));
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        (error as any).code = code;
+        (error as Error & { code: number }).code = code;
         reject(error);
       } else if (signal) {
         const error = new Error(`Command terminated by signal ${signal}: ` + [cmd, ...args].join(' '));
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        (error as any).signal = signal;
+        (error as Error & { signal: NodeJS.Signals }).signal = signal;
         reject(error);
       } else {
         resolve();

--- a/packages/just-scripts/src/webpack/overlays/displayBailoutOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/displayBailoutOverlay.ts
@@ -1,11 +1,14 @@
+// WARNING: Careful about adding more imports - only import types from externals
 import type { Configuration } from 'webpack';
 
-export const displayBailoutOverlay = (): Partial<Configuration> => ({
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  stats: {
-    // Examine all modules
-    maxModules: Infinity,
-    // Display bailout reasons
-    optimizationBailout: true,
-  } as any,
-});
+export function displayBailoutOverlay(): Configuration {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    stats: {
+      // Examine all modules
+      maxModules: Infinity,
+      // Display bailout reasons
+      optimizationBailout: true,
+    } as any,
+  };
+}

--- a/packages/just-scripts/src/webpack/overlays/fileOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/fileOverlay.ts
@@ -1,13 +1,24 @@
-// // WARNING: Careful about add more imports - only import types from webpack
+// WARNING: Careful about adding more imports - only import types from externals
 import type { Configuration } from 'webpack';
+import { resolveWrapper } from '../../tryRequire';
 
-export const fileOverlay = (): Partial<Configuration> => ({
-  module: {
-    rules: [
-      {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: ['file-loader'],
-      },
-    ],
-  },
-});
+/**
+ * Get a config overlay with rules for loading image files with `file-loader`.
+ * Throws if `file-loader` is not found.
+ */
+export function fileOverlay(): Configuration {
+  const fileLoaderPath = resolveWrapper('file-loader');
+  if (!fileLoaderPath) {
+    throw new Error('Could not find "file-loader". Please install this package.');
+  }
+  return {
+    module: {
+      rules: [
+        {
+          test: /\.(png|svg|jpg|gif)$/,
+          use: [fileLoaderPath],
+        },
+      ],
+    },
+  };
+}

--- a/packages/just-scripts/src/webpack/overlays/htmlOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/htmlOverlay.ts
@@ -1,12 +1,16 @@
-// // WARNING: Careful about add more imports - only import types from webpack
+// WARNING: Careful about adding more imports - only import types from externals
 import type { Configuration } from 'webpack';
 import { tryRequire } from '../../tryRequire';
 
-export const htmlOverlay: (options: any) => Partial<Configuration> = options => {
+/**
+ * Create an `HTMLWebpackPlugin` config overlay. No-op if `html-webpack-plugin` is not found.
+ */
+export function htmlOverlay(options: unknown): Configuration {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const HtmlWebpackPlugin = tryRequire('html-webpack-plugin');
+  const HtmlWebpackPlugin: any = tryRequire('html-webpack-plugin');
+  if (!HtmlWebpackPlugin) return {};
   return {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-    plugins: [...(HtmlWebpackPlugin ? [new HtmlWebpackPlugin(options)] : [])],
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    plugins: [new HtmlWebpackPlugin(options)],
   };
-};
+}

--- a/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
@@ -1,8 +1,6 @@
-// // WARNING: Careful about add more imports - only import types from webpack
-import type { Configuration } from 'webpack';
-import type { Loader } from 'webpack';
-import { resolve } from 'just-task';
-import { tryRequire } from '../../tryRequire';
+// WARNING: Careful about adding more imports - only import types from externals
+import type { Configuration, RuleSetRule } from 'webpack';
+import { resolveWrapper, tryRequire } from '../../tryRequire';
 
 const cssTest = /\.css$/;
 const cssModuleTest = /\.module\.css$/;
@@ -15,47 +13,37 @@ export interface CssLoaderOptions {
   localIdentName?: string;
 }
 
-function createStyleLoaderRule(cssOptions: CssLoaderOptions, preprocessor: 'sass-loader' | null = null): Loader[] {
-  const styleLoader = resolve('@microsoft/loader-load-themed-styles') || resolve('style-loader');
-  const postCssLoader = resolve('postcss-loader');
+function createStyleLoaderRule(
+  options: CssLoaderOptions & {
+    cssLoaderPath: string;
+    styleLoaderPath: string;
+    sassLoaderPath?: string;
+  },
+): RuleSetRule['use'] {
+  const { modules, localIdentName, sassLoaderPath, cssLoaderPath, styleLoaderPath } = options;
 
-  const preloaders = [
-    ...(postCssLoader
-      ? [
-          {
-            loader: 'postcss-loader',
-            options: {
-              plugins: function () {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-                return [tryRequire('autoprefixer')];
-              },
-            },
-          },
-        ]
-      : []),
-    ...(preprocessor ? [preprocessor] : []),
-  ];
+  const postcssLoaderPath = resolveWrapper('postcss-loader');
 
-  const moduleOptions = cssOptions.localIdentName
-    ? {
-        modules: {
-          mode: 'local',
-          localIdentName: cssOptions.localIdentName,
-        },
-      }
-    : {
-        modules: cssOptions.modules,
-      };
+  const preloaders: RuleSetRule['use'] = [];
+  postcssLoaderPath &&
+    preloaders.push({
+      loader: postcssLoaderPath,
+      options: {
+        plugins: () => [tryRequire('autoprefixer')],
+      },
+    });
+  sassLoaderPath && preloaders.push({ loader: sassLoaderPath });
 
   return [
     {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      loader: styleLoader!, // creates style nodes from JS strings
+      // creates style nodes from JS strings
+      loader: styleLoaderPath,
     },
     {
-      loader: 'css-loader', // translates CSS into CommonJS
+      // translates CSS into CommonJS
+      loader: cssLoaderPath,
       options: {
-        ...moduleOptions,
+        modules: localIdentName ? { mode: 'local', localIdentName } : modules,
         importLoaders: preloaders.length,
       },
     },
@@ -63,67 +51,98 @@ function createStyleLoaderRule(cssOptions: CssLoaderOptions, preprocessor: 'sass
   ];
 }
 
-export const createStylesOverlay = function (options: CssLoaderOptions = {}): Partial<Configuration> {
-  const sassLoader = (resolve('sass') || resolve('node-sass')) && resolve('sass-loader');
-  const cssLoader = resolve('css-loader');
+/**
+ * Create a style module rules config overlay with custom options.
+ * Returns an empty config if `css-loader` is not found.
+ *
+ * Required dependencies: `css-loader`, one of `style-loader` or `@microsoft/loader-load-themed-styles`
+ * (throws if no style loader is found).
+ *
+ * Optional dependencies: `postcss-loader`, `postcss`, `autoprefixer`, `sass-loader`, one of `sass` or `node-sass`.
+ */
+export function createStylesOverlay(options: CssLoaderOptions = {}): Configuration {
+  const cssLoaderPath = resolveWrapper('css-loader');
+  if (!cssLoaderPath) {
+    return {};
+  }
+
+  const styleLoaderPath = resolveWrapper('@microsoft/loader-load-themed-styles') || resolveWrapper('style-loader');
+  if (!styleLoaderPath) {
+    throw new Error(
+      'Could not find "@microsoft/loader-load-themed-styles" or "style-loader". Please install one of these packages.',
+    );
+  }
+
+  const sassLoaderPath =
+    resolveWrapper('sass') || resolveWrapper('node-sass') ? resolveWrapper('sass-loader') : undefined;
 
   return {
     module: {
       rules: [
-        ...(cssLoader
+        {
+          test: cssTest,
+          exclude: [/node_modules/, cssModuleTest],
+          use: createStyleLoaderRule({
+            cssLoaderPath,
+            styleLoaderPath,
+            modules: false,
+            localIdentName: options.localIdentName || defaultIdentName,
+          }),
+          sideEffects: true,
+        },
+        {
+          test: cssModuleTest,
+          exclude: [/node_modules/],
+          use: createStyleLoaderRule({
+            cssLoaderPath,
+            styleLoaderPath,
+            modules: true,
+            localIdentName: options.localIdentName || defaultIdentName,
+          }),
+        },
+        ...(sassLoaderPath
           ? [
               {
-                test: cssTest,
-                exclude: [/node_modules/, cssModuleTest],
+                test: sassTest,
+                exclude: [/node_modules/, sassModuleTest],
                 use: createStyleLoaderRule({
+                  cssLoaderPath,
+                  styleLoaderPath,
+                  sassLoaderPath,
                   modules: false,
                   localIdentName: options.localIdentName || defaultIdentName,
                 }),
                 sideEffects: true,
               },
               {
-                test: cssModuleTest,
+                test: sassModuleTest,
                 exclude: [/node_modules/],
                 use: createStyleLoaderRule({
+                  cssLoaderPath,
+                  styleLoaderPath,
+                  sassLoaderPath,
                   modules: true,
                   localIdentName: options.localIdentName || defaultIdentName,
                 }),
               },
             ]
           : []),
-        ...(sassLoader && cssLoader
-          ? [
-              {
-                test: sassTest,
-                exclude: [/node_modules/, sassModuleTest],
-                use: createStyleLoaderRule(
-                  {
-                    modules: false,
-                    localIdentName: options.localIdentName || defaultIdentName,
-                  },
-                  'sass-loader',
-                ),
-                sideEffects: true,
-              },
-              {
-                test: sassModuleTest,
-                exclude: [/node_modules/],
-                use: createStyleLoaderRule(
-                  {
-                    modules: true,
-                    localIdentName: options.localIdentName || defaultIdentName,
-                  },
-                  'sass-loader',
-                ),
-              },
-            ]
-          : []),
       ],
     },
   };
-};
+}
 
-export const stylesOverlay = (): Partial<Configuration> =>
-  createStylesOverlay({
+/**
+ * Create a style module rules config overlay with default options.
+ * Returns an empty config if `css-loader` is not found.
+ *
+ * Required dependencies: `css-loader`, one of `style-loader` or `@microsoft/loader-load-themed-styles`
+ * (throws if no style loader is found).
+ *
+ * Optional dependencies: `postcss-loader`, `postcss`, `autoprefixer`, `sass-loader`, one of `sass` or `node-sass`.
+ */
+export function stylesOverlay(): Configuration {
+  return createStylesOverlay({
     localIdentName: defaultIdentName,
   });
+}

--- a/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
@@ -17,20 +17,19 @@ function createStyleLoaderRule(
   options: CssLoaderOptions & {
     cssLoaderPath: string;
     styleLoaderPath: string;
+    postcssLoaderPath: string | null;
+    autoprefixer: unknown;
     sassLoaderPath?: string;
   },
 ): RuleSetRule['use'] {
-  const { modules, localIdentName, sassLoaderPath, cssLoaderPath, styleLoaderPath } = options;
-
-  const postcssLoaderPath = resolveWrapper('postcss-loader');
+  const { modules, localIdentName, sassLoaderPath, cssLoaderPath, postcssLoaderPath, autoprefixer, styleLoaderPath } =
+    options;
 
   const preloaders: RuleSetRule['use'] = [];
   postcssLoaderPath &&
     preloaders.push({
       loader: postcssLoaderPath,
-      options: {
-        plugins: () => [tryRequire('autoprefixer')],
-      },
+      options: autoprefixer ? { plugins: () => [autoprefixer] } : {},
     });
   sassLoaderPath && preloaders.push({ loader: sassLoaderPath });
 
@@ -61,6 +60,8 @@ function createStyleLoaderRule(
  * Optional dependencies: `postcss-loader`, `postcss`, `autoprefixer`, `sass-loader`, one of `sass` or `node-sass`.
  */
 export function createStylesOverlay(options: CssLoaderOptions = {}): Configuration {
+  const localIdentName = options.localIdentName || defaultIdentName;
+
   const cssLoaderPath = resolveWrapper('css-loader');
   if (!cssLoaderPath) {
     return {};
@@ -73,6 +74,12 @@ export function createStylesOverlay(options: CssLoaderOptions = {}): Configurati
     );
   }
 
+  const loaderArgs = {
+    cssLoaderPath,
+    styleLoaderPath,
+    postcssLoaderPath: resolveWrapper('postcss-loader'),
+    autoprefixer: tryRequire<unknown>('autoprefixer'),
+  };
   const sassLoaderPath =
     resolveWrapper('sass') || resolveWrapper('node-sass') ? resolveWrapper('sass-loader') : undefined;
 
@@ -83,10 +90,9 @@ export function createStylesOverlay(options: CssLoaderOptions = {}): Configurati
           test: cssTest,
           exclude: [/node_modules/, cssModuleTest],
           use: createStyleLoaderRule({
-            cssLoaderPath,
-            styleLoaderPath,
+            ...loaderArgs,
             modules: false,
-            localIdentName: options.localIdentName || defaultIdentName,
+            localIdentName,
           }),
           sideEffects: true,
         },
@@ -94,10 +100,9 @@ export function createStylesOverlay(options: CssLoaderOptions = {}): Configurati
           test: cssModuleTest,
           exclude: [/node_modules/],
           use: createStyleLoaderRule({
-            cssLoaderPath,
-            styleLoaderPath,
+            ...loaderArgs,
             modules: true,
-            localIdentName: options.localIdentName || defaultIdentName,
+            localIdentName,
           }),
         },
         ...(sassLoaderPath
@@ -106,11 +111,10 @@ export function createStylesOverlay(options: CssLoaderOptions = {}): Configurati
                 test: sassTest,
                 exclude: [/node_modules/, sassModuleTest],
                 use: createStyleLoaderRule({
-                  cssLoaderPath,
-                  styleLoaderPath,
+                  ...loaderArgs,
                   sassLoaderPath,
                   modules: false,
-                  localIdentName: options.localIdentName || defaultIdentName,
+                  localIdentName,
                 }),
                 sideEffects: true,
               },
@@ -118,11 +122,10 @@ export function createStylesOverlay(options: CssLoaderOptions = {}): Configurati
                 test: sassModuleTest,
                 exclude: [/node_modules/],
                 use: createStyleLoaderRule({
-                  cssLoaderPath,
-                  styleLoaderPath,
+                  ...loaderArgs,
                   sassLoaderPath,
                   modules: true,
-                  localIdentName: options.localIdentName || defaultIdentName,
+                  localIdentName,
                 }),
               },
             ]

--- a/packages/just-scripts/src/webpack/overlays/tsOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/tsOverlay.ts
@@ -1,7 +1,7 @@
+// WARNING: Careful about adding more imports - only import types from externals
 import type ts from 'typescript';
-// // WARNING: Careful about add more imports - only import types from webpack
 import type { Configuration } from 'webpack';
-import { tryRequire } from '../../tryRequire';
+import { resolveWrapper, tryRequire } from '../../tryRequire';
 
 export interface TsLoaderOptions {
   configFile: string;
@@ -47,9 +47,20 @@ export interface TsOverlayOptions {
   checkerOptions?: Partial<TsCheckerOptions>;
 }
 
-export const tsOverlay = (overlayOptions?: TsOverlayOptions): Partial<Configuration> => {
+/**
+ * Create a typescript module rules config overlay.
+ *
+ * Required dependencies: `ts-loader` (throws if not found) and implicitly `typescript`.
+ * Optional dependencies: `fork-ts-checker-webpack-plugin`.
+ */
+export function tsOverlay(overlayOptions?: TsOverlayOptions): Partial<Configuration> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const ForkTsCheckerPlugin = tryRequire('fork-ts-checker-webpack-plugin');
+  const ForkTsCheckerPlugin: any = tryRequire('fork-ts-checker-webpack-plugin');
+
+  const tsLoaderPath = resolveWrapper('ts-loader');
+  if (!tsLoaderPath) {
+    throw new Error('Could not find "ts-loader". Please install this package.');
+  }
 
   overlayOptions = overlayOptions || {};
 
@@ -68,7 +79,7 @@ export const tsOverlay = (overlayOptions?: TsOverlayOptions): Partial<Configurat
         {
           test: /\.tsx?$/,
           use: {
-            loader: 'ts-loader',
+            loader: tsLoaderPath,
             options: overlayOptions.loaderOptions,
           },
           exclude: /node_modules/,
@@ -78,4 +89,4 @@ export const tsOverlay = (overlayOptions?: TsOverlayOptions): Partial<Configurat
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     plugins: [...(ForkTsCheckerPlugin ? [new ForkTsCheckerPlugin(overlayOptions.checkerOptions)] : [])],
   };
-};
+}

--- a/packages/just-scripts/src/webpack/webpack.config.ts
+++ b/packages/just-scripts/src/webpack/webpack.config.ts
@@ -15,6 +15,10 @@ export const basicWebpackConfig: Configuration = {
   },
 };
 
-export const webpackConfig = (config: Partial<Configuration>): Configuration => {
+/**
+ * Create a webpack config.
+ * For dependencies, see {@link stylesOverlay}, {@link tsOverlay}, and {@link fileOverlay}.
+ */
+export function webpackConfig(config: Partial<Configuration>): Configuration {
   return merge(basicWebpackConfig, stylesOverlay(), tsOverlay(), fileOverlay(), config);
-};
+}

--- a/packages/just-scripts/src/webpack/webpack.serve.config.ts
+++ b/packages/just-scripts/src/webpack/webpack.serve.config.ts
@@ -16,6 +16,10 @@ export const basicWebpackServeConfig: Configuration = {
   },
 };
 
-export const webpackServeConfig = (config: Partial<Configuration>): Configuration => {
+/**
+ * Create a webpack serve config.
+ * For dependencies, see {@link stylesOverlay}, {@link tsOverlay}, and {@link fileOverlay}.
+ */
+export function webpackServeConfig(config: Partial<Configuration>): Configuration {
   return merge(basicWebpackServeConfig, stylesOverlay(), tsOverlay(), fileOverlay(), config);
-};
+}

--- a/packages/just-task/etc/just-task.api.md
+++ b/packages/just-task/etc/just-task.api.md
@@ -78,6 +78,7 @@ export function resolveCwd(moduleName: string, options?: ResolveOptions): string
 // @public (undocumented)
 interface ResolveOptions {
     cwd?: string;
+    dirname?: string;
     extensions?: string[];
 }
 

--- a/packages/just-task/src/__tests__/resolve.spec.ts
+++ b/packages/just-task/src/__tests__/resolve.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { describe, expect, it, jest, afterEach, beforeEach } from '@jest/globals';
 import path from 'path';
@@ -14,6 +13,14 @@ import {
 import * as option from '../option';
 import * as config from '../config';
 import mockfs from 'mock-fs';
+
+jest.mock('../option');
+
+const mockArgv = option.argv as jest.MockedFunction<() => object>;
+
+beforeEach(() => {
+  mockArgv.mockReturnValue({});
+});
 
 describe('_isFileNameLike', () => {
   it('returns false for empty input', () => {
@@ -90,21 +97,23 @@ describe('_getResolvePaths', () => {
   });
 
   it('uses resolvePaths for before __dirname', () => {
-    jest.spyOn(option, 'argv').mockImplementation(() => ({ config: 'config/just-task.js' }) as any);
+    mockArgv.mockReturnValue({ config: 'config/just-task.js' });
     addResolvePath('custom1');
     addResolvePath('custom2');
 
-    const paths = _getResolvePaths('cwd');
+    const paths = _getResolvePaths({ cwd: 'cwd' });
 
     expect(paths.map(p => path.basename(p))).toEqual(['cwd', 'config', 'custom1', 'custom2', 'src']);
+  });
+
+  it('includes dirname if provided', () => {
+    const paths = _getResolvePaths({ cwd: 'cwd', dirname: 'caller' });
+
+    expect(paths.map(p => path.basename(p))).toEqual(['cwd', 'caller', 'src']);
   });
 });
 
 describe('resolveCwd', () => {
-  beforeEach(() => {
-    jest.spyOn(option, 'argv').mockImplementation(() => ({ config: undefined }) as any);
-  });
-
   afterEach(() => {
     mockfs.restore();
     resetResolvePaths();
@@ -139,8 +148,6 @@ describe('resolveCwd', () => {
 });
 
 describe('resolve', () => {
-  jest.spyOn(option, 'argv').mockImplementation(() => ({ config: undefined }) as any);
-
   afterEach(() => {
     mockfs.restore();
     resetResolvePaths();
@@ -169,7 +176,7 @@ describe('resolve', () => {
       a: { 'b.txt': '' },
     });
 
-    jest.spyOn(option, 'argv').mockImplementation(() => ({ config: 'a/just-task.js' }) as any);
+    mockArgv.mockReturnValue({ config: 'a/just-task.js' });
 
     expect(resolve('b.txt')).toContain(path.join('a', 'b.txt'));
   });
@@ -192,7 +199,7 @@ describe('resolve', () => {
       'b.txt': '', // wrong
     });
 
-    jest.spyOn(option, 'argv').mockImplementation(() => ({ config: 'a/just-task.js' }) as any);
+    mockArgv.mockReturnValue({ config: 'a/just-task.js' });
 
     addResolvePath('c');
     expect(resolve('b.txt', { cwd: 'd' })).toContain(path.join('d', 'b.txt'));

--- a/packages/just-task/src/resolve.ts
+++ b/packages/just-task/src/resolve.ts
@@ -5,6 +5,8 @@ import { argv } from './option';
 export interface ResolveOptions {
   /** Directory to start resolution from. Defaults to `process.cwd()`. */
   cwd?: string;
+  /** If calling from another package, the directory of the calling file */
+  dirname?: string;
   /** Array of file extensions to search in order */
   extensions?: string[];
 }
@@ -40,7 +42,7 @@ export function _isFileNameLike(name: string): boolean {
  */
 export function _tryResolve(moduleName: string, options: ResolveOptions): string | null {
   try {
-    const { cwd, ...rest } = options;
+    const { cwd, dirname, ...rest } = options;
     const nameToResolve = _isFileNameLike(moduleName) ? `./${moduleName}` : moduleName;
     return resolveSync(nameToResolve, { basedir: cwd, ...rest, preserveSymlinks: true });
   } catch (e) {
@@ -52,20 +54,29 @@ export function _tryResolve(moduleName: string, options: ResolveOptions): string
  * Exported for testing only.
  * @private
  */
-export function _getResolvePaths(cwd?: string): string[] {
-  if (!cwd) {
-    cwd = process.cwd();
-  }
+export function _getResolvePaths(options: Pick<ResolveOptions, 'cwd' | 'dirname'> = {}): string[] {
+  const { dirname } = options;
+  const cwd = options.cwd || process.cwd();
 
   const configArg = argv().config as string | undefined;
   const configFilePath = configArg ? path.resolve(path.dirname(configArg)) : undefined;
 
-  return [cwd, ...(configFilePath ? [configFilePath] : []), ...customResolvePaths, __dirname];
+  return [
+    cwd,
+    ...(configFilePath ? [configFilePath] : []),
+    ...customResolvePaths,
+    ...(dirname ? [dirname] : []),
+    __dirname,
+  ];
 }
 
 /**
- * Resolve a module. Resolution will be tried starting from `cwd`, the location of a config file
- * passed using the `--config` command line arg, and any paths added using `addResolvePath`.
+ * Resolve a module. Resolution will be tried starting from:
+ * 1. `cwd`
+ * 2. the location of a config file passed using the `--config` command line arg
+ * 3. any paths added using `addResolvePath`
+ * 4. the location of the calling file, if `dirname` is provided
+ * 5. the location of the `just-task` package
  * @param moduleName Module name to resolve. Anything which appears to be a file name (contains .
  * and doesn't contain slashes) will be resolved relative to the working directory.
  * Other names will be resolved within node_modules.
@@ -73,7 +84,7 @@ export function _getResolvePaths(cwd?: string): string[] {
  * @returns The module path, or null if the module can't be resolved.
  */
 export function resolve(moduleName: string, options?: ResolveOptions): string | null {
-  const allResolvePaths = _getResolvePaths(options?.cwd);
+  const allResolvePaths = _getResolvePaths(options);
 
   for (const tryPath of allResolvePaths) {
     const resolved = _tryResolve(moduleName, { ...options, cwd: tryPath });


### PR DESCRIPTION
In preparation for explicitly declaring optional peer deps, it makes sense to add a mechanism for resolving deps relative to `just-scripts` in addition to `just-task` (most important in strict installation layouts).

This PR adds a `dirname` option to `just-task`'s `resolve` utility to allow resolving from the calling package, and updates all the tasks and webpack config helpers to use it.

Other related changes:
- When loading dependencies with `tryRequire`, warn if the dep is resolved but can't be loaded, instead of silently continuing (may indicate an ESM/CJS interop issue or some other issue).
- All tasks either log or throw if a no-op due to a missing dependency or config file. (It's inconsistent which tasks log/no-op or throw... that stays the same but is now documented.)
- **Webpack configs and overlays**: use resolved loader paths in the config rather than names, to ensure custom resolution locations are respected. If the loader isn't found (which previously would have caused an error later), throw an error. (Overlays that previously treated their dependencies as optional keep that behavior, even though it's inconsistent across overlays.)