### PR TITLE
Support default exports from config files + typing cleanup

### DIFF
--- a/change/change-bbf4e793-4826-4407-897c-4377df1aea3d.json
+++ b/change/change-bbf4e793-4826-4407-897c-4377df1aea3d.json
@@ -1,0 +1,18 @@
+{
+  "changes": [
+    {
+      "type": "major",
+      "comment": "Clean up task options: Remove `WebpackTaskOptions.env` which hasn't been used for a long time, and specify type of `onCompile` `stats`. Also specify real types for `ApiExtractorOptions.onResult`.",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    },
+    {
+      "type": "patch",
+      "comment": "Support default exports from the just config file",
+      "packageName": "just-task",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-scripts/etc/just-scripts.api.md
+++ b/packages/just-scripts/etc/just-scripts.api.md
@@ -10,7 +10,9 @@ import type { BuildOptions } from 'esbuild';
 import type { Configuration } from 'webpack';
 import type ForkTsCheckerWebpackPluginType from 'fork-ts-checker-webpack-plugin';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type { MultiStats } from 'webpack';
 import type { Options } from 'nano-spawn';
+import type { Stats } from 'webpack';
 import { TaskFunction } from 'just-task';
 import type ts from 'typescript';
 import * as webpackMerge from 'webpack-merge';
@@ -19,7 +21,7 @@ import * as webpackMerge from 'webpack-merge';
 export interface ApiExtractorOptions extends ApiExtractorTypes.IExtractorInvokeOptions {
     configJsonFilePath?: string;
     onConfigLoaded?: (config: ApiExtractorTypes.IConfigFile) => void;
-    onResult?: (result: any, extractorOptions: any) => void;
+    onResult?: (result: ApiExtractorTypes.ExtractorResult, extractorOptions: ApiExtractorTypes.IExtractorInvokeOptions) => void;
     projectFolder?: string;
 }
 
@@ -143,7 +145,7 @@ export interface CssLoaderOptions {
 // @public (undocumented)
 export function defaultCleanPaths(): string[];
 
-// @public (undocumented)
+// @public
 export function displayBailoutOverlay(): Configuration;
 
 // @public (undocumented)
@@ -429,8 +431,7 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction;
 export interface WebpackTaskOptions extends Configuration {
     // (undocumented)
     config?: string;
-    env?: Record<string, unknown>;
-    onCompile?: (err: Error, stats: any) => void | Promise<void>;
+    onCompile?: (err: Error, stats: Stats | MultiStats | undefined) => void | Promise<void>;
     outputStats?: boolean | string;
     transpileOnly?: boolean;
 }

--- a/packages/just-scripts/src/interfaces/PackageJson.ts
+++ b/packages/just-scripts/src/interfaces/PackageJson.ts
@@ -4,9 +4,8 @@ export interface Dependencies {
 
 export interface PackageJson {
   name: string;
-  description?: string;
   dependencies?: Dependencies;
   devDependencies?: Dependencies;
   bin?: string | Record<string, string>;
-  [key: string]: any;
+  [key: string]: unknown;
 }

--- a/packages/just-scripts/src/tasks/__tests__/apiExtractorTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/apiExtractorTask.mock.spec.ts
@@ -31,15 +31,14 @@ const mockPrepare = jest.fn<typeof apiExtractor.ExtractorConfig.prepare>(options
 jest.mock('../../tryRequire', () => ({
   tryRequire: jest.fn((name: string) => {
     if (name === '@microsoft/api-extractor') {
-      const mockApiExtractor: Partial<Record<keyof typeof apiExtractor, any>> = {
-        Extractor: { invoke: mockInvoke },
+      return {
+        Extractor: { invoke: mockInvoke } satisfies Partial<typeof apiExtractor.Extractor>,
         ExtractorConfig: {
           FILENAME: 'api-extractor.json',
           loadFile: mockLoadFile,
           prepare: mockPrepare,
-        },
+        } satisfies Partial<typeof apiExtractor.ExtractorConfig>,
       };
-      return mockApiExtractor;
     }
     return null;
   }),

--- a/packages/just-scripts/src/tasks/__tests__/webpackTask.mock.spec.ts
+++ b/packages/just-scripts/src/tasks/__tests__/webpackTask.mock.spec.ts
@@ -92,7 +92,7 @@ describe('webpackTask (mocked)', () => {
 
   describe('onCompile callback', () => {
     it('calls onCompile with err and stats', async () => {
-      const onCompile = jest.fn<(err: Error | null, stats: any) => void>();
+      const onCompile = jest.fn<(err: Error | null, stats: unknown) => void>();
       mockWebpack.mockImplementation((_configs, cb) => {
         cb(null, { hasErrors: () => false });
       });

--- a/packages/just-scripts/src/tasks/apiExtractorTask.ts
+++ b/packages/just-scripts/src/tasks/apiExtractorTask.ts
@@ -16,10 +16,11 @@ export interface ApiExtractorOptions extends ApiExtractorTypes.IExtractorInvokeO
 
   /**
    * Callback after api-extractor is invoked.
-   * @param result - Result of invoking api-extractor. Actual type is `ExtractorResult` from `@microsoft/api-extractor`.
-   * @param extractorOptions - Options with which api-extractor was invoked. Actual type is `IExtractorInvokeOptions`.
    */
-  onResult?: (result: any, extractorOptions: any) => void;
+  onResult?: (
+    result: ApiExtractorTypes.ExtractorResult,
+    extractorOptions: ApiExtractorTypes.IExtractorInvokeOptions,
+  ) => void;
 
   /**
    * Callback after the config file is loaded.

--- a/packages/just-scripts/src/tasks/webpackTask.ts
+++ b/packages/just-scripts/src/tasks/webpackTask.ts
@@ -1,5 +1,5 @@
 // WARNING: Careful about adding more imports - only import types from webpack
-import type { Configuration, WebpackOptionsNormalized } from 'webpack';
+import type { Configuration, MultiStats, Stats, WebpackOptionsNormalized } from 'webpack';
 import { logger, argv, type TaskFunction } from 'just-task';
 import { tryRequire } from '../tryRequire';
 import fs from 'fs';
@@ -15,11 +15,6 @@ export interface WebpackTaskOptions extends Configuration {
   outputStats?: boolean | string;
 
   /**
-   * Environment variables to be passed to webpack
-   */
-  env?: Record<string, unknown>;
-
-  /**
    * Transpile the config only
    */
   transpileOnly?: boolean;
@@ -27,7 +22,7 @@ export interface WebpackTaskOptions extends Configuration {
   /**
    * Optional callback triggered on compile
    */
-  onCompile?: (err: Error, stats: any) => void | Promise<void>;
+  onCompile?: (err: Error, stats: Stats | MultiStats | undefined) => void | Promise<void>;
 }
 
 /**
@@ -53,24 +48,25 @@ export function webpackTask(options?: WebpackTaskOptions): TaskFunction {
       enableTypeScript({ transpileOnly });
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    let configModuleExports = webpackConfigPath ? require(path.resolve(webpackConfigPath)) : {};
+    type ConfigFunction = (
+      env: unknown,
+      argv: unknown,
+    ) => Configuration | Configuration[] | Promise<Configuration | Configuration[]>;
+    type ConfigExport = Configuration | Configuration[] | ConfigFunction | undefined;
+    let configModuleExports = webpackConfigPath
+      ? (require(path.resolve(webpackConfigPath)) as ConfigExport)
+      : undefined;
     if (configModuleExports && typeof configModuleExports === 'object' && 'default' in configModuleExports) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      configModuleExports = configModuleExports.default;
+      configModuleExports = (configModuleExports as { default?: ConfigExport }).default;
     }
 
-    let webpackConfigs: Configuration[];
+    let webpackConfigs: Configuration | Configuration[];
 
-    // If the loaded webpack config is a function
-    // call it with the original process.argv arguments from build.js.
     if (typeof configModuleExports == 'function') {
       const args = argv();
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-      webpackConfigs = configModuleExports(args.env, args);
+      webpackConfigs = await configModuleExports(args.env, args);
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      webpackConfigs = configModuleExports;
+      webpackConfigs = configModuleExports || {};
     }
 
     if (!Array.isArray(webpackConfigs)) {

--- a/packages/just-scripts/src/webpack/overlays/displayBailoutOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/displayBailoutOverlay.ts
@@ -1,14 +1,16 @@
 // WARNING: Careful about adding more imports - only import types from externals
-import type { Configuration } from 'webpack';
+import type { Configuration, StatsOptions } from 'webpack';
 
+/**
+ * Enable the display of optimization bailout reasons in the webpack stats output.
+ */
 export function displayBailoutOverlay(): Configuration {
   return {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     stats: {
       // Examine all modules
       maxModules: Infinity,
       // Display bailout reasons
       optimizationBailout: true,
-    } as any,
+    } as StatsOptions,
   };
 }

--- a/packages/just-task/etc/just-task.api.md
+++ b/packages/just-task/etc/just-task.api.md
@@ -58,9 +58,9 @@ interface OptionConfig {
     alias?: string | string[];
     array?: boolean;
     boolean?: boolean;
-    coerce?: (arg: any) => any;
+    coerce?: (arg: unknown) => unknown;
     count?: boolean;
-    default?: any;
+    default?: unknown;
     describe?: string;
     narg?: number;
     normalize?: boolean;

--- a/packages/just-task/src/__tests__/__mocks__/just.config.ts
+++ b/packages/just-task/src/__tests__/__mocks__/just.config.ts
@@ -1,7 +1,6 @@
 import { task, series, parallel, condition, option, logger, argv } from '../../index';
 
-// Currently export = is required by the usage in cli.spec.ts
-export = () => {
+export default () => {
   option('name');
   option('production');
 

--- a/packages/just-task/src/__tests__/resolve.spec.ts
+++ b/packages/just-task/src/__tests__/resolve.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { describe, expect, it, jest, afterEach, beforeEach } from '@jest/globals';
 import path from 'path';
 import {
@@ -25,8 +24,8 @@ beforeEach(() => {
 describe('_isFileNameLike', () => {
   it('returns false for empty input', () => {
     expect(_isFileNameLike('')).toBe(false);
-    expect(_isFileNameLike(undefined as any)).toBe(false);
-    expect(_isFileNameLike(null as any)).toBe(false);
+    expect(_isFileNameLike(undefined as unknown as string)).toBe(false);
+    expect(_isFileNameLike(null as unknown as string)).toBe(false);
   });
 
   it('returns true for filenames', () => {
@@ -54,7 +53,7 @@ describe('_tryResolve', () => {
 
   it('does not throw', () => {
     expect(_tryResolve('foo', { cwd: 'bar' })).toBeNull();
-    expect(_tryResolve(undefined as any, undefined as any)).toBeNull();
+    expect(_tryResolve(undefined as unknown as string, undefined as unknown as object)).toBeNull();
   });
 
   it('does not recurse into child dirs', () => {
@@ -222,7 +221,7 @@ describe.each(['just.config.js', 'just.config.cjs', 'just.config.ts', 'just.conf
         },
         [configPath]: 'localConfig',
       });
-      const resolvedConfig = config.resolveConfigFile({ config: undefined, defaultConfig: undefined } as any);
+      const resolvedConfig = config.resolveConfigFile({ _: [] });
       expect(resolvedConfig).toContain(configPath);
     });
 
@@ -237,7 +236,8 @@ describe.each(['just.config.js', 'just.config.cjs', 'just.config.ts', 'just.conf
       const resolvedConfig = config.resolveConfigFile({
         config: './config/configArgument.ts',
         defaultConfig: './config/defaultConfigArgument.ts',
-      } as any);
+        _: [],
+      });
       expect(resolvedConfig).toContain('configArgument.ts');
     });
 
@@ -252,7 +252,8 @@ describe.each(['just.config.js', 'just.config.cjs', 'just.config.ts', 'just.conf
       const resolvedConfig = config.resolveConfigFile({
         config: undefined,
         defaultConfig: './config/defaultConfigArgument.ts',
-      } as any);
+        _: [],
+      });
       expect(resolvedConfig).toContain(configPath);
     });
 
@@ -266,7 +267,8 @@ describe.each(['just.config.js', 'just.config.cjs', 'just.config.ts', 'just.conf
       const resolvedConfig = config.resolveConfigFile({
         config: undefined,
         defaultConfig: './config/defaultConfigArgument.ts',
-      } as any);
+        _: [],
+      });
       expect(resolvedConfig).toContain('defaultConfigArgument.ts');
     });
   },

--- a/packages/just-task/src/config.ts
+++ b/packages/just-task/src/config.ts
@@ -27,7 +27,9 @@ export function resolveConfigFile(args: yargsParser.Arguments): string | null {
   return null;
 }
 
-export function readConfig(): { [key: string]: TaskFunction } | void {
+type ConfigExports = Record<string, TaskFunction>;
+
+export function readConfig(): ConfigExports | void {
   // uses a separate instance of yargs to first parse the config (without the --help in the way) so we can parse the configFile first regardless
   const args = argv();
   const configFile = resolveConfigFile(args);
@@ -40,19 +42,23 @@ export function readConfig(): { [key: string]: TaskFunction } | void {
     }
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const configModule = require(configFile);
+      let configModule = require(configFile) as ConfigExports | (() => ConfigExports) | undefined;
+      // If the module only has a default export, use that as the config. (A config file can also
+      // export named task functions, and theoretically a task could be called "default", so
+      // ignore the default export if there are other exports alongside it.)
+      if (typeof configModule === 'object' && configModule.default && Object.keys(configModule).length === 1) {
+        configModule = configModule.default as unknown as ConfigExports | (() => ConfigExports);
+      }
 
       mark('registry:configModule');
 
       if (typeof configModule === 'function') {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         configModule();
+        configModule = undefined;
       }
 
       logger.perf('registry:configModule');
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return configModule;
     } catch (e) {
       logger.error(`Invalid configuration file: ${configFile}`);

--- a/packages/just-task/src/option.ts
+++ b/packages/just-task/src/option.ts
@@ -15,13 +15,13 @@ export interface OptionConfig {
    * Provide a custom synchronous function that returns a coerced value from the argument provided (or throws an error), e.g.
    * `{ coerce: function (arg) { return modifiedArg } }`.
    */
-  coerce?: (arg: any) => any;
+  coerce?: (arg: unknown) => unknown;
 
   /** Indicate a key that should be used as a counter, e.g., `-vvv = {v: 3}`. */
   count?: boolean;
 
   /** Provide default value: `{ default: 'hello world!' }`. */
-  default?: any;
+  default?: unknown;
 
   /** Specify that a key requires n arguments: `{ narg: {x: 2} }`. */
   narg?: number;
@@ -59,7 +59,6 @@ export function option(key: string, options: OptionConfig = {}): void {
 
   for (const argName of assignArgs) {
     if (options[argName]) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       (argOptions[argName] ??= {})[key] = options[argName];
     }
   }

--- a/packages/just-task/src/undertaker.ts
+++ b/packages/just-task/src/undertaker.ts
@@ -61,7 +61,7 @@ undertaker.on('stop', function (args: UndertakerEndEventArgs) {
   }
 });
 
-undertaker.on('error', function (args: UndertakerEndEventArgs & { error: any }) {
+undertaker.on('error', function (args: UndertakerEndEventArgs & { error: unknown }) {
   delete tasksInProgress[args.name];
 
   if (!errorReported) {
@@ -69,25 +69,21 @@ undertaker.on('error', function (args: UndertakerEndEventArgs & { error: any }) 
     logger.error(chalk.red(`Error detected while running '${colorizeTaskName(args.name)}'`));
     logger.error(chalk.yellow('------------------------------------'));
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const stackOrMessage = (args.error as Error).stack || (args.error as Error).message || args.error;
-
+    const error = args.error as Partial<Error> & { stdout?: string; stderr?: string };
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
+    const stackOrMessage = error.stack || error.message || String(error || '');
     if (stackOrMessage) {
       logger.error(chalk.yellow(stackOrMessage));
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (args.error.stdout) {
+    if (error.stdout) {
       logger.error(chalk.yellow('stdout:'));
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      logger.error(args.error.stdout);
+      logger.error(String(error.stdout));
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (args.error.stderr) {
+    if (error.stderr) {
       logger.error(chalk.yellow('stderr:'));
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      logger.error(args.error.stderr);
+      logger.error(String(error.stderr));
     }
 
     logger.error(chalk.yellow('------------------------------------'));

--- a/scripts/eslintConfig.mjs
+++ b/scripts/eslintConfig.mjs
@@ -42,9 +42,7 @@ export function getConfig(dirname, ...configs) {
         '@typescript-eslint/consistent-type-exports': 'error',
         '@typescript-eslint/explicit-module-boundary-types': 'error',
         '@typescript-eslint/no-import-type-side-effects': 'error',
-
-        // Should be enabled
-        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-explicit-any': 'error',
 
         '@typescript-eslint/no-restricted-imports': [
           'error',


### PR DESCRIPTION
If `just.config.*` only has a default export, use that as the config. (A config file can also export named task functions, and theoretically a task could be called "default", so ignore the default export if there are other exports alongside it.)

Add proper types in various places instead of `any`:
- `webpackTask`: Declare types for loading the config. Specify type of `WebpackTaskOptions.onCompile` `stats`. Remove `WebpackTaskOptions.env` which hasn't been used for a long time (seems like a leftover from when the task was CLI-based).
- Specify real types for `ApiExtractorOptions.onResult`
- Various internal typing fixes in `just-task`