### PR TITLE
Fix `stylesOverlay` CSS module handling

### DIFF
--- a/change/change-ecde7223-4a6f-426d-91ee-3e3355259a24.json
+++ b/change/change-ecde7223-4a6f-426d-91ee-3e3355259a24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "major",
+      "comment": "`stylesOverlay`/webpack configs: Properly handle the `CssLoaderOptions.modules` option: if the user passes `modules: false`, **no** files are treated as CSS modules. With `modules: true`, **all** files are treated as modules. By default (`modules` unset), behavior depends on the presence of the `*.module.[s]css` extension. (Marked as a breaking change since the previous buggy behavior of treating all files as modules existed for so long.)",
+      "packageName": "just-scripts",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/just-example-lib/src/index.ts
+++ b/packages/just-example-lib/src/index.ts
@@ -10,7 +10,7 @@ export const sample = 5;
 const root = document.createElement('div');
 root.innerHTML = `
   <h1>Hello, world!</h1>
-  <button>button</button>
+  <button class="btn">button</button>
   <img src="${clippy}" alt="Clippy" />
 `;
 document.body.appendChild(root);

--- a/packages/just-example-lib/src/style2.scss
+++ b/packages/just-example-lib/src/style2.scss
@@ -1,6 +1,6 @@
 $primary-color: #3498db;
 
-button {
+.btn {
   background-color: $primary-color;
   color: white;
   font-size: 3rem;

--- a/packages/just-scripts/etc/just-scripts.api.md
+++ b/packages/just-scripts/etc/just-scripts.api.md
@@ -136,9 +136,7 @@ export function createTarTask(opts?: CreateOptions): TaskFunction;
 
 // @public (undocumented)
 export interface CssLoaderOptions {
-    // (undocumented)
     localIdentName?: string;
-    // (undocumented)
     modules?: boolean;
 }
 

--- a/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
+++ b/packages/just-scripts/src/webpack/overlays/stylesOverlay.ts
@@ -9,12 +9,18 @@ const sassModuleTest = /\.module\.(scss|sass)$/;
 const defaultIdentName = '[name]_[local]_[hash:base64:5]';
 
 export interface CssLoaderOptions {
+  /**
+   * If true, force enabling CSS modules (with `localIdentName` or the default) for all files.
+   * If false, force disabling CSS modules for all files.
+   * If undefined, enable only for `*.module.[s]css`.
+   */
   modules?: boolean;
+  /** Class name format override. Ignored if `modules: false`. */
   localIdentName?: string;
 }
 
 function createStyleLoaderRule(
-  options: CssLoaderOptions & {
+  options: Pick<CssLoaderOptions, 'localIdentName'> & {
     cssLoaderPath: string;
     styleLoaderPath: string;
     postcssLoaderPath: string | null;
@@ -22,8 +28,7 @@ function createStyleLoaderRule(
     sassLoaderPath?: string;
   },
 ): RuleSetRule['use'] {
-  const { modules, localIdentName, sassLoaderPath, cssLoaderPath, postcssLoaderPath, autoprefixer, styleLoaderPath } =
-    options;
+  const { localIdentName, sassLoaderPath, cssLoaderPath, postcssLoaderPath, autoprefixer, styleLoaderPath } = options;
 
   const preloaders: RuleSetRule['use'] = [];
   postcssLoaderPath &&
@@ -45,7 +50,7 @@ function createStyleLoaderRule(
       // translates CSS into CommonJS
       loader: cssLoaderPath,
       options: {
-        modules: localIdentName ? { mode: 'local', localIdentName } : modules,
+        modules: localIdentName ? { mode: 'local', localIdentName } : false,
         importLoaders: preloaders.length,
       },
     },
@@ -64,6 +69,7 @@ function createStyleLoaderRule(
  */
 export function createStylesOverlay(options: CssLoaderOptions = {}): Configuration {
   const localIdentName = options.localIdentName || defaultIdentName;
+  const moduleOption = options.modules;
 
   const cssLoaderPath = resolveWrapper('css-loader');
   if (!cssLoaderPath) {
@@ -86,56 +92,44 @@ export function createStylesOverlay(options: CssLoaderOptions = {}): Configurati
   const sassLoaderPath =
     resolveWrapper('sass') || resolveWrapper('node-sass') ? resolveWrapper('sass-loader') : undefined;
 
-  return {
-    module: {
-      rules: [
-        {
-          test: cssTest,
-          exclude: [/node_modules/, cssModuleTest],
-          use: createStyleLoaderRule({
-            ...loaderArgs,
-            modules: false,
-            localIdentName,
-          }),
-          sideEffects: true,
-        },
-        {
-          test: cssModuleTest,
-          exclude: [/node_modules/],
-          use: createStyleLoaderRule({
-            ...loaderArgs,
-            modules: true,
-            localIdentName,
-          }),
-        },
-        ...(sassLoaderPath
-          ? [
-              {
-                test: sassTest,
-                exclude: [/node_modules/, sassModuleTest],
-                use: createStyleLoaderRule({
-                  ...loaderArgs,
-                  sassLoaderPath,
-                  modules: false,
-                  localIdentName,
-                }),
-                sideEffects: true,
-              },
-              {
-                test: sassModuleTest,
-                exclude: [/node_modules/],
-                use: createStyleLoaderRule({
-                  ...loaderArgs,
-                  sassLoaderPath,
-                  modules: true,
-                  localIdentName,
-                }),
-              },
-            ]
-          : []),
-      ],
-    },
-  };
+  const rules: RuleSetRule[] = [];
+
+  if (moduleOption !== true) {
+    rules.push({
+      test: cssTest,
+      exclude: [/node_modules/, ...(moduleOption === false ? [] : [cssModuleTest])],
+      use: createStyleLoaderRule({ ...loaderArgs }),
+      sideEffects: true,
+    });
+  }
+  if (moduleOption !== false) {
+    rules.push({
+      test: moduleOption ? cssTest : cssModuleTest,
+      exclude: [/node_modules/],
+      use: createStyleLoaderRule({ ...loaderArgs, localIdentName }),
+    });
+  }
+
+  if (sassLoaderPath) {
+    // these should exactly mirror the above but add sassLoaderPath
+    if (moduleOption !== true) {
+      rules.push({
+        test: sassTest,
+        exclude: [/node_modules/, ...(moduleOption === false ? [] : [sassModuleTest])],
+        use: createStyleLoaderRule({ ...loaderArgs, sassLoaderPath }),
+        sideEffects: true,
+      });
+    }
+    if (moduleOption !== false) {
+      rules.push({
+        test: moduleOption ? sassTest : sassModuleTest,
+        exclude: [/node_modules/],
+        use: createStyleLoaderRule({ ...loaderArgs, sassLoaderPath, localIdentName }),
+      });
+    }
+  }
+
+  return { module: { rules } };
 }
 
 /**


### PR DESCRIPTION
Properly handle the `CssLoaderOptions.modules` option in `stylesOverlay`:
- By default (`modules` unset), behavior depends on the presence of the `*.module.[s]css` extension. 
- With `modules: false`, **no** files are treated as CSS modules
- With `modules: true`, **all** files are treated as modules

Marked as a breaking change since the previous buggy behavior of treating all files as modules existed for so long.