### PR TITLE
More task type fixes and doc updates

### DIFF
--- a/change/change-158e3cf6-b91b-41e7-85c9-2fbafd33bf28.json
+++ b/change/change-158e3cf6-b91b-41e7-85c9-2fbafd33bf28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "none",
+      "comment": "more task type fixes (previously documented)",
+      "packageName": "just-task",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    }
+  ]
+}

--- a/change/change-dad5a01b-2a9c-488e-942a-62c55c205a6b.json
+++ b/change/change-dad5a01b-2a9c-488e-942a-62c55c205a6b.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "none",
+      "comment": "more webpack ts config fixes (previously documented)",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    }
+  ]
+}

--- a/docs/scripts/index.md
+++ b/docs/scripts/index.md
@@ -1,21 +1,22 @@
 # Just scripts
 
-Unlike other build libraries, Just strives to be useful from the beginning. You can choose to write your own tasks that call other Node.js tools like TypeScript, jest, and webpack. However, Just includes some script functions to get you up and running immediately. The included tasks are enough to have a very productive environment without dictating a certain stack to be used with Just.
+Just is useful from the start. You can either write your own tasks that call Node.js tools like TypeScript, jest, and webpack, or use the script functions `just-scripts` provides to get productive immediately — without being locked into a particular stack.
 
-> NOTE: even though `just-scripts` interacts with `typescript`, it does not take `typescript` as a dependency. It assumes that the developers will include that in their own projects. This gives `just-scripts` the flexibility of targeting many different versions of individual build tools without imposing a version on the consumers.
+> NOTE: `just-scripts` declares `typescript` and other large dependencies as **optional peer dependencies**. This means you can install only the dependencies you intend to use, with the desired versions for your project (rather than pulling in a different version by accident). `just-scripts` is also very flexible about how it resolves dependencies: it will try relative to `cwd`, the config file location, any custom resolve paths, or the `just-scripts` package.
 
-These scripts are coded as higher order task functions. Each of these script functions return a task function to be registered as a task in your own `just.config.js` like this:
+The `just-scripts` task helpers are coded as higher order task functions. Each of these script functions return a task function to be registered as a task in your own `just.config.ts` like this:
 
 ```ts
-// just.config.js
+// just.config.ts
 import { tscTask } from 'just-scripts';
-task('ts', tscTask());
+// The extra () => ensures all deps are delay resolved/loaded
+task('ts', () => tscTask());
 ```
 
 Generally, these higher order functions also take an `options` argument to generate a specific task function preconfigured according to the options. For example:
 
 ```ts
-// just.config.js
+// just.config.ts
 import { tscTask } from 'just-scripts';
 task('ts:commonjs', tscTask({ module: 'commonjs' }));
 task('ts:esnext', tscTask({ module: 'esnext' }));

--- a/docs/scripts/jest.md
+++ b/docs/scripts/jest.md
@@ -2,16 +2,16 @@
 
 Jest is one of the most popular testing libraries in the Javascript ecosystem. It is also a preset supported out of the box inside the `just-scripts` library. Similar to the other presets, this task function assumes that you have a `jest.config.js` at the root of the project.
 
-```tsx
-// just.config.js
+```ts
+// just.config.ts
 import { jestTask } from 'just-scripts';
 task('test', jestTask());
 ```
 
 You can pass in a few options like any another preset tasks in the `just-scripts` library.
 
-```tsx
-// just.config.js
+```ts
+// just.config.ts
 import { jestTask } from 'just-scripts';
 
 const options = {
@@ -21,20 +21,6 @@ const options = {
 task('test', jestTask(options));
 ```
 
-## Available Options
+## Available options
 
-### config
-
-You can pass in a different `jest.config.js` file to the `jestTask()`.
-
-### runInBand
-
-This causes the `jest` runner to run the tests in a single thread.
-
-### coverage
-
-This causes `jest` to collect coverage information. It is much slower, and therefore is turned OFF by default.
-
-### updateSnapshots
-
-This causes the `jestTask()` to update snapshots. Configuration of the snapshot location is subject to the `jest.config.js` file.
+See the types for a complete list of options, including `config` to customize the config file path, and various common Jest options.

--- a/docs/scripts/lint.md
+++ b/docs/scripts/lint.md
@@ -3,7 +3,7 @@
 As the amount of code grows, developers need a way to keep the code looking consistent. `eslint` is the de facto linter for JS and TS code.
 
 ```tsx
-// just.config.js
+// just.config.ts
 import { eslintTask } from 'just-scripts';
 task('eslint', eslintTask());
 ```

--- a/docs/scripts/typescript.md
+++ b/docs/scripts/typescript.md
@@ -1,24 +1,21 @@
 # TypeScript
 
-TypeScript is a very popular compiler that allows developers to use modern ES6 features as well as a very mature typing system. The benefits are so great that it has become one of the first presets supported by the `just-scripts` library.
+The `tscTask()` function runs the TypeScript compiler. By default it uses the `tsconfig.json` in the project root, but you can pass options to override compiler settings; these are forwarded to `tsc` as command-line arguments. See the [TypeScript docs](http://www.typescriptlang.org/docs/handbook/compiler-options.html) for the available compiler options.
 
-Given a library with TypeScript source code, it might be desirable to have multiple output formats for different audiences. By default, the `tscTask()` function looks for the `tsconfig.json` present in the project root. The preset higher order function can take in an option that overrides compilation options. The TypeScript compiler options are passed to the `tsc.js` script.
-
-A list of available options are located at the [TypeScript documentation site](http://www.typescriptlang.org/docs/handbook/compiler-options.html). The options passed into the preset function will be passed in as command line arguments as a string.
-
-```tsx
-// just.config.js
+```ts
+// just.config.ts
 import { tscTask } from 'just-scripts';
-task('ts', tscTask());
+// The extra () => ensures all deps are delay resolved/loaded
+task('ts', () => tscTask());
 ```
 
 For variety, try having two kinds of output at the same time (built in parallel)
 
-```tsx
-// just.config.js
+```ts
+// just.config.ts
 import { parallel } from 'just-task';
 import { tscTask } from 'just-scripts';
-task('ts:commonjs', tscTask({ module: 'commonjs' }));
-task('ts:esnext', tscTask({ module: 'esnext' }));
+task('ts:commonjs', () => tscTask({ module: 'commonjs' }));
+task('ts:esnext', () => tscTask({ module: 'esnext' }));
 task('ts', parallel('ts:commonjs', 'ts:esnext'));
 ```

--- a/docs/scripts/webpack.md
+++ b/docs/scripts/webpack.md
@@ -1,36 +1,37 @@
 # Webpack
 
-Webpack is the Javascript, CSS and asset bundler that powers some of the largest Web applications. Just Scripts comes with great integration with Webpack out of the box. All of the power of Webpack comes at the cost of complexity in its configuration. The bundler actually comes with great defaults. However, it takes some non-trivial amount of config to make it work with transpilers like TypeScript.
+Webpack is the JavaScript, CSS and asset bundler that powers some of the largest web applications. `just-scripts` integrates with Webpack out of the box. Unlike `create-react-app`, it doesn't require ejecting to customize the config, and it tames Webpack's complexity with composable **configs** and **overlays**.
 
-`just-scripts` exports a flexible Webpack `just-task` task function. Unlike `create-react-app`, `just-scripts` does not require ejecting to allow customizations of the Webpack configuration. `just-scripts` abstracts the complexity of the configuration with what is known as "Overlays". For example, to add support of TypeScript transpilation, several parts of the configuration needs to be changed to support the various parts of building with TypeScript.
+The `webpackTask()` task function runs a production build. It looks for a `webpack.config.{js,cjs,mjs,ts,cts,mts}` file at the root of the project, or you can pass an explicit path via the `config` option.
 
-This task function will look for two files at the root of the project:
+> For inner loop development with a dev server, use `webpackDevServerTask()`, which resolves `webpack.serve.config.*` (falling back to `webpack.config.*`) using the same set of extensions.
 
-- webpack.config.js
-- webpack.serve.config.js
+## Example
 
-The Webpack task function will use `webpack.config.js` for its optimized production builds. It will use the `webpack.serve.config.js` for innerloop development.
+The config file can be fully customized, but the helpers below get you going quickly. An example `webpack.config.js`:
 
-## Example `webpack.config.js` and `webpack.serve.config.js`
-
-The `webpack.config.js` and `webpack.serve.config.js` can be completely customized to your own needs. However, some great utilities from `just-scripts` make it really easy to get going. Take a look at an example `webpack.config.js` that uses these utilities:
-
-```ts
-const { webpackMerge, htmlOverlay, webpackServeConfig } = require('just-scripts');
-module.exports = webpackMerge(webpackServeConfig, htmlOverlay);
+```js
+const { webpackConfig, htmlOverlay } = require('just-scripts');
+module.exports = webpackConfig(htmlOverlay());
 ```
 
-From this example, several concepts are illustrated. First, you can see that `just-scripts` exposes:
+`webpackConfig` builds a complete config; `htmlOverlay()` returns a partial config that's merged in. To assemble a config yourself, use the re-exported `webpack-merge` package: `webpackMerge.merge(...)`.
 
-- `webpackMerge`: this is just a thin wrapper on top of the excellent `webpack-merge` package
-- `webpackServeConfig`: this a very basic preset configuration that you can use as a baseline, there is also a `webpackConfig` module exported that you can use for your `webpack.config.js`
-- `htmlOverlay`: this is one of the overlays that adds some functionality to Webpack to be merged by the `webpack-merge` utility
+## Configs
+
+Each `*Config` function returns a complete `Configuration`, pre-merged with the file, styles, and TypeScript overlays plus any config you pass in. The `basicWebpack*Config` objects are the bare bases (entry, mode, output) with no overlays, if you'd rather start from scratch.
+
+- `webpackConfig(config)`: production build config (`mode: 'production'`); accepts custom config to merge in
+- `webpackServeConfig(config)`: development serve config (`mode: 'development'`); accepts custom config to merge in
+- `basicWebpackConfig`: bare production base object
+- `basicWebpackServeConfig`: bare development base object
 
 ## Overlays
 
-These overlays are not configurable (for now), but they do provide a great baseline to start from.
+Each overlay is a function returning a partial `Configuration`. Call it (with options where supported) and merge the result into your config using `webpackMerge.merge()`. Note `webpackConfig`/`webpackServeConfig` already include the file, styles, and TypeScript overlays.
 
-- `fileOverlay`: This adds the `file-loader` to allow loading SVG, PNG, GIF, JPG files
-- `htmlOverlay`: This adds the `html-webpack-plugin` that generates the right code to include scripts and other assets into your `index.html`
-- `stylesOverlay`: This adds styling support for both CSS and Sass
-- `tsOverlay`: This adds a `ts-loader` transpilation support for TypeScript files while configuring a `fork-ts-checker-webpack-plugin` for typechecking in a separate process for the fastest compilation experience
+- `fileOverlay()`: loads SVG, PNG, GIF, JPG files via `file-loader` (throws if it isn't installed)
+- `htmlOverlay(options)`: injects scripts and assets into a generated `index.html` via `html-webpack-plugin` (no-op if the plugin isn't installed)
+- `stylesOverlay()`: adds CSS and Sass support; use `createStylesOverlay(options)` to customize
+- `tsOverlay(options)`: adds `ts-loader` for TypeScript, with `fork-ts-checker-webpack-plugin` (if installed) typechecking in a separate process for faster builds
+- `displayBailoutOverlay()`: logs Webpack optimization bailout reasons, useful for diagnosing why modules aren't concatenated

--- a/docs/tasks/args.md
+++ b/docs/tasks/args.md
@@ -1,23 +1,23 @@
 # Command line arguments
 
-`just-task` uses the best pirate themed command line argument library ever: `yargs`, matey! So, rigs get documented pretty much automatically.
+`just-task` uses the best pirate themed command line argument library ever: `yargs-parser`, matey!
 
 ## Reading arguments
 
-To read the arguments passed in from command line, use the `argv()` function provided by `yargs`.
+To read the arguments passed in from command line, use the `argv()` function exported by `just-task`.
 
-```js
-const { task, argv } = require('just-task');
+```ts
+import { task, logger, argv } from 'just-task';
 
 task('pillageMeArgs', function () {
   logger.info('a bunch of aarrrrrrgs', argv());
 });
 ```
 
-## Describe the task with `option()`
+## Describe an option with `option()`
 
-```js
-const { task, logger, option, argv } = require('just-task');
+```ts
+import { task, logger, option, argv } from 'just-task';
 
 option('name');
 
@@ -26,13 +26,14 @@ task('blimey', 'An exclamation of surprise.', function () {
 });
 ```
 
-The `option()` function is the same one exposed by `yargs.option()` - so you can look up that [`option()` documentation](http://yargs.js.org/docs/#api-optionkey-opt) for what is possible.
+The `option()` function configures how a key is parsed (for example as a `boolean`, `string`, `number`, or `array`, or with an `alias` or `default`). These options map to the [`yargs-parser` configuration](https://github.com/yargs/yargs-parser#api).
 
-## Automatically generated task help usage
+## Listing available tasks
 
-If you describe the task in this fashion, you can get a list of tasks with descriptions like this:
+You can get a list of registered tasks along with their descriptions by running `just` with no task name (or with `--help`):
 
 ```
 just --help
-just blimey --help
 ```
+
+Tasks defined with a description (the second argument to `task()`) will show that description in the list.

--- a/docs/tasks/index.md
+++ b/docs/tasks/index.md
@@ -1,6 +1,8 @@
 # Getting started
 
-`Just` simplifies your life in managing build tasks. It stands on the shoulders of excellent and well tested libraries: undertaker, yargs, and plop.js. We encourage developers to make `just-scripts` available locally instead of installing `just-scripts` as a global tool.
+`Just` simplifies your life in managing build tasks. It stands on the shoulders of excellent and well tested libraries: `undertaker` and `yargs-parser`.
+
+Start by installing `just-scripts` in your project:
 
 ```sh
 npm i -D just-scripts
@@ -31,7 +33,7 @@ npm i -D ts-node typescript
 
 2. Place tasks inside `just.config.ts` in your root folder (next to package.json):
 
-```js
+```ts
 // ES Module style
 import { task, option, logger, argv } from 'just-scripts';
 
@@ -44,11 +46,14 @@ task('sayhello', function () {
 
 ## Run it!
 
-Then run it! It is best to either place `just` inside a npm run script or run it with `npx`:
+Then run it! You can either call `just` inside package.json `scripts` or run it directly with `npx`/`yarn`:
 
 ```sh
 $ npx just sayhello
 $ npx just sayhello --name me
+
+# Alternatively:
+$ npx just-scripts sayhello
 ```
 
-That's all!
+(The `just` and `just-scripts` CLIs are interchangeable: `just` CLI comes from the `just-scripts` package's dependency `just-task`, so it should be available automatically unless you use a package manager with strict installation layout. `just-scripts` directly provides a wrapper CLI called `just-scripts`.)

--- a/docs/tasks/thunk.md
+++ b/docs/tasks/thunk.md
@@ -1,21 +1,21 @@
 # Higher order task functions
 
-When a project truly gets big enough to have multiple variants of a build, a simple task function might be reused as variants. For example, the `just-task-preset` package includes a useful collection of task functions like `tscTask`. However, these tasks tend to be very generic. `tscTask()` is a task function factory. Calling it will generate a task function. But sometimes variations of the same preconfigured task function is needed. We will use a concept called `thunk` to create a task function that creates a task function on the fly!
+Preset task factories like `tscTask` from `just-scripts` generate a task function when called. To produce variations of a preconfigured task on the fly, wrap the factory call in a `thunk` — a task function that returns a task function.
+
+(For convenience, `just-scripts` also exports the contents of `just-task`, and provides its own CLI called `just-scripts`, which wraps the `just` CLI from `just-task`.)
 
 Here is an example of a simple usage of a preset task function factory:
 
-```js
-const { task } = require('just-task');
-const { tscTask } = require('just-task-preset');
+```ts
+import { task, tscTask } from 'just-scripts';
 
 task('build', tscTask());
 ```
 
 Now, let's try to preconfigure this task based on something we can pass in from the arguments:
 
-```js
-const { task, argv, option } = require('just-task');
-const { tscTask } = require('just-task-preset');
+```ts
+import { task, argv, option, tscTask } from 'just-scripts';
 
 option('amd');
 
@@ -25,6 +25,6 @@ task('build', () => tscTask({ module: argv().amd ? 'amd' : 'commonjs' }));
 Now the build task can take in an argument and perform TypeScript compilation for different modes:
 
 ```sh
-$ just build --amd
-$ just build --commonjs
+$ just-scripts build         # compiles with module: commonjs
+$ just-scripts build --amd   # compiles with module: amd
 ```

--- a/packages/just-example-lib/just.config.ts
+++ b/packages/just-example-lib/just.config.ts
@@ -27,10 +27,13 @@ import {
 } from 'just-scripts';
 import path from 'path';
 
-task('typescript', tscTask({}));
+// nested "thunk" type initialization
+// (if the task doesn't run, lib won't exist and api-extractor will fail)
+task('typescript', () => tscTask({}));
+
 task('typescript:watch', tscTask({ watch: true }));
 
-// creates src/style2.scss.ts
+// creates src/style2.scss.ts (typescript will fail if this doesn't work)
 task(
   'sass',
   sassTask({

--- a/packages/just-example-lib/package.json
+++ b/packages/just-example-lib/package.json
@@ -22,7 +22,6 @@
     "esbuild": "catalog:dev",
     "eslint": "catalog:dev",
     "file-loader": "^6.2.0",
-    "fork-ts-checker-webpack-plugin": "catalog:dev",
     "html-webpack-plugin": "catalog:dev",
     "jest": "catalog:dev",
     "just-scripts": "workspace:^",

--- a/packages/just-example-lib/webpack.config.cts
+++ b/packages/just-example-lib/webpack.config.cts
@@ -1,6 +1,15 @@
-import { webpackConfig, webpackMerge, htmlOverlay } from 'just-scripts';
+import { basicWebpackConfig, webpackMerge, htmlOverlay, fileOverlay, tsOverlay, stylesOverlay } from 'just-scripts';
 
 // must use export = for cts loaded directly with node
 export = () => {
-  return webpackMerge.merge(webpackConfig(htmlOverlay({})), { devtool: false });
+  return webpackMerge.merge(
+    basicWebpackConfig,
+    tsOverlay({ checkerOptions: false }),
+    fileOverlay(),
+    stylesOverlay(),
+    htmlOverlay({}),
+    {
+      devtool: false,
+    },
+  );
 };

--- a/packages/just-scripts/etc/just-scripts.api.md
+++ b/packages/just-scripts/etc/just-scripts.api.md
@@ -371,8 +371,7 @@ export function tsOverlay(overlayOptions?: TsOverlayOptions): Configuration;
 
 // @public (undocumented)
 export interface TsOverlayOptions {
-    // (undocumented)
-    checkerOptions?: TsCheckerOptions;
+    checkerOptions?: TsCheckerOptions | false;
     // (undocumented)
     loaderOptions?: TsLoaderOptions;
 }

--- a/packages/just-scripts/src/tasks/__tests__/webpackCliTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/webpackCliTask.mock.spec.ts
@@ -100,4 +100,25 @@ describe('webpackCliTask (mocked)', () => {
       expect(mockSpawn.mock.calls[0][2]?.env).toEqual(env);
     });
   });
+
+  describe('ts-node env', () => {
+    beforeEach(() => {
+      mockfs({ ...mockFsWebpackCli() });
+    });
+
+    it.each(['webpack.config.ts', 'webpack.config.cts', 'webpack.config.mts'])(
+      'enables ts-node transpileOnly for a %s config',
+      async configPath => {
+        const task = webpackCliTask({ webpackCliArgs: ['--config', configPath] });
+        await callTaskForTest(task);
+        expect(mockSpawn.mock.calls[0][2]?.env).toMatchObject({ TS_NODE_TRANSPILE_ONLY: 'true' });
+      },
+    );
+
+    it('does not enable ts-node env for a .js config', async () => {
+      const task = webpackCliTask({ webpackCliArgs: ['--config', 'webpack.config.js'] });
+      await callTaskForTest(task);
+      expect(mockSpawn.mock.calls[0][2]?.env).toBeUndefined();
+    });
+  });
 });

--- a/packages/just-scripts/src/tasks/webpackCliTask.ts
+++ b/packages/just-scripts/src/tasks/webpackCliTask.ts
@@ -1,7 +1,7 @@
 import type { TaskFunction } from 'just-task';
 import { logger } from 'just-task';
 import { logNodeCommand, spawn } from '../utils';
-import { getTsNodeEnv } from '../typescript/getTsNodeEnv';
+import { getTsNodeEnv, isTsConfigFile } from '../typescript/getTsNodeEnv';
 import { findWebpackConfig } from '../webpack/findWebpackConfig';
 import { resolveWrapper } from '../tryRequire';
 
@@ -64,7 +64,7 @@ export function webpackCliTask(options: WebpackCliTaskOptions = {}): TaskFunctio
       configPath = findWebpackConfig();
     }
 
-    if (configPath?.endsWith('.ts')) {
+    if (isTsConfigFile(configPath ?? '')) {
       options.env = {
         ...options.env,
         ...getTsNodeEnv(options.tsconfig, options.transpileOnly),

--- a/packages/just-scripts/src/tasks/webpackDevServerTask.ts
+++ b/packages/just-scripts/src/tasks/webpackDevServerTask.ts
@@ -4,7 +4,7 @@ import { logNodeCommand, spawn } from '../utils';
 import type { TaskFunction } from 'just-task';
 import fs from 'fs';
 import type { WebpackCliTaskOptions } from './webpackCliTask';
-import { getTsNodeEnv } from '../typescript/getTsNodeEnv';
+import { getTsNodeEnv, isTsConfigFile } from '../typescript/getTsNodeEnv';
 import { findWebpackConfig } from '../webpack/findWebpackConfig';
 import { resolveWrapper } from '../tryRequire';
 
@@ -70,7 +70,7 @@ export function webpackDevServerTask(options: WebpackDevServerTaskOptions = {}):
       args.push('--config', configPath);
       options.env = {
         ...options.env,
-        ...(configPath.endsWith('.ts') && getTsNodeEnv(options.tsconfig, options.transpileOnly)),
+        ...(isTsConfigFile(configPath) && getTsNodeEnv(options.tsconfig, options.transpileOnly)),
       };
     }
 

--- a/packages/just-scripts/src/typescript/getTsNodeEnv.ts
+++ b/packages/just-scripts/src/typescript/getTsNodeEnv.ts
@@ -1,5 +1,13 @@
 import { logger } from 'just-task';
 
+/**
+ * Whether the given config path is a TypeScript file that should be loaded via ts-node
+ * (matches `.ts`, `.cts`, and `.mts` extensions).
+ */
+export function isTsConfigFile(configPath: string): boolean {
+  return /\.[cm]?ts$/.test(configPath);
+}
+
 export function getTsNodeEnv(tsconfig?: string, transpileOnly?: boolean): { [key: string]: string | undefined } {
   const env: { [key: string]: string | undefined } = {};
 

--- a/packages/just-scripts/src/webpack/overlays/tsOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/tsOverlay.ts
@@ -22,7 +22,8 @@ export type TsCheckerOptions = ConstructorParameters<typeof ForkTsCheckerWebpack
 
 export interface TsOverlayOptions {
   loaderOptions?: TsLoaderOptions;
-  checkerOptions?: TsCheckerOptions;
+  /** Set to false to disable type checking */
+  checkerOptions?: TsCheckerOptions | false;
 }
 
 /**
@@ -32,9 +33,10 @@ export interface TsOverlayOptions {
  * Optional dependencies: `fork-ts-checker-webpack-plugin`.
  */
 export function tsOverlay(overlayOptions?: TsOverlayOptions): Configuration {
-  const ForkTsCheckerPlugin = tryRequire<typeof import('fork-ts-checker-webpack-plugin')>(
-    'fork-ts-checker-webpack-plugin',
-  );
+  const ForkTsCheckerPlugin =
+    overlayOptions?.checkerOptions !== false
+      ? tryRequire<typeof import('fork-ts-checker-webpack-plugin')>('fork-ts-checker-webpack-plugin')
+      : undefined;
   const tsLoaderPath = resolveWrapper('ts-loader');
   if (!tsLoaderPath) {
     throw new Error('Could not find "ts-loader". Please install this package.');
@@ -64,6 +66,6 @@ export function tsOverlay(overlayOptions?: TsOverlayOptions): Configuration {
         },
       ],
     },
-    plugins: [...(ForkTsCheckerPlugin ? [new ForkTsCheckerPlugin(overlayOptions.checkerOptions)] : [])],
+    plugins: ForkTsCheckerPlugin ? [new ForkTsCheckerPlugin(overlayOptions.checkerOptions)] : [],
   };
 }

--- a/packages/just-task/etc/just-task.api.md
+++ b/packages/just-task/etc/just-task.api.md
@@ -45,7 +45,7 @@ export function mark(marker: string): void;
 // @public
 export interface NestedTaskFunction {
     // (undocumented)
-    (done: TaskCallback): TaskFunctionResult;
+    (done: TaskCallback): TaskFunctionResult | NestedTaskFunction;
 }
 
 // Warning: (ae-forgotten-export) The symbol "OptionConfig" needs to be exported by the entry point index.d.ts

--- a/packages/just-task/src/interfaces.ts
+++ b/packages/just-task/src/interfaces.ts
@@ -16,12 +16,16 @@ export type Task = string | TaskFunction;
 export type TaskFunctionResult = ReturnType<Undertaker.TaskFunction>;
 
 /**
- * A task function that produces a {@link TaskFunctionResult} directly (no further nesting).
- * This is the shape of the inner function returned by the "factory" form of {@link TaskFunction};
- * `wrapTask` invokes it with the `done` callback.
+ * The function returned by the "factory" form of {@link TaskFunction}. `wrapTask` invokes it
+ * with the `done` callback and uses its result.
+ *
+ * Its return type mirrors {@link TaskFunction}'s (`TaskFunctionResult | NestedTaskFunction`)
+ * because the value returned by a factory is itself any task function — e.g. the result of
+ * `tscTask()`, whose declared return type is a full `TaskFunction`. This is intentionally
+ * self-referential so those task functions remain assignable here.
  */
 export interface NestedTaskFunction {
-  (done: TaskCallback): TaskFunctionResult;
+  (done: TaskCallback): TaskFunctionResult | NestedTaskFunction;
 }
 
 /**

--- a/packages/just-task/src/wrapTask.ts
+++ b/packages/just-task/src/wrapTask.ts
@@ -54,8 +54,9 @@ export function wrapTask(fn: MaybeWrappedTaskFunction): Undertaker.TaskFunction 
     const results = (origFn as () => TaskFunctionResult | NestedTaskFunction)();
 
     // The result is a function, so assume it is the "factory" form's task function and run it.
+    // Its result is the actual task's leaf result, which Undertaker awaits.
     if (typeof results === 'function') {
-      return results(done);
+      return results(done) as TaskFunctionResult;
     }
 
     // A promise is returned to Undertaker so it can await completion.

--- a/scripts/tsconfig.base.json
+++ b/scripts/tsconfig.base.json
@@ -5,6 +5,8 @@
     // Use CJS output for now
     "module": "node20",
     "moduleResolution": "node16",
+    "allowJs": true,
+    "checkJs": true,
     "pretty": true,
     "declaration": true,
     "declarationMap": true,

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
-    "checkJs": true
+    "noEmit": true
   },
   "include": ["."],
   "exclude": ["node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6448,7 +6448,6 @@ __metadata:
     esbuild: "catalog:dev"
     eslint: "catalog:dev"
     file-loader: "npm:^6.2.0"
-    fork-ts-checker-webpack-plugin: "catalog:dev"
     html-webpack-plugin: "catalog:dev"
     jest: "catalog:dev"
     just-scripts: "workspace:^"


### PR DESCRIPTION
One more fix to the `task` types for "thunk" patterns... and some tangentially related config changes which revealed some missing logic from the previous change to allow webpack configs with cts/mts extensions

Also update the doc site.